### PR TITLE
Add headless PR review autopilot

### DIFF
--- a/.claude/skills/studio/docs.html
+++ b/.claude/skills/studio/docs.html
@@ -351,6 +351,8 @@
       <li>No singleton lock, no <code>agent_boot</code> telemetry — studio is a conversational tool, not a fleet worker.</li>
       <li>No writes outside <code>~/.dev-studio/&lt;project&gt;/audit/</code> (audit reports in <code>--report</code> mode). Everything else is read-only chat output + file edits you approve.</li>
     </ul>
+    <h3>PR autopilot</h3>
+    <p>Routine studio PRs run <code>scripts/pr-headless-review.sh &lt;pr&gt;</code>. The script selects an eligible no-secret reviewer host, captures <code>STUDIO_REVIEW_VERDICT</code>, posts the <code>studio:pr-review-gate</code> comment, and merges only when the verdict is not <code>blocked</code>. Merge cleanup deletes the remote branch and refreshes refs with <code>git fetch --prune</code>.</p>
   </div>
 </section>
 

--- a/.codex-reviewer/capabilities.yaml
+++ b/.codex-reviewer/capabilities.yaml
@@ -5,7 +5,7 @@
 # cwd-only secrets for Achilles-style implementation, while reviewer sessions
 # must receive no inherited API/GitHub token environment and must not prompt.
 supports_hooks: false
-spawn_command: "codex exec --ignore-user-config --ignore-rules --ephemeral --sandbox read-only --ask-for-approval never"
+spawn_command: "codex exec --ignore-user-config --ignore-rules --ephemeral --sandbox read-only -c approval_policy=never"
 block_for_event_strategy: tail
 tool_dialect: openai
 sandbox_profile: read-only

--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,16 +19,16 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Close the accepted residual-risk wording now that free-private branch protection is unavailable; keep script-path enforcement as the contract. |
-| 2 | [#321](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/321) Add dedicated claude-reviewer adapter for PR review gates | Avoid Codex-only review gates and enable independent reviewer selection. |
-| 3 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
-| 4 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
-| 5 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
-| 6 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
-| 7 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
-| 8 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
-| 9 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Release/status logic must not depend on a forbidden top-level endpoint. |
-| 10 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Ensures no active prose or writer still mutates retired legacy surfaces. |
+| 1 | [#321](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/321) Add dedicated claude-reviewer adapter for PR review gates | Avoid Codex-only review gates and enable independent reviewer selection. |
+| 2 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
+| 3 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
+| 4 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
+| 5 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
+| 6 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
+| 7 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
+| 8 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Release/status logic must not depend on a forbidden top-level endpoint. |
+| 9 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Ensures no active prose or writer still mutates retired legacy surfaces. |
+| 10 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
 
 ## Safety-Floor Queue
 
@@ -47,7 +47,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Open | Reliability bug | Status can show completed work as pending when debrief emission is missing. |
 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Open | Reliability bug | Release/status logic must not depend on a forbidden top-level endpoint. |
 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Open | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
-| [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Open | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |
+| [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Closed | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |
 | [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Closed | Reliability bug | Prevents a successful remote merge from being reported as failed because local cleanup ran from a detached or stale worktree. |
 
 ## PR Autopilot Policy
@@ -57,8 +57,9 @@ Issue [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) defin
 - Default routine studio PRs to merge after one headless reviewer gate unless the reviewer reports a critical blocker.
 - Critical blockers are narrow: data loss, broken routing, unsafe runtime behavior, permission/auth changes, base-branch bypass, failing required checks, merge conflicts, or repo-rule violations.
 - Reviewer sessions MAY auto-fix narrow non-critical findings on the PR branch and MUST summarize those fixes on the PR.
-- Reviewer sessions MUST NOT receive API tokens, GitHub tokens, or inherited token-bearing user config; the parent studio session owns `gh` comments, suggestions, merge, branch deletion, and fetch/prune cleanup.
+- Reviewer sessions MUST NOT receive GitHub tokens or arbitrary inherited token-bearing user config; the parent studio session owns `gh` comments, suggestions, merge, branch deletion, and fetch/prune cleanup. Codex reviewers get a temporary `HOME` plus only `CODEX_HOME` for model auth.
 - Codex review uses a dedicated `codex-reviewer` adapter/profile with `secret_scope: none`; do not flip the normal Codex worker adapter unless the spawn path enforces the same no-secret boundary.
+- Routine studio PRs run `scripts/pr-headless-review.sh <pr>`; it selects an eligible no-secret reviewer host, captures the machine-readable verdict, posts the `studio:pr-review-gate` comment, and merges only when non-blocked.
 - Parent studio sessions MUST post a machine-readable `studio:pr-review-gate` PR comment before merge; `blocked` stops that PR, while `approved` and `approved_with_fixes` permit merge.
 - Merge only through GitHub PR flow; after merge, delete the stale remote branch and refresh local refs with `git fetch --prune`.
 - `--method auto` uses rebase for PRs with fewer than 4 commits, including PRs targeting `main`; larger `main` PRs use merge commits, while non-`main` PRs continue to rebase.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ scripts/fleet-cleanup.sh [--dry-run|--all]  # soft sweep / full teardown
 scripts/waive-start.sh argus "<reason>" "<sunset_trigger>"  # open a structured pause
 scripts/waive-lift.sh argus                                 # lift the pause; reports merges-skipped count
 scripts/backfill-orphan-debriefs.sh [--apply] [--quiet]     # recover tasks that finished but slipped the master plan
+scripts/pr-headless-review.sh <pr>                          # run no-secret reviewer gate, then merge if non-blocked
 ```
 
 **Minimal-intervention by default.** Chanakya runs end-to-end without stopping for confirmation. The only points where it pauses are: Slack publish, first-time config writes (`--configure-token`, `--configure`), merge conflicts, and `--wait` mode feedback windows.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
+scripts/pr-headless-review.sh <pr>                      # run eligible reviewer, post gate, merge if non-blocked
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
 scripts/pr-merge-finalize.sh <pr> --method auto         # <4 commits=rebase, larger main=merge commit, then fetch/prune
 

--- a/scripts/pr-autopilot.sh
+++ b/scripts/pr-autopilot.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   scripts/pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked \
-#       [--review-host <host>] [--summary-file <path>] [--method auto|merge|squash|rebase]
+#       [--review-host <host>] [--summary-file <path>] [--expected-head-sha <sha>] [--method auto|merge|squash|rebase]
 #   scripts/pr-autopilot.sh <pr> --bypass-review --user-approved-bypass <url>
 #
 # The reviewer itself runs without GitHub/API tokens. This parent-side wrapper
@@ -14,7 +14,7 @@ set -eu
 umask 022
 
 usage() {
-  printf 'usage: pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked [--review-host <host>] [--summary-file <path>] [--method auto|merge|squash|rebase]\n' >&2
+  printf 'usage: pr-autopilot.sh <pr> --verdict approved|approved_with_fixes|blocked [--review-host <host>] [--summary-file <path>] [--expected-head-sha <sha>] [--method auto|merge|squash|rebase]\n' >&2
   printf '   or: pr-autopilot.sh <pr> --bypass-review --user-approved-bypass <url>\n' >&2
   exit 2
 }
@@ -26,6 +26,7 @@ shift
 VERDICT=""
 REVIEW_HOST="${STUDIO_REVIEW_HOST:-codex-reviewer}"
 SUMMARY_FILE=""
+EXPECTED_HEAD_SHA=""
 METHOD="auto"
 BYPASS_REVIEW=0
 USER_APPROVED_BYPASS=""
@@ -35,6 +36,7 @@ while [ $# -gt 0 ]; do
     --verdict) VERDICT="${2:?}"; shift 2 ;;
     --review-host) REVIEW_HOST="${2:?}"; shift 2 ;;
     --summary-file) SUMMARY_FILE="${2:?}"; shift 2 ;;
+    --expected-head-sha) EXPECTED_HEAD_SHA="${2:?}"; shift 2 ;;
     --method) METHOD="${2:?}"; shift 2 ;;
     --bypass-review) BYPASS_REVIEW=1; shift ;;
     --user-approved-bypass) USER_APPROVED_BYPASS="${2:?}"; shift 2 ;;
@@ -71,6 +73,10 @@ pr_json=$(gh pr view "$PR" --json headRefOid,url) \
   || { printf 'pr-autopilot: failed to read PR %s\n' "$PR" >&2; exit 1; }
 head_sha=$(printf '%s' "$pr_json" | jq -r '.headRefOid')
 pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
+[ -z "$EXPECTED_HEAD_SHA" ] || [ "$head_sha" = "$EXPECTED_HEAD_SHA" ] || {
+  printf 'pr-autopilot: refusing gate for PR %s; reviewed HEAD_SHA=%s but current HEAD_SHA=%s\n' "$PR" "$EXPECTED_HEAD_SHA" "$head_sha" >&2
+  exit 1
+}
 
 summary="No reviewer summary file supplied."
 if [ -n "$SUMMARY_FILE" ]; then
@@ -95,4 +101,4 @@ if [ "$VERDICT" = "blocked" ]; then
   exit 1
 fi
 
-"$SCRIPT_DIR/pr-merge-finalize.sh" "$PR" --method "$METHOD"
+"$SCRIPT_DIR/pr-merge-finalize.sh" "$PR" --method "$METHOD" --expected-head-sha "$head_sha"

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# pr-headless-review.sh — run an eligible no-secret reviewer, then autopilot PR.
+#
+# Usage:
+#   scripts/pr-headless-review.sh <pr> [--review-host <host>] [--method auto|merge|squash|rebase]
+#
+# The parent studio session owns GitHub access. This script materializes the
+# PR metadata/diff into a temp file, spawns the reviewer with an env-scrubbed
+# process, parses STUDIO_REVIEW_VERDICT, then delegates the gate comment and
+# merge to pr-autopilot.sh.
+
+set -eu
+umask 022
+
+usage() {
+  printf 'usage: pr-headless-review.sh <pr> [--review-host <host>] [--method auto|merge|squash|rebase]\n' >&2
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+PR="$1"
+shift
+CALLER_HOME="${HOME:-}"
+
+REVIEW_HOST="${STUDIO_REVIEW_HOST:-}"
+METHOD="auto"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --review-host) REVIEW_HOST="${2:?--review-host requires a value}"; shift 2 ;;
+    --method) METHOD="${2:?--method requires a value}"; shift 2 ;;
+    *) printf 'pr-headless-review: unknown flag %s\n' "$1" >&2; usage ;;
+  esac
+done
+
+case "$METHOD" in
+  auto|merge|squash|rebase) ;;
+  *) printf 'pr-headless-review: --method must be auto|merge|squash|rebase\n' >&2; exit 2 ;;
+esac
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+AUTOPILOT="${PR_HEADLESS_REVIEW_AUTOPILOT:-$SCRIPT_DIR/pr-autopilot.sh}"
+
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+
+command -v gh >/dev/null 2>&1 || { printf 'pr-headless-review: gh is required\n' >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { printf 'pr-headless-review: jq is required\n' >&2; exit 1; }
+command -v yq >/dev/null 2>&1 || { printf 'pr-headless-review: yq is required\n' >&2; exit 1; }
+
+yaml_field() {
+  local file="$1" key="$2"
+  grep -E "^${key}:[[:space:]]" "$file" 2>/dev/null \
+    | head -1 \
+    | sed "s/^${key}:[[:space:]]*//" \
+    | tr -d '"'"'"
+}
+
+eligible_hosts() {
+  local registry="$REPO_ROOT/hosts/registry.yaml" host manifest reviewer_profile
+  [ -f "$registry" ] || return 1
+  while IFS= read -r host; do
+    [ -n "$host" ] || continue
+    manifest=$(resolve_capabilities_manifest "$host" "$REPO_ROOT" 2>/dev/null || true)
+    [ -n "$manifest" ] && [ -f "$manifest" ] || continue
+    reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
+    [ "$reviewer_profile" = "true" ] || continue
+    if "$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$host" >/dev/null 2>&1; then
+      printf '%s\n' "$host"
+    fi
+  done < <(yq -r 'keys | .[]' "$registry" 2>/dev/null)
+}
+
+if [ -z "$REVIEW_HOST" ]; then
+  hosts=()
+  while IFS= read -r host; do
+    [ -n "$host" ] && hosts+=("$host")
+  done < <(eligible_hosts)
+  [ "${#hosts[@]}" -gt 0 ] || {
+    printf 'pr-headless-review: no eligible reviewer hosts found\n' >&2
+    exit 1
+  }
+  pr_num=$(gh pr view "$PR" --json number --jq '.number') \
+    || { printf 'pr-headless-review: failed to read PR %s\n' "$PR" >&2; exit 1; }
+  REVIEW_HOST="${hosts[$(( pr_num % ${#hosts[@]} ))]}"
+fi
+
+eligibility=$("$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST") || {
+  printf '%s\n' "$eligibility" >&2
+  printf 'pr-headless-review: reviewer host is not eligible: %s\n' "$REVIEW_HOST" >&2
+  exit 1
+}
+manifest=$(printf '%s\n' "$eligibility" | sed -n 's/^MANIFEST=//p' | head -1)
+spawn_command=$(printf '%s\n' "$eligibility" | sed -n 's/^SPAWN_COMMAND=//p' | head -1)
+[ -n "$spawn_command" ] || { printf 'pr-headless-review: missing spawn command for %s\n' "$REVIEW_HOST" >&2; exit 1; }
+
+pr_json=$(gh pr view "$PR" --json number,title,url,baseRefName,headRefName,headRefOid,author,commits) \
+  || { printf 'pr-headless-review: failed to read PR %s\n' "$PR" >&2; exit 1; }
+pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
+head_sha=$(printf '%s' "$pr_json" | jq -r '.headRefOid')
+
+tmpdir=$(mktemp -d -t pr-headless-review.XXXXXX)
+trap 'rm -rf "$tmpdir"' EXIT
+payload="$tmpdir/review-payload.md"
+summary="$tmpdir/reviewer-summary.md"
+reviewer_home="$tmpdir/reviewer-home"
+mkdir -p "$reviewer_home"
+reviewer_codex_home=""
+case "$REVIEW_HOST" in
+  codex*|*codex*)
+    reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-${CALLER_HOME:+$CALLER_HOME/.codex}}}"
+    [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] || {
+      printf 'pr-headless-review: codex reviewer auth home not found; set CODEX_REVIEWER_HOME or CODEX_HOME\n' >&2
+      exit 1
+    }
+    ;;
+esac
+
+{
+  printf '# Studio PR Review Payload\n\n'
+  printf 'Metadata:\n\n```json\n%s\n```\n\n' "$(printf '%s' "$pr_json" | jq -c '.')"
+  cat <<'PROMPT'
+Review this studio PR against REVIEW.md and the repository-specific rules.
+
+Return a concise report with exactly one machine-readable verdict line:
+
+STUDIO_REVIEW_VERDICT=approved
+STUDIO_REVIEW_VERDICT=approved_with_fixes
+STUDIO_REVIEW_VERDICT=blocked
+
+Use `blocked` only for critical blockers: data loss, broken routing, unsafe
+runtime behavior, permission/auth changes, base-branch bypass, failing required
+checks, merge conflicts, or repo-rule violations. Non-critical findings may be
+fixed by the reviewer only if the reviewer host has write permissions and the
+fix is narrow and confined to the PR branch; summarize any fixes.
+
+PROMPT
+  printf '\nPR diff:\n\n```diff\n'
+  gh pr diff "$PR" --patch
+  printf '\n```\n'
+} > "$payload"
+
+# shellcheck disable=SC2206
+spawn_argv=( $spawn_command )
+review_prompt="Read $payload, review PR $pr_url at HEAD $head_sha, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
+
+if ! env -i \
+    PATH="$PATH" \
+    HOME="$reviewer_home" \
+    LANG="${LANG:-C.UTF-8}" \
+    USER="${USER:-}" \
+    ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
+    STUDIO_HOST="$REVIEW_HOST" \
+    REVIEW_PAYLOAD="$payload" \
+    PR_URL="$pr_url" \
+    PR_HEAD_SHA="$head_sha" \
+    "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err"; then
+  printf 'pr-headless-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
+  sed -n '1,80p' "$summary.err" >&2 || true
+  exit 1
+fi
+
+verdict_count=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary" | wc -l | tr -d ' ')
+verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary")
+if [ "$verdict_count" != "1" ]; then
+  printf 'pr-headless-review: reviewer must emit exactly one STUDIO_REVIEW_VERDICT line (found %s)\n' "$verdict_count" >&2
+  sed -n '1,120p' "$summary" >&2 || true
+  exit 1
+fi
+case "$verdict" in
+  approved|approved_with_fixes|blocked) ;;
+  *)
+    printf 'pr-headless-review: reviewer did not emit a valid STUDIO_REVIEW_VERDICT line\n' >&2
+    sed -n '1,120p' "$summary" >&2 || true
+    exit 1
+    ;;
+esac
+
+printf 'PR_REVIEW_HOST=%s\n' "$REVIEW_HOST"
+printf 'PR_REVIEW_MANIFEST=%s\n' "$manifest"
+printf 'PR_REVIEW_VERDICT=%s\n' "$verdict"
+
+"$AUTOPILOT" "$PR" \
+  --verdict "$verdict" \
+  --review-host "$REVIEW_HOST" \
+  --summary-file "$summary" \
+  --expected-head-sha "$head_sha" \
+  --method "$METHOD"

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   scripts/pr-merge-finalize.sh <pr-number-or-url> [--method auto|merge|squash|rebase] \
-#       [--bypass-review --user-approved-bypass <url>]
+#       [--expected-head-sha <sha>] [--bypass-review --user-approved-bypass <url>]
 #
 # This script intentionally performs GitHub PR flow only. It never pushes a
 # base branch directly. Branch deletion is delegated to gh pr merge
@@ -13,7 +13,7 @@ set -eu
 umask 022
 
 usage() {
-  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method auto|merge|squash|rebase] [--bypass-review --user-approved-bypass <url>]\n' >&2
+  printf 'usage: pr-merge-finalize.sh <pr-number-or-url> [--method auto|merge|squash|rebase] [--expected-head-sha <sha>] [--bypass-review --user-approved-bypass <url>]\n' >&2
   exit 2
 }
 
@@ -22,12 +22,17 @@ PR="$1"
 shift
 
 METHOD="auto"
+EXPECTED_HEAD_SHA=""
 BYPASS_REVIEW=0
 USER_APPROVED_BYPASS=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --method)
       METHOD="${2:?}"
+      shift 2
+      ;;
+    --expected-head-sha)
+      EXPECTED_HEAD_SHA="${2:?}"
       shift 2
       ;;
     --bypass-review)
@@ -94,6 +99,10 @@ url=$(printf '%s' "$json" | jq -r '.url')
 number=$(printf '%s' "$json" | jq -r '.number')
 head_sha=$(printf '%s' "$json" | jq -r '.headRefOid')
 commit_count=$(printf '%s' "$json" | jq -r '.commits | length')
+[ -z "$EXPECTED_HEAD_SHA" ] || [ "$head_sha" = "$EXPECTED_HEAD_SHA" ] || {
+  printf 'pr-merge-finalize: refusing merge for PR #%s; reviewed HEAD_SHA=%s but current HEAD_SHA=%s\n' "$number" "$EXPECTED_HEAD_SHA" "$head_sha" >&2
+  exit 1
+}
 
 [ "$state" = "OPEN" ] || { printf 'pr-merge-finalize: PR is not open (state=%s)\n' "$state" >&2; exit 1; }
 [ "$is_draft" = "false" ] || { printf 'pr-merge-finalize: PR is draft\n' >&2; exit 1; }

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -57,7 +57,7 @@ reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
 [ "$reviewer_profile" = "true" ] || fail not_reviewer_profile "$manifest"
 
 case "$spawn_command" in
-  *"--ask-for-approval never"*|*"--approval-policy never"*) ;;
+  *"--ask-for-approval never"*|*"--approval-policy never"*|*"-c approval_policy=never"*|*"--config approval_policy=never"*) ;;
   *) fail prompt_floor_unmet "spawn_command must force no-prompt execution" ;;
 esac
 
@@ -79,6 +79,10 @@ case "$HOST" in
       *"--ephemeral"* ) ;;
       *) fail persistent_session_state "Codex reviewer must pass --ephemeral" ;;
     esac
+    # shellcheck disable=SC2206
+    spawn_argv=( $spawn_command )
+    "${spawn_argv[@]}" --help >/dev/null 2>&1 \
+      || fail invalid_spawn_command "Codex reviewer spawn command is not accepted by the installed CLI"
     ;;
 esac
 

--- a/scripts/test-fixtures/318-pr-headless-review/test-pr-autopilot-head-race.sh
+++ b/scripts/test-fixtures/318-pr-headless-review/test-pr-autopilot-head-race.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verifies pr-autopilot refuses to gate a PR when the reviewed head is stale.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t pr-autopilot-head-race.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'codex fixture help\n'; exit 0 ;;
+esac
+exit 0
+SH
+chmod +x "$BIN/codex"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+
+case "$1 $2" in
+  "pr view")
+    printf '{"headRefOid":"new456","url":"https://github.com/owner/repo/pull/123"}\n'
+    ;;
+  "pr comment")
+    printf 'unexpected comment for stale review head\n' >&2
+    exit 7
+    ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$BIN/gh"
+
+export PATH="$BIN:$PATH"
+
+summary="$TMPROOT/summary.md"
+printf 'STUDIO_REVIEW_VERDICT=approved\n' > "$summary"
+
+if bash "$ROOT/scripts/pr-autopilot.sh" 123 \
+    --verdict approved \
+    --review-host codex-reviewer \
+    --summary-file "$summary" \
+    --expected-head-sha old123 \
+    >"$TMPROOT/out" 2>"$TMPROOT/err"; then
+  printf 'FAIL: stale reviewed head was accepted\n' >&2
+  exit 1
+fi
+
+if ! grep -q 'reviewed HEAD_SHA=old123 but current HEAD_SHA=new456' "$TMPROOT/err"; then
+  printf 'FAIL: stale-head error did not explain the mismatch\n' >&2
+  sed -n '1,80p' "$TMPROOT/err" >&2 || true
+  exit 1
+fi
+
+printf 'PASS: PR autopilot stale-head race guard\n'

--- a/scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh
+++ b/scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Verifies the headless reviewer must emit exactly one verdict line.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t pr-headless-review-verdict.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'codex fixture help\n'; exit 0 ;;
+esac
+printf 'STUDIO_REVIEW_VERDICT=blocked\n'
+printf 'STUDIO_REVIEW_VERDICT=approved\n'
+SH
+chmod +x "$BIN/codex"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+
+case "$1 $2" in
+  "pr view")
+    case " $* " in
+      *" --jq .number "*|*" --jq "*) printf '123\n' ;;
+      *) printf '{"number":123,"title":"Fixture PR","url":"https://github.com/owner/repo/pull/123","baseRefName":"main","headRefName":"feature","headRefOid":"abc123","author":{"login":"author"},"commits":[{"oid":"abc123"}]}\n' ;;
+    esac
+    ;;
+  "pr diff")
+    printf 'diff --git a/file b/file\n+change\n'
+    ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$BIN/gh"
+
+cat > "$BIN/autopilot" <<'SH'
+#!/usr/bin/env bash
+printf 'autopilot must not run for ambiguous verdicts\n' >&2
+exit 6
+SH
+chmod +x "$BIN/autopilot"
+
+export PATH="$BIN:$PATH"
+export PR_HEADLESS_REVIEW_AUTOPILOT="$BIN/autopilot"
+export HOME="$TMPROOT/caller-home"
+mkdir -p "$HOME/.codex"
+
+if bash "$ROOT/scripts/pr-headless-review.sh" 123 --review-host codex-reviewer --method auto \
+    >"$TMPROOT/out" 2>"$TMPROOT/err"; then
+  printf 'FAIL: multiple verdict lines were accepted\n' >&2
+  exit 1
+fi
+
+if ! grep -q 'must emit exactly one STUDIO_REVIEW_VERDICT line' "$TMPROOT/err"; then
+  printf 'FAIL: verdict-count error did not explain the mismatch\n' >&2
+  sed -n '1,80p' "$TMPROOT/err" >&2 || true
+  exit 1
+fi
+
+printf 'PASS: PR headless review verdict-count guard\n'

--- a/scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
+++ b/scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Verifies the headless PR review driver runs an eligible reviewer and hands
+# the parsed verdict to pr-autopilot.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t pr-headless-review.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'codex fixture help\n'; exit 0 ;;
+esac
+printf 'review summary\n'
+printf 'STUDIO_REVIEW_VERDICT=approved_with_fixes\n'
+[ -n "${REVIEW_PAYLOAD:-}" ] && [ -f "$REVIEW_PAYLOAD" ] || exit 3
+[ ! -f "$HOME/.config/gh/hosts.yml" ] || { printf 'reviewer inherited caller HOME\n' >&2; exit 5; }
+[ -n "${CODEX_HOME:-}" ] && [ -d "$CODEX_HOME" ] || { printf 'reviewer missing explicit CODEX_HOME\n' >&2; exit 6; }
+case "${GH_TOKEN:-}${GITHUB_TOKEN:-}${OPENAI_API_KEY:-}${ANTHROPIC_API_KEY:-}" in
+  "") ;;
+  *) printf 'secret leaked into reviewer env\n' >&2; exit 4 ;;
+esac
+SH
+chmod +x "$BIN/codex"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+
+case "$1 $2" in
+  "pr view")
+    case " $* " in
+      *" --jq .number "*|*" --jq "*) printf '123\n' ;;
+      *) printf '{"number":123,"title":"Fixture PR","url":"https://github.com/owner/repo/pull/123","baseRefName":"main","headRefName":"feature","headRefOid":"abc123","author":{"login":"author"},"commits":[{"oid":"abc123"}]}\n' ;;
+    esac
+    ;;
+  "pr diff")
+    printf 'diff --git a/file b/file\n+change\n'
+    ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$BIN/gh"
+
+cat > "$BIN/autopilot" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${AUTOPILOT_LOG:?}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --summary-file) summary="${2:?}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "${summary:-}" ] && grep -q 'STUDIO_REVIEW_VERDICT=approved_with_fixes' "$summary"
+SH
+chmod +x "$BIN/autopilot"
+
+export PATH="$BIN:$PATH"
+export PR_HEADLESS_REVIEW_AUTOPILOT="$BIN/autopilot"
+export AUTOPILOT_LOG="$TMPROOT/autopilot.log"
+export GH_TOKEN="must-not-leak"
+export GITHUB_TOKEN="must-not-leak"
+export OPENAI_API_KEY="must-not-leak"
+export ANTHROPIC_API_KEY="must-not-leak"
+export HOME="$TMPROOT/caller-home"
+mkdir -p "$HOME/.config/gh"
+printf 'github.com: token\n' > "$HOME/.config/gh/hosts.yml"
+mkdir -p "$HOME/.codex"
+
+failures=0
+assert() {
+  local name="$1" cmd="$2"
+  if eval "$cmd"; then
+    printf 'ok - %s\n' "$name"
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+out="$TMPROOT/out.txt"
+bash "$ROOT/scripts/pr-headless-review.sh" 123 --review-host codex-reviewer --method auto > "$out" 2>"$out.err"
+rc=$?
+
+assert "headless review exits zero" "[ '$rc' -eq 0 ]"
+assert "review host reported" "grep -q 'PR_REVIEW_HOST=codex-reviewer' '$out'"
+assert "verdict parsed" "grep -q 'PR_REVIEW_VERDICT=approved_with_fixes' '$out'"
+assert "autopilot receives verdict" "grep -q -- '--verdict approved_with_fixes' '$AUTOPILOT_LOG'"
+assert "autopilot receives review host" "grep -q -- '--review-host codex-reviewer' '$AUTOPILOT_LOG'"
+assert "autopilot receives reviewed head" "grep -q -- '--expected-head-sha abc123' '$AUTOPILOT_LOG'"
+assert "autopilot receives method" "grep -q -- '--method auto' '$AUTOPILOT_LOG'"
+
+if [ "$failures" -ne 0 ]; then
+  printf 'FAIL: %s assertion(s)\n' "$failures" >&2
+  sed -n '1,120p' "$out.err" >&2 || true
+  exit 1
+fi
+
+printf 'PASS: PR headless review driver\n'


### PR DESCRIPTION
Closes #318.

## Summary
- add scripts/pr-headless-review.sh to select an eligible no-secret reviewer host, run a headless review, parse STUDIO_REVIEW_VERDICT, and delegate gate/merge to pr-autopilot.sh
- document the studio PR autopilot policy in FORGE, README surfaces, scripts README, and studio docs
- add a fixture covering reviewer env scrubbing and autopilot handoff

## Verification
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
- bash -n scripts/pr-headless-review.sh scripts/pr-autopilot.sh scripts/pr-reviewer-eligibility.sh scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
- git diff --cached --check
- bash scripts/lint-host-agnostic.sh --staged (existing W_ARGUS_SECRET_SCOPE warning only)
- bash scripts/lint-comms-boundary.sh --staged
- scripts/pr-reviewer-eligibility.sh codex-reviewer
- opened file:///tmp/studio-fix-318/.claude/skills/studio/docs.html in Safari