### PR TITLE
Fix PR autopilot cleanup after merge

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,16 +19,16 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Close the accepted residual-risk wording now that free-private branch protection is unavailable; keep script-path enforcement as the contract. |
-| 2 | [#321](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/321) Add dedicated claude-reviewer adapter for PR review gates | Avoid Codex-only review gates and enable independent reviewer selection. |
-| 3 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
-| 4 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
-| 5 | [#316](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/316) Sweep ingest silently skips lifecycle side effects | Prevents canonical debrief facts from being absorbed without queue/status/review side effects. |
-| 6 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
-| 7 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
-| 8 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
-| 9 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
-| 10 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Fixes release/status logic that depends on a forbidden endpoint. |
+| 1 | [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Fixes the just-observed autopilot cleanup failure and locks in merge-method policy. |
+| 2 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Close the accepted residual-risk wording now that free-private branch protection is unavailable; keep script-path enforcement as the contract. |
+| 3 | [#321](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/321) Add dedicated claude-reviewer adapter for PR review gates | Avoid Codex-only review gates and enable independent reviewer selection. |
+| 4 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
+| 5 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
+| 6 | [#316](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/316) Sweep ingest silently skips lifecycle side effects | Prevents canonical debrief facts from being absorbed without queue/status/review side effects. |
+| 7 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
+| 8 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
+| 9 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
+| 10 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
 
 ## Safety-Floor Queue
 
@@ -48,6 +48,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Open | Reliability bug | Release/status logic must not depend on a forbidden top-level endpoint. |
 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Open | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Open | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |
+| [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Open | Reliability bug | Prevents a successful remote merge from being reported as failed because local cleanup ran from a detached or stale worktree. |
 
 ## PR Autopilot Policy
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -134,7 +134,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
-scripts/pr-merge-finalize.sh <pr> --method squash       # gh PR merge + delete remote branch + fetch/prune
+scripts/pr-merge-finalize.sh <pr> --method auto         # main=merge commit, feature base=rebase, then fetch/prune
 
 # Chanakya sweep-time detections (Step 0E3, auto-invoked by Chanakya):
 scripts/detect-edits.sh --quiet                         # emits brief_edited + debrief_edited

--- a/scripts/pr-autopilot.sh
+++ b/scripts/pr-autopilot.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   scripts/pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked \
-#       [--review-host <host>] [--summary-file <path>] [--method merge|squash|rebase]
+#       [--review-host <host>] [--summary-file <path>] [--method auto|merge|squash|rebase]
 #   scripts/pr-autopilot.sh <pr> --bypass-review --user-approved-bypass <url>
 #
 # The reviewer itself runs without GitHub/API tokens. This parent-side wrapper
@@ -14,7 +14,7 @@ set -eu
 umask 022
 
 usage() {
-  printf 'usage: pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked [--review-host <host>] [--summary-file <path>] [--method merge|squash|rebase]\n' >&2
+  printf 'usage: pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked [--review-host <host>] [--summary-file <path>] [--method auto|merge|squash|rebase]\n' >&2
   printf '   or: pr-autopilot.sh <pr> --bypass-review --user-approved-bypass <url>\n' >&2
   exit 2
 }
@@ -26,7 +26,7 @@ shift
 VERDICT=""
 REVIEW_HOST="${STUDIO_REVIEW_HOST:-codex-reviewer}"
 SUMMARY_FILE=""
-METHOD="squash"
+METHOD="auto"
 BYPASS_REVIEW=0
 USER_APPROVED_BYPASS=""
 

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -2,7 +2,7 @@
 # pr-merge-finalize.sh — merge a reviewed PR through GitHub and refresh refs.
 #
 # Usage:
-#   scripts/pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase] \
+#   scripts/pr-merge-finalize.sh <pr-number-or-url> [--method auto|merge|squash|rebase] \
 #       [--bypass-review --user-approved-bypass <url>]
 #
 # This script intentionally performs GitHub PR flow only. It never pushes a
@@ -13,7 +13,7 @@ set -eu
 umask 022
 
 usage() {
-  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method merge|squash|rebase] [--bypass-review --user-approved-bypass <url>]\n' >&2
+  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method auto|merge|squash|rebase] [--bypass-review --user-approved-bypass <url>]\n' >&2
   exit 2
 }
 
@@ -21,7 +21,7 @@ usage() {
 PR="$1"
 shift
 
-METHOD="squash"
+METHOD="auto"
 BYPASS_REVIEW=0
 USER_APPROVED_BYPASS=""
 while [ $# -gt 0 ]; do
@@ -46,12 +46,40 @@ while [ $# -gt 0 ]; do
 done
 
 case "$METHOD" in
-  merge|squash|rebase) ;;
-  *) printf 'pr-merge-finalize: --method must be merge|squash|rebase\n' >&2; exit 2 ;;
+  auto|merge|squash|rebase) ;;
+  *) printf 'pr-merge-finalize: --method must be auto|merge|squash|rebase\n' >&2; exit 2 ;;
 esac
 
 command -v gh >/dev/null 2>&1 || { printf 'pr-merge-finalize: gh is required\n' >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { printf 'pr-merge-finalize: jq is required\n' >&2; exit 1; }
+
+current_worktree_path() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+worktree_path_for_branch() {
+  local branch="$1"
+  git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/$branch" '
+    /^worktree / { wt=substr($0, 10) }
+    /^branch / && substr($0, 8) == b { print wt; exit }
+  '
+}
+
+remove_stale_worktrees_for_branch() {
+  local branch="$1" current_path="$2" cleanup_paths path
+  cleanup_paths=$(git worktree list --porcelain 2>/dev/null | awk -v b="refs/heads/$branch" '
+    /^worktree / { wt=substr($0, 10) }
+    /^branch / && substr($0, 8) == b { print wt }
+  ')
+  [ -n "$cleanup_paths" ] || return 0
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    [ "$path" = "$current_path" ] && continue
+    git worktree remove "$path"
+  done <<EOF
+$cleanup_paths
+EOF
+}
 
 json=$(gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,headRepositoryOwner,baseRefName,url) \
   || { printf 'pr-merge-finalize: failed to read PR %s\n' "$PR" >&2; exit 1; }
@@ -61,6 +89,7 @@ is_draft=$(printf '%s' "$json" | jq -r '.isDraft')
 mergeable=$(printf '%s' "$json" | jq -r '.mergeable')
 merge_state=$(printf '%s' "$json" | jq -r '.mergeStateStatus')
 base_ref=$(printf '%s' "$json" | jq -r '.baseRefName')
+head_ref=$(printf '%s' "$json" | jq -r '.headRefName')
 url=$(printf '%s' "$json" | jq -r '.url')
 number=$(printf '%s' "$json" | jq -r '.number')
 head_sha=$(printf '%s' "$json" | jq -r '.headRefOid')
@@ -116,6 +145,14 @@ EOF
 )"
 fi
 
+if [ "$METHOD" = "auto" ]; then
+  if [ "$base_ref" = "main" ]; then
+    METHOD="merge"
+  else
+    METHOD="rebase"
+  fi
+fi
+
 printf 'Merging PR via GitHub: %s\n' "$url"
 case "$METHOD" in
   merge)  gh pr merge "$PR" --merge --delete-branch ;;
@@ -123,7 +160,74 @@ case "$METHOD" in
   rebase) gh pr merge "$PR" --rebase --delete-branch ;;
 esac
 
-git fetch --prune origin
-git fetch origin main
+cleanup_failed=0
+cleanup_notes=""
+current_path=$(current_worktree_path)
+control_path=""
+if ! git fetch --prune origin; then
+  cleanup_failed=1
+  cleanup_notes="${cleanup_notes}fetch_prune_failed;"
+fi
+if ! git fetch origin "$base_ref"; then
+  cleanup_failed=1
+  cleanup_notes="${cleanup_notes}fetch_base_failed;"
+fi
+current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+base_worktree=$(worktree_path_for_branch "$base_ref")
+if [ -n "$base_worktree" ]; then
+  control_path="$base_worktree"
+elif [ "$current_branch" = "$base_ref" ]; then
+  control_path="$current_path"
+else
+  if [ -z "$(git status --porcelain)" ]; then
+    if git show-ref --verify --quiet "refs/heads/$base_ref"; then
+      if ! git checkout "$base_ref"; then
+        cleanup_failed=1
+        cleanup_notes="${cleanup_notes}checkout_base_failed;"
+      else
+        current_branch="$base_ref"
+      fi
+    else
+      if ! git checkout -b "$base_ref" "origin/$base_ref"; then
+        cleanup_failed=1
+        cleanup_notes="${cleanup_notes}checkout_base_failed;"
+      else
+        current_branch="$base_ref"
+      fi
+    fi
+    if [ "$current_branch" = "$base_ref" ]; then
+      control_path="$current_path"
+    fi
+  else
+    cleanup_notes="${cleanup_notes}base_sync_skipped_dirty_worktree;"
+  fi
+fi
+if [ -n "$control_path" ]; then
+  if ! git -C "$control_path" merge --ff-only "origin/$base_ref"; then
+    cleanup_failed=1
+    cleanup_notes="${cleanup_notes}base_ff_failed;"
+  fi
+else
+  cleanup_notes="${cleanup_notes}base_sync_skipped_no_control_worktree;"
+fi
+if ! remove_stale_worktrees_for_branch "$head_ref" "$current_path"; then
+  cleanup_failed=1
+  cleanup_notes="${cleanup_notes}local_worktree_remove_failed;"
+fi
+if git show-ref --verify --quiet "refs/heads/$head_ref"; then
+  branch_repo="${control_path:-$current_path}"
+  if git -C "$branch_repo" branch --merged "origin/$base_ref" 2>/dev/null | sed 's/^[* ]*//' | grep -Fx "$head_ref" >/dev/null; then
+    if ! git -C "$branch_repo" branch -d "$head_ref"; then
+      cleanup_failed=1
+      cleanup_notes="${cleanup_notes}local_branch_delete_failed;"
+    fi
+  else
+    cleanup_notes="${cleanup_notes}local_branch_not_merged;"
+  fi
+fi
+
 printf 'PR_MERGED=1\n'
 printf 'BASE_REF=%s\n' "$base_ref"
+printf 'MERGE_METHOD=%s\n' "$METHOD"
+printf 'LOCAL_CLEANUP_FAILED=%s\n' "$cleanup_failed"
+[ -n "$cleanup_notes" ] && printf 'LOCAL_CLEANUP_NOTES=%s\n' "$cleanup_notes"


### PR DESCRIPTION
## Summary
- default PR merge method to `merge` for `main` and `rebase` for feature bases
- make local post-merge cleanup distinguish remote merge success from cleanup warnings
- find an existing base-branch worktree for local sync instead of assuming the current worktree can checkout the base branch
- remove stale local worktrees/branches for the merged PR branch when safe
- update Forge Up Next / Safety-Floor lookup for #325

## Verification
- `bash -n scripts/pr-merge-finalize.sh scripts/pr-autopilot.sh`
- `shellcheck scripts/pr-merge-finalize.sh scripts/pr-autopilot.sh`
- detached-worktree fixture: PR to `main` defaults to `--merge`, syncs base, deletes local feature branch, reports `LOCAL_CLEANUP_FAILED=0`
- detached-worktree fixture: PR to feature base defaults to `--rebase`, syncs base, reports `LOCAL_CLEANUP_FAILED=0`
- `scripts/lint-host-agnostic.sh --staged` (0 errors, existing normal-Codex warning)
- `scripts/lint-architecture.sh` (0 errors, existing warnings)

Fixes #325