### PR TITLE
Add Forge PR autopilot safety primitives

### DIFF
--- a/.codex-reviewer/capabilities.yaml
+++ b/.codex-reviewer/capabilities.yaml
@@ -1,0 +1,13 @@
+# Codex reviewer adapter (OpenAI Codex CLI, v0.120+)
+#
+# Dedicated review profile for headless PR/review gates. This is intentionally
+# separate from .codex/capabilities.yaml: the normal Codex worker adapter uses
+# cwd-only secrets for Achilles-style implementation, while reviewer sessions
+# must receive no inherited API/GitHub token environment and must not prompt.
+supports_hooks: false
+spawn_command: "codex exec --ignore-user-config --ignore-rules --ephemeral --sandbox read-only --ask-for-approval never"
+block_for_event_strategy: tail
+tool_dialect: openai
+sandbox_profile: read-only
+secret_scope: none
+reviewer_profile: true

--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -28,6 +28,18 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Open | Reliability bug | Status can show completed work as pending when debrief emission is missing. |
 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Open | Reliability bug | Release/status logic must not depend on a forbidden top-level endpoint. |
 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Open | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
+| [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Open | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |
+
+## PR Autopilot Policy
+
+Issue [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) defines the current Forge PR path.
+
+- Default routine studio PRs to merge after one headless reviewer gate unless the reviewer reports a critical blocker.
+- Critical blockers are narrow: data loss, broken routing, unsafe runtime behavior, permission/auth changes, base-branch bypass, failing required checks, merge conflicts, or repo-rule violations.
+- Reviewer sessions MAY auto-fix narrow non-critical findings on the PR branch and MUST summarize those fixes on the PR.
+- Reviewer sessions MUST NOT receive API tokens, GitHub tokens, or inherited token-bearing user config; the parent studio session owns `gh` comments, suggestions, merge, branch deletion, and fetch/prune cleanup.
+- Codex review uses a dedicated `codex-reviewer` adapter/profile with `secret_scope: none`; do not flip the normal Codex worker adapter unless the spawn path enforces the same no-secret boundary.
+- Merge only through GitHub PR flow; after merge, delete the stale remote branch and refresh local refs with `git fetch --prune`.
 
 ## Capability-Next Queue
 

--- a/hosts/registry.yaml
+++ b/hosts/registry.yaml
@@ -45,6 +45,18 @@ codex:
   tool_dialect: openai
   status: adapted
 
+codex-reviewer:
+  display_name: "OpenAI Codex CLI Reviewer"
+  detect_binary: codex
+  global_skill_dir: "~/.codex/skills"
+  project_skill_dir: ".codex/skills"
+  routing_file: "AGENTS.md"
+  routing_walks_parents: false
+  capabilities_path: ".codex-reviewer/capabilities.yaml"
+  global_instructions_path: "~/.codex/AGENTS.md"
+  tool_dialect: openai
+  status: adapted
+
 gemini-cli:
   display_name: "Gemini CLI"
   detect_binary: gemini

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -131,6 +131,10 @@ scripts/task-emit-debrief.sh <task-uuid> <brief-uuid> self-reviewed '{...}'   # 
 # Studio-feedback ingestion (auto-fires via SessionStart hook + Chanakya Step 0F):
 scripts/ingest-feedback.sh                              # idempotent; silent no-op outside generic-dev-studio
 
+# Studio PR autopilot primitives (#318):
+scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
+scripts/pr-merge-finalize.sh <pr> --method squash       # gh PR merge + delete remote branch + fetch/prune
+
 # Chanakya sweep-time detections (Step 0E3, auto-invoked by Chanakya):
 scripts/detect-edits.sh --quiet                         # emits brief_edited + debrief_edited
 

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# pr-merge-finalize.sh — merge a reviewed PR through GitHub and refresh refs.
+#
+# Usage:
+#   scripts/pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase]
+#
+# This script intentionally performs GitHub PR flow only. It never pushes a
+# base branch directly. Branch deletion is delegated to gh pr merge
+# --delete-branch, then local refs are refreshed with fetch --prune.
+
+set -u
+umask 022
+
+usage() {
+  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase]\n' >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+PR="$1"
+shift
+
+METHOD="squash"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --method)
+      METHOD="${2:?}"
+      shift 2
+      ;;
+    *)
+      printf 'pr-merge-finalize: unknown flag %s\n' "$1" >&2
+      usage
+      ;;
+  esac
+done
+
+case "$METHOD" in
+  merge|squash|rebase) ;;
+  *) printf 'pr-merge-finalize: --method must be merge|squash|rebase\n' >&2; exit 2 ;;
+esac
+
+command -v gh >/dev/null 2>&1 || { printf 'pr-merge-finalize: gh is required\n' >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { printf 'pr-merge-finalize: jq is required\n' >&2; exit 1; }
+
+json=$(gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRepositoryOwner,baseRefName,url) \
+  || { printf 'pr-merge-finalize: failed to read PR %s\n' "$PR" >&2; exit 1; }
+
+state=$(printf '%s' "$json" | jq -r '.state')
+is_draft=$(printf '%s' "$json" | jq -r '.isDraft')
+mergeable=$(printf '%s' "$json" | jq -r '.mergeable')
+merge_state=$(printf '%s' "$json" | jq -r '.mergeStateStatus')
+base_ref=$(printf '%s' "$json" | jq -r '.baseRefName')
+url=$(printf '%s' "$json" | jq -r '.url')
+
+[ "$state" = "OPEN" ] || { printf 'pr-merge-finalize: PR is not open (state=%s)\n' "$state" >&2; exit 1; }
+[ "$is_draft" = "false" ] || { printf 'pr-merge-finalize: PR is draft\n' >&2; exit 1; }
+
+case "$mergeable" in
+  MERGEABLE|UNKNOWN) ;;
+  *) printf 'pr-merge-finalize: PR is not mergeable (mergeable=%s)\n' "$mergeable" >&2; exit 1 ;;
+esac
+
+case "$merge_state" in
+  CLEAN|HAS_HOOKS|UNSTABLE|UNKNOWN) ;;
+  BLOCKED|DIRTY|DRAFT)
+    printf 'pr-merge-finalize: PR has blocking merge state: %s\n' "$merge_state" >&2
+    exit 1
+    ;;
+  *)
+    printf 'pr-merge-finalize: refusing unknown merge state: %s\n' "$merge_state" >&2
+    exit 1
+    ;;
+esac
+
+printf 'Merging PR via GitHub: %s\n' "$url"
+case "$METHOD" in
+  merge)  gh pr merge "$PR" --merge --delete-branch ;;
+  squash) gh pr merge "$PR" --squash --delete-branch ;;
+  rebase) gh pr merge "$PR" --rebase --delete-branch ;;
+esac
+
+git fetch --prune origin
+git fetch origin main
+printf 'PR_MERGED=1\n'
+printf 'BASE_REF=%s\n' "$base_ref"

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# pr-reviewer-eligibility.sh — preflight a host for headless PR review.
+#
+# Usage:
+#   scripts/pr-reviewer-eligibility.sh [host]
+#
+# The check is intentionally stricter than Achilles worker dispatch:
+# PR reviewers must be headless, no-prompt, and no-secret. The parent studio
+# session owns GitHub actions through gh; reviewer sessions read diffs and
+# report verdicts/fixes only.
+
+set -u
+umask 022
+
+HOST="${1:-${STUDIO_REVIEW_HOST:-codex-reviewer}}"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+
+fail() {
+  printf 'PR_REVIEWER_ELIGIBLE=0\n'
+  printf 'REASON=%s\n' "$1"
+  [ -n "${2:-}" ] && printf 'DETAIL=%s\n' "$2"
+  exit 1
+}
+
+yaml_field() {
+  local file="$1" key="$2"
+  grep -E "^${key}:[[:space:]]" "$file" 2>/dev/null \
+    | head -1 \
+    | sed "s/^${key}:[[:space:]]*//" \
+    | tr -d '"'"'"
+}
+
+registry="$REPO_ROOT/hosts/registry.yaml"
+[ -f "$registry" ] || fail missing_registry "$registry"
+command -v yq >/dev/null 2>&1 || fail missing_yq "yq is required to read hosts/registry.yaml"
+
+detect_binary=$(yq -r ".\"$HOST\".detect_binary // \"\"" "$registry" 2>/dev/null)
+[ -n "$detect_binary" ] && [ "$detect_binary" != "null" ] || fail unknown_host "$HOST"
+command -v "$detect_binary" >/dev/null 2>&1 || fail missing_cli "$detect_binary"
+
+manifest=$(resolve_capabilities_manifest "$HOST" "$REPO_ROOT") \
+  || fail missing_manifest "host=$HOST has no capabilities_path"
+[ -f "$manifest" ] || fail missing_manifest "$manifest"
+
+spawn_command=$(yaml_field "$manifest" spawn_command)
+secret_scope=$(yaml_field "$manifest" secret_scope)
+sandbox_profile=$(yaml_field "$manifest" sandbox_profile)
+reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
+
+[ -n "$spawn_command" ] || fail missing_spawn_command "$manifest"
+[ "$secret_scope" = "none" ] || fail secret_scope_floor_unmet "secret_scope=$secret_scope"
+[ "$sandbox_profile" != "none" ] || fail sandbox_floor_unmet "sandbox_profile=none"
+[ "$reviewer_profile" = "true" ] || fail not_reviewer_profile "$manifest"
+
+case "$spawn_command" in
+  *"--ask-for-approval never"*|*"--approval-policy never"*) ;;
+  *) fail prompt_floor_unmet "spawn_command must force no-prompt execution" ;;
+esac
+
+case "$spawn_command" in
+  *"--dangerously-bypass-approvals-and-sandbox"*) fail unsafe_spawn_command "dangerous sandbox bypass is forbidden" ;;
+esac
+
+case "$HOST" in
+  codex*|*codex*)
+    case "$spawn_command" in
+      *"--ignore-user-config"* ) ;;
+      *) fail inherited_user_config "Codex reviewer must pass --ignore-user-config" ;;
+    esac
+    case "$spawn_command" in
+      *"--ignore-rules"* ) ;;
+      *) fail inherited_rules "Codex reviewer must pass --ignore-rules" ;;
+    esac
+    case "$spawn_command" in
+      *"--ephemeral"* ) ;;
+      *) fail persistent_session_state "Codex reviewer must pass --ephemeral" ;;
+    esac
+    ;;
+esac
+
+printf 'PR_REVIEWER_ELIGIBLE=1\n'
+printf 'HOST=%s\n' "$HOST"
+printf 'MANIFEST=%s\n' "${manifest#"$REPO_ROOT/"}"
+printf 'SPAWN_COMMAND=%s\n' "$spawn_command"


### PR DESCRIPTION
## Summary
- document the #318 PR autopilot policy in the Forge reliability lookup
- add a dedicated `codex-reviewer` capability profile with `secret_scope: none`
- add PR reviewer eligibility and GitHub PR merge/fetch cleanup primitives

## Verification
- `scripts/pr-reviewer-eligibility.sh codex-reviewer`
- normal `codex` profile refused for reviewer eligibility with `secret_scope_floor_unmet`
- `bash -n scripts/pr-reviewer-eligibility.sh scripts/pr-merge-finalize.sh`
- `scripts/lint-host-agnostic.sh --staged` (0 errors, existing normal-Codex warning)
- `scripts/lint-architecture.sh` (0 errors, existing warnings)

Refs #318