### PR TITLE
Enforce Forge PR review gate before merge

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -39,7 +39,9 @@ Issue [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) defin
 - Reviewer sessions MAY auto-fix narrow non-critical findings on the PR branch and MUST summarize those fixes on the PR.
 - Reviewer sessions MUST NOT receive API tokens, GitHub tokens, or inherited token-bearing user config; the parent studio session owns `gh` comments, suggestions, merge, branch deletion, and fetch/prune cleanup.
 - Codex review uses a dedicated `codex-reviewer` adapter/profile with `secret_scope: none`; do not flip the normal Codex worker adapter unless the spawn path enforces the same no-secret boundary.
+- Parent studio sessions MUST post a machine-readable `studio:pr-review-gate` PR comment before merge; `blocked` stops that PR, while `approved` and `approved_with_fixes` permit merge.
 - Merge only through GitHub PR flow; after merge, delete the stale remote branch and refresh local refs with `git fetch --prune`.
+- Bypass is not interactive and is not implicit: `pr-merge-finalize.sh` refuses ungated PRs unless passed `--bypass-review --user-approved-bypass <github-url>`, and records that bypass on the PR.
 
 ## Capability-Next Queue
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
+scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
 scripts/pr-merge-finalize.sh <pr> --method squash       # gh PR merge + delete remote branch + fetch/prune
 
 # Chanakya sweep-time detections (Step 0E3, auto-invoked by Chanakya):

--- a/scripts/pr-autopilot.sh
+++ b/scripts/pr-autopilot.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# pr-autopilot.sh — post a reviewer gate verdict, then merge eligible PRs.
+#
+# Usage:
+#   scripts/pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked \
+#       [--review-host <host>] [--summary-file <path>] [--method merge|squash|rebase]
+#   scripts/pr-autopilot.sh <pr> --bypass-review --user-approved-bypass <url>
+#
+# The reviewer itself runs without GitHub/API tokens. This parent-side wrapper
+# owns PR comments and merge actions through gh, leaving a machine-readable
+# marker that pr-merge-finalize.sh requires before integration.
+
+set -eu
+umask 022
+
+usage() {
+  printf 'usage: pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked [--review-host <host>] [--summary-file <path>] [--method merge|squash|rebase]\n' >&2
+  printf '   or: pr-autopilot.sh <pr> --bypass-review --user-approved-bypass <url>\n' >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+PR="$1"
+shift
+
+VERDICT=""
+REVIEW_HOST="${STUDIO_REVIEW_HOST:-codex-reviewer}"
+SUMMARY_FILE=""
+METHOD="squash"
+BYPASS_REVIEW=0
+USER_APPROVED_BYPASS=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --verdict) VERDICT="${2:?}"; shift 2 ;;
+    --review-host) REVIEW_HOST="${2:?}"; shift 2 ;;
+    --summary-file) SUMMARY_FILE="${2:?}"; shift 2 ;;
+    --method) METHOD="${2:?}"; shift 2 ;;
+    --bypass-review) BYPASS_REVIEW=1; shift ;;
+    --user-approved-bypass) USER_APPROVED_BYPASS="${2:?}"; shift 2 ;;
+    *) printf 'pr-autopilot: unknown flag %s\n' "$1" >&2; usage ;;
+  esac
+done
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+
+command -v gh >/dev/null 2>&1 || { printf 'pr-autopilot: gh is required\n' >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { printf 'pr-autopilot: jq is required\n' >&2; exit 1; }
+
+if [ "$BYPASS_REVIEW" -eq 1 ]; then
+  [ -n "$USER_APPROVED_BYPASS" ] || {
+    printf 'pr-autopilot: --bypass-review requires --user-approved-bypass <url>\n' >&2
+    exit 1
+  }
+  "$SCRIPT_DIR/pr-merge-finalize.sh" "$PR" --method "$METHOD" --bypass-review --user-approved-bypass "$USER_APPROVED_BYPASS"
+  exit $?
+fi
+
+case "$VERDICT" in
+  approved|approved_with_fixes|blocked) ;;
+  "") printf 'pr-autopilot: --verdict is required unless --bypass-review is used\n' >&2; exit 2 ;;
+  *) printf 'pr-autopilot: verdict must be approved|approved_with_fixes|blocked\n' >&2; exit 2 ;;
+esac
+
+if ! "$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST" >/dev/null; then
+  printf 'pr-autopilot: reviewer host is not eligible: %s\n' "$REVIEW_HOST" >&2
+  exit 1
+fi
+
+pr_json=$(gh pr view "$PR" --json headRefOid,url) \
+  || { printf 'pr-autopilot: failed to read PR %s\n' "$PR" >&2; exit 1; }
+head_sha=$(printf '%s' "$pr_json" | jq -r '.headRefOid')
+pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
+
+summary="No reviewer summary file supplied."
+if [ -n "$SUMMARY_FILE" ]; then
+  [ -f "$SUMMARY_FILE" ] || { printf 'pr-autopilot: summary file not found: %s\n' "$SUMMARY_FILE" >&2; exit 1; }
+  summary=$(sed -n '1,120p' "$SUMMARY_FILE")
+fi
+
+gh pr comment "$PR" --body "$(cat <<EOF
+<!-- studio:pr-review-gate v1 -->
+STUDIO_REVIEW_GATE=$VERDICT
+REVIEW_HOST=$REVIEW_HOST
+HEAD_SHA=$head_sha
+PR_URL=$pr_url
+POSTED_BY=parent-studio-session
+
+$summary
+EOF
+)"
+
+if [ "$VERDICT" = "blocked" ]; then
+  printf 'pr-autopilot: reviewer blocked PR %s; merge not attempted\n' "$PR" >&2
+  exit 1
+fi
+
+"$SCRIPT_DIR/pr-merge-finalize.sh" "$PR" --method "$METHOD"

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -2,17 +2,18 @@
 # pr-merge-finalize.sh — merge a reviewed PR through GitHub and refresh refs.
 #
 # Usage:
-#   scripts/pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase]
+#   scripts/pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase] \
+#       [--bypass-review --user-approved-bypass <url>]
 #
 # This script intentionally performs GitHub PR flow only. It never pushes a
 # base branch directly. Branch deletion is delegated to gh pr merge
 # --delete-branch, then local refs are refreshed with fetch --prune.
 
-set -u
+set -eu
 umask 022
 
 usage() {
-  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase]\n' >&2
+  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase] [--bypass-review --user-approved-bypass <url>]\n' >&2
   exit 2
 }
 
@@ -21,10 +22,20 @@ PR="$1"
 shift
 
 METHOD="squash"
+BYPASS_REVIEW=0
+USER_APPROVED_BYPASS=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --method)
       METHOD="${2:?}"
+      shift 2
+      ;;
+    --bypass-review)
+      BYPASS_REVIEW=1
+      shift
+      ;;
+    --user-approved-bypass)
+      USER_APPROVED_BYPASS="${2:?}"
       shift 2
       ;;
     *)
@@ -42,7 +53,7 @@ esac
 command -v gh >/dev/null 2>&1 || { printf 'pr-merge-finalize: gh is required\n' >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { printf 'pr-merge-finalize: jq is required\n' >&2; exit 1; }
 
-json=$(gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRepositoryOwner,baseRefName,url) \
+json=$(gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,headRepositoryOwner,baseRefName,url) \
   || { printf 'pr-merge-finalize: failed to read PR %s\n' "$PR" >&2; exit 1; }
 
 state=$(printf '%s' "$json" | jq -r '.state')
@@ -51,6 +62,8 @@ mergeable=$(printf '%s' "$json" | jq -r '.mergeable')
 merge_state=$(printf '%s' "$json" | jq -r '.mergeStateStatus')
 base_ref=$(printf '%s' "$json" | jq -r '.baseRefName')
 url=$(printf '%s' "$json" | jq -r '.url')
+number=$(printf '%s' "$json" | jq -r '.number')
+head_sha=$(printf '%s' "$json" | jq -r '.headRefOid')
 
 [ "$state" = "OPEN" ] || { printf 'pr-merge-finalize: PR is not open (state=%s)\n' "$state" >&2; exit 1; }
 [ "$is_draft" = "false" ] || { printf 'pr-merge-finalize: PR is draft\n' >&2; exit 1; }
@@ -71,6 +84,37 @@ case "$merge_state" in
     exit 1
     ;;
 esac
+
+gate_comment=$(gh pr view "$PR" --json comments --jq '
+  [.comments[]?
+   | select(.body | contains("<!-- studio:pr-review-gate v1 -->"))
+   | select(.body | test("STUDIO_REVIEW_GATE=(approved|approved_with_fixes)"))
+   | select(.body | contains("HEAD_SHA='"$head_sha"'"))
+  ] | last | .body // ""
+') || { printf 'pr-merge-finalize: failed to read PR review gate comments\n' >&2; exit 1; }
+
+if [ -z "$gate_comment" ]; then
+  if [ "$BYPASS_REVIEW" -ne 1 ]; then
+    printf 'pr-merge-finalize: refusing merge for PR #%s; no approved studio review gate comment found\n' "$number" >&2
+    printf 'Run scripts/pr-autopilot.sh with a reviewer verdict for HEAD_SHA=%s, or pass --bypass-review --user-approved-bypass <url> after explicit user approval.\n' "$head_sha" >&2
+    exit 1
+  fi
+  [ -n "$USER_APPROVED_BYPASS" ] || {
+    printf 'pr-merge-finalize: --bypass-review requires --user-approved-bypass <url>\n' >&2
+    exit 1
+  }
+  case "$USER_APPROVED_BYPASS" in
+    https://github.com/*/issues/*|https://github.com/*/pull/*|https://github.com/*/discussions/*) ;;
+    *) printf 'pr-merge-finalize: user-approved bypass must be a GitHub issue, PR, comment, or discussion URL\n' >&2; exit 1 ;;
+  esac
+  gh pr comment "$PR" --body "$(cat <<EOF
+<!-- studio:pr-review-gate v1 -->
+STUDIO_REVIEW_GATE=bypassed
+USER_APPROVED_BYPASS=$USER_APPROVED_BYPASS
+NOTE=Review gate bypass was explicitly user-approved. Parent studio session performed the GitHub action.
+EOF
+)"
+fi
 
 printf 'Merging PR via GitHub: %s\n' "$url"
 case "$METHOD" in


### PR DESCRIPTION
## Summary
- add `scripts/pr-autopilot.sh` as the parent-side wrapper that posts a machine-readable reviewer gate comment before merge
- make `scripts/pr-merge-finalize.sh` refuse ungated PRs unless an explicit user-approved bypass URL is supplied
- bind approved gate comments to the current PR head SHA so approvals cannot be reused after a push
- switch the autopilot/finalize scripts to fail-fast behavior so failed eligibility or `gh` actions cannot fall through

## Verification
- `bash -n scripts/pr-autopilot.sh scripts/pr-merge-finalize.sh scripts/pr-reviewer-eligibility.sh`
- `scripts/pr-autopilot.sh 319 --review-host codex --verdict approved` refuses with `reviewer host is not eligible`
- `scripts/pr-reviewer-eligibility.sh codex-reviewer` passes
- `scripts/lint-host-agnostic.sh --staged` (0 errors, existing normal-Codex warning)
- `scripts/lint-architecture.sh` (0 errors, existing warnings)

Refs #318