### PR TITLE
Prefer rebase for small PRs

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,16 +19,16 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Fixes the just-observed autopilot cleanup failure and locks in merge-method policy. |
-| 2 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Close the accepted residual-risk wording now that free-private branch protection is unavailable; keep script-path enforcement as the contract. |
-| 3 | [#321](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/321) Add dedicated claude-reviewer adapter for PR review gates | Avoid Codex-only review gates and enable independent reviewer selection. |
-| 4 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
-| 5 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
-| 6 | [#316](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/316) Sweep ingest silently skips lifecycle side effects | Prevents canonical debrief facts from being absorbed without queue/status/review side effects. |
-| 7 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
-| 8 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
-| 9 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
-| 10 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
+| 1 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Close the accepted residual-risk wording now that free-private branch protection is unavailable; keep script-path enforcement as the contract. |
+| 2 | [#321](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/321) Add dedicated claude-reviewer adapter for PR review gates | Avoid Codex-only review gates and enable independent reviewer selection. |
+| 3 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
+| 4 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
+| 5 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
+| 6 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
+| 7 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
+| 8 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
+| 9 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Release/status logic must not depend on a forbidden top-level endpoint. |
+| 10 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Ensures no active prose or writer still mutates retired legacy surfaces. |
 
 ## Safety-Floor Queue
 
@@ -36,7 +36,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 
 | Issue | Status | Class | Why It Belongs Here |
 |---|---|---|---|
-| [#316](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/316) Sweep ingest silently skips lifecycle side effects when debrief facts are present but events are missing | Open | Reliability bug | Inbox sweep must reconcile canonical debrief facts into queue drain, review-skip, audit, status, and follow-up signals. |
+| [#316](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/316) Sweep ingest silently skips lifecycle side effects when debrief facts are present but events are missing | Closed | Reliability bug | Inbox sweep must reconcile canonical debrief facts into queue drain, review-skip, audit, status, and follow-up signals. |
 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass with non-canonical task IDs suppresses event emission and sweep hooks | Open | Reliability bug | Direct artifact creation can bypass lib-ledger contracts and make downstream hooks silently no-op. |
 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows from sweeps | Open | Reliability bug | Event-log loss makes sweeps and analytics falsely precise unless gaps are bounded and recoverable. |
 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing from deployed skills layout | Open | Reliability bug | Review gate availability depends on host registry deployment and deterministic infra-failure handling. |
@@ -48,7 +48,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Open | Reliability bug | Release/status logic must not depend on a forbidden top-level endpoint. |
 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Open | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Open | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |
-| [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Open | Reliability bug | Prevents a successful remote merge from being reported as failed because local cleanup ran from a detached or stale worktree. |
+| [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Closed | Reliability bug | Prevents a successful remote merge from being reported as failed because local cleanup ran from a detached or stale worktree. |
 
 ## PR Autopilot Policy
 
@@ -61,6 +61,7 @@ Issue [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) defin
 - Codex review uses a dedicated `codex-reviewer` adapter/profile with `secret_scope: none`; do not flip the normal Codex worker adapter unless the spawn path enforces the same no-secret boundary.
 - Parent studio sessions MUST post a machine-readable `studio:pr-review-gate` PR comment before merge; `blocked` stops that PR, while `approved` and `approved_with_fixes` permit merge.
 - Merge only through GitHub PR flow; after merge, delete the stale remote branch and refresh local refs with `git fetch --prune`.
+- `--method auto` uses rebase for PRs with fewer than 4 commits, including PRs targeting `main`; larger `main` PRs use merge commits, while non-`main` PRs continue to rebase.
 - Bypass is not interactive and is not implicit: `pr-merge-finalize.sh` refuses ungated PRs unless passed `--bypass-review --user-approved-bypass <github-url>`, and records that bypass on the PR.
 
 ## Capability-Next Queue

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -134,7 +134,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
-scripts/pr-merge-finalize.sh <pr> --method auto         # main=merge commit, feature base=rebase, then fetch/prune
+scripts/pr-merge-finalize.sh <pr> --method auto         # <4 commits=rebase, larger main=merge commit, then fetch/prune
 
 # Chanakya sweep-time detections (Step 0E3, auto-invoked by Chanakya):
 scripts/detect-edits.sh --quiet                         # emits brief_edited + debrief_edited

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -81,7 +81,7 @@ $cleanup_paths
 EOF
 }
 
-json=$(gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,headRepositoryOwner,baseRefName,url) \
+json=$(gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,headRepositoryOwner,baseRefName,url,commits) \
   || { printf 'pr-merge-finalize: failed to read PR %s\n' "$PR" >&2; exit 1; }
 
 state=$(printf '%s' "$json" | jq -r '.state')
@@ -93,6 +93,7 @@ head_ref=$(printf '%s' "$json" | jq -r '.headRefName')
 url=$(printf '%s' "$json" | jq -r '.url')
 number=$(printf '%s' "$json" | jq -r '.number')
 head_sha=$(printf '%s' "$json" | jq -r '.headRefOid')
+commit_count=$(printf '%s' "$json" | jq -r '.commits | length')
 
 [ "$state" = "OPEN" ] || { printf 'pr-merge-finalize: PR is not open (state=%s)\n' "$state" >&2; exit 1; }
 [ "$is_draft" = "false" ] || { printf 'pr-merge-finalize: PR is draft\n' >&2; exit 1; }
@@ -146,7 +147,9 @@ EOF
 fi
 
 if [ "$METHOD" = "auto" ]; then
-  if [ "$base_ref" = "main" ]; then
+  if [ "$commit_count" -lt 4 ]; then
+    METHOD="rebase"
+  elif [ "$base_ref" = "main" ]; then
     METHOD="merge"
   else
     METHOD="rebase"
@@ -237,7 +240,9 @@ fi
 
 printf 'PR_MERGED=1\n'
 printf 'BASE_REF=%s\n' "$base_ref"
+printf 'PR_COMMITS=%s\n' "$commit_count"
 printf 'MERGE_METHOD=%s\n' "$METHOD"
 [ -n "$remote_merge_warning" ] && printf 'REMOTE_MERGE_WARNING=%s\n' "$remote_merge_warning"
 printf 'LOCAL_CLEANUP_FAILED=%s\n' "$cleanup_failed"
 [ -n "$cleanup_notes" ] && printf 'LOCAL_CLEANUP_NOTES=%s\n' "$cleanup_notes"
+exit 0

--- a/scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
+++ b/scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Verifies pr-merge-finalize auto method selection without calling GitHub.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t pr-merge-method.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+WORK="$TMPROOT/repo"
+mkdir -p "$BIN" "$WORK"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+
+json_payload() {
+  local n="${COMMIT_COUNT:-1}" base="${BASE_REF:-main}" commits="" i=0
+  while [ "$i" -lt "$n" ]; do
+    if [ "$i" -gt 0 ]; then commits="$commits,"; fi
+    commits="${commits}{\"oid\":\"c$i\"}"
+    i=$((i + 1))
+  done
+  printf '{"number":123,"state":"OPEN","isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","headRefName":"feature","headRefOid":"abc123","headRepositoryOwner":{"login":"owner"},"baseRefName":"%s","url":"https://github.com/owner/repo/pull/123","commits":[%s]}\n' "$base" "$commits"
+}
+
+case "$1 $2" in
+  "pr view")
+    case " $* " in
+      *" --jq "*) printf '\n' ;;
+      *) json_payload ;;
+    esac
+    ;;
+  "pr comment")
+    exit 0
+    ;;
+  "pr merge")
+    printf '%s\n' "$*" >> "${MERGE_LOG:?}"
+    exit 0
+    ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$BIN/gh"
+
+export PATH="$BIN:$PATH"
+export MERGE_LOG="$TMPROOT/merge.log"
+
+(
+  cd "$WORK" || exit 1
+  git init -q
+  git checkout -b main -q
+  git config user.email test@example.invalid
+  git config user.name test
+  printf 'x\n' > README.md
+  git add README.md
+  git commit -q -m init
+)
+
+failures=0
+assert() {
+  local name="$1" cmd="$2"
+  if eval "$cmd"; then
+    printf 'ok - %s\n' "$name"
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+run_case() {
+  local base="$1" count="$2" expected="$3" out
+  out="$TMPROOT/out-$base-$count.txt"
+  : > "$MERGE_LOG"
+  BASE_REF="$base" COMMIT_COUNT="$count" \
+    bash "$ROOT/scripts/pr-merge-finalize.sh" 123 --method auto \
+      --bypass-review --user-approved-bypass https://github.com/owner/repo/pull/123 \
+      > "$out" 2>"$out.err"
+  assert "auto $base $count commits reports $expected" "grep -q 'MERGE_METHOD=$expected' '$out'"
+  assert "auto $base $count commits calls gh --$expected" "grep -q -- '--$expected' '$MERGE_LOG'"
+  assert "auto $base $count commits exits zero" "grep -q 'PR_MERGED=1' '$out'"
+}
+
+cd "$WORK" || exit 1
+run_case main 3 rebase
+run_case main 4 merge
+run_case feature 4 rebase
+
+if [ "$failures" -ne 0 ]; then
+  printf 'FAIL: %s assertion(s)\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'PASS: PR merge method policy\n'


### PR DESCRIPTION
## Summary
- Change `pr-merge-finalize.sh --method auto` to rebase PRs with fewer than 4 commits, including PRs targeting `main`.
- Keep merge commits for larger `main` PRs and keep non-main PRs on rebase.
- Make successful `pr-merge-finalize.sh` runs end with `exit 0` after cleanup reporting.
- Refresh `FORGE-RELIABILITY.md` after #316/#325 closed.

## Tests
- bash scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
- bash -n scripts/pr-merge-finalize.sh scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
- git diff --check
- bash scripts/lint-host-agnostic.sh --staged (existing W_ARGUS_SECRET_SCOPE)
- bash scripts/lint-comms-boundary.sh --staged