### PR TITLE
Add claude-reviewer profile for PR gates

### DIFF
--- a/.claude-reviewer/capabilities.yaml
+++ b/.claude-reviewer/capabilities.yaml
@@ -1,0 +1,14 @@
+# Claude reviewer adapter (Claude Code CLI)
+#
+# Dedicated review profile for headless PR/review gates. This is intentionally
+# separate from .claude-plugin/capabilities.yaml: the normal Claude Code
+# reference adapter is host-native and inherits caller environment/config, while
+# reviewer sessions must be no-prompt, read-only, and receive no inherited
+# GitHub/API token environment from the parent studio session.
+supports_hooks: false
+spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config {} --tools Read,Grep,Glob"
+block_for_event_strategy: tail
+tool_dialect: claude
+sandbox_profile: read-only
+secret_scope: none
+reviewer_profile: true

--- a/hosts/ADAPTER-SPEC.md
+++ b/hosts/ADAPTER-SPEC.md
@@ -73,6 +73,16 @@ secret_scope = none
 
 **Why:** Argus consumes diffs and emits verdicts. It never calls an external API, reads user credentials, or writes to cloud services. Injecting any secret into an Argus session is unnecessary surface — a future prompt-injection in a diff could exfiltrate it.
 
+### PR reviewer profiles (Forge gate — reads PR payloads, emits verdicts)
+
+PR review gates use dedicated reviewer profiles (`reviewer_profile: true`), not
+normal worker/reference adapters. A reviewer profile must declare
+`secret_scope: none`, force no-prompt headless execution, and keep the session
+read-only unless a narrow auto-fix path is explicitly designed later.
+
+Do not make a normal worker profile eligible by relaxing the gate. Add a
+dedicated `<host>-reviewer` adapter with its own manifest and enforcement.
+
 ### Env-scrub at Argus dispatch
 
 `scripts/dispatch-review.sh` enforces the Argus floor at spawn time by env-scrubbing the subprocess. Only PATH/HOME/LANG/USER, the host plugin-root, and explicit task-context vars cross the boundary; `ANTHROPIC_API_KEY`, `GH_TOKEN`/`GITHUB_TOKEN`, and arbitrary inherited env are dropped. The host CLI re-authenticates from its own keychain inside the spawned session.

--- a/hosts/registry.yaml
+++ b/hosts/registry.yaml
@@ -33,6 +33,18 @@ claude-code:
   tool_dialect: claude
   status: adapted
 
+claude-reviewer:
+  display_name: "Claude Code Reviewer"
+  detect_binary: claude
+  global_skill_dir: "~/.claude-reviewer/skills"
+  project_skill_dir: ".claude-reviewer/skills"
+  routing_file: "CLAUDE.md"
+  routing_walks_parents: true
+  capabilities_path: ".claude-reviewer/capabilities.yaml"
+  global_instructions_path: "~/.claude-personal/CLAUDE.md"
+  tool_dialect: claude
+  status: adapted
+
 codex:
   display_name: "OpenAI Codex CLI"
   detect_binary: codex

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,6 +133,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
+scripts/pr-reviewer-eligibility.sh claude-reviewer      # same reviewer floor for Claude Code
 scripts/pr-headless-review.sh <pr>                      # run eligible reviewer, post gate, merge if non-blocked
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
 scripts/pr-merge-finalize.sh <pr> --method auto         # <4 commits=rebase, larger main=merge commit, then fetch/prune

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -57,15 +57,58 @@ reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
 [ "$reviewer_profile" = "true" ] || fail not_reviewer_profile "$manifest"
 
 case "$spawn_command" in
-  *"--ask-for-approval never"*|*"--approval-policy never"*|*"-c approval_policy=never"*|*"--config approval_policy=never"*) ;;
+  *"--ask-for-approval never"*|*"--approval-policy never"*|*"-c approval_policy=never"*|*"--config approval_policy=never"*|*"--permission-mode dontAsk"*) ;;
   *) fail prompt_floor_unmet "spawn_command must force no-prompt execution" ;;
 esac
 
 case "$spawn_command" in
   *"--dangerously-bypass-approvals-and-sandbox"*) fail unsafe_spawn_command "dangerous sandbox bypass is forbidden" ;;
+  *"--dangerously-skip-permissions"*) fail unsafe_spawn_command "dangerous permission bypass is forbidden" ;;
 esac
 
 case "$HOST" in
+  claude*|*claude*)
+    # shellcheck disable=SC2206
+    spawn_argv=( $spawn_command )
+    case "$spawn_command" in
+      *" -p "*|*" --print "*) ;;
+      *) fail interactive_spawn_command "Claude reviewer must use -p/--print" ;;
+    esac
+    case "$spawn_command" in
+      *"--setting-sources project"*) ;;
+      *) fail inherited_user_config "Claude reviewer must restrict setting sources to project" ;;
+    esac
+    case "$spawn_command" in
+      *"--disable-slash-commands"*) ;;
+      *) fail inherited_slash_commands "Claude reviewer must disable slash commands" ;;
+    esac
+    case "$spawn_command" in
+      *"--no-session-persistence"*) ;;
+      *) fail persistent_session_state "Claude reviewer must disable session persistence" ;;
+    esac
+    case "$spawn_command" in
+      *"--strict-mcp-config"*) ;;
+      *) fail inherited_mcp_config "Claude reviewer must use strict MCP config" ;;
+    esac
+    tools_value=""
+    i=0
+    while [ "$i" -lt "${#spawn_argv[@]}" ]; do
+      case "${spawn_argv[$i]}" in
+        --tools)
+          i=$((i + 1))
+          tools_value="${spawn_argv[$i]:-}"
+          ;;
+        --tools=*)
+          tools_value="${spawn_argv[$i]#--tools=}"
+          ;;
+      esac
+      i=$((i + 1))
+    done
+    [ "$tools_value" = "Read,Grep,Glob" ] \
+      || fail write_tool_floor_unmet "Claude reviewer tools must exactly equal Read,Grep,Glob"
+    "${spawn_argv[@]}" --help >/dev/null 2>&1 \
+      || fail invalid_spawn_command "Claude reviewer spawn command is not accepted by the installed CLI"
+    ;;
   codex*|*codex*)
     case "$spawn_command" in
       *"--ignore-user-config"* ) ;;

--- a/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
+++ b/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Verifies claude-reviewer is eligible for headless PR review and normal
+# claude-code remains ineligible.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t claude-reviewer.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+cat > "$BIN/claude" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'claude fixture help\n'; exit 0 ;;
+esac
+
+case " $* " in
+  *" -p "*|*" --print "*) ;;
+  *) printf 'claude reviewer was not headless\n' >&2; exit 3 ;;
+esac
+case " $* " in
+  *" --permission-mode dontAsk "*) ;;
+  *) printf 'claude reviewer can still prompt\n' >&2; exit 4 ;;
+esac
+case " $* " in
+  *" --setting-sources project "*) ;;
+  *) printf 'claude reviewer inherited user/local settings\n' >&2; exit 5 ;;
+esac
+case " $* " in
+  *" --disable-slash-commands "*) ;;
+  *) printf 'claude reviewer inherited slash commands\n' >&2; exit 6 ;;
+esac
+case " $* " in
+  *" --no-session-persistence "*) ;;
+  *) printf 'claude reviewer persisted session state\n' >&2; exit 7 ;;
+esac
+case " $* " in
+  *" --strict-mcp-config "*) ;;
+  *) printf 'claude reviewer inherited MCP config\n' >&2; exit 8 ;;
+esac
+case " $* " in
+  *" --tools Read,Grep,Glob "*) ;;
+  *) printf 'claude reviewer did not use read-only tools\n' >&2; exit 9 ;;
+esac
+
+[ -n "${REVIEW_PAYLOAD:-}" ] && [ -f "$REVIEW_PAYLOAD" ] || exit 10
+[ ! -f "$HOME/.config/gh/hosts.yml" ] || { printf 'reviewer inherited caller HOME\n' >&2; exit 11; }
+case "${GH_TOKEN:-}${GITHUB_TOKEN:-}${OPENAI_API_KEY:-}${ANTHROPIC_API_KEY:-}" in
+  "") ;;
+  *) printf 'secret leaked into reviewer env\n' >&2; exit 12 ;;
+esac
+
+printf 'claude review summary\n'
+printf 'STUDIO_REVIEW_VERDICT=approved\n'
+SH
+chmod +x "$BIN/claude"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -u
+
+case "$1 $2" in
+  "pr view")
+    case " $* " in
+      *" --jq .number "*|*" --jq "*) printf '123\n' ;;
+      *) printf '{"number":123,"title":"Fixture PR","url":"https://github.com/owner/repo/pull/123","baseRefName":"main","headRefName":"feature","headRefOid":"abc123","author":{"login":"author"},"commits":[{"oid":"abc123"}]}\n' ;;
+    esac
+    ;;
+  "pr diff")
+    printf 'diff --git a/file b/file\n+change\n'
+    ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$BIN/gh"
+
+cat > "$BIN/autopilot" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "${AUTOPILOT_LOG:?}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --summary-file) summary="${2:?}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "${summary:-}" ] && grep -q 'STUDIO_REVIEW_VERDICT=approved' "$summary"
+SH
+chmod +x "$BIN/autopilot"
+
+export PATH="$BIN:$PATH"
+export PR_HEADLESS_REVIEW_AUTOPILOT="$BIN/autopilot"
+export AUTOPILOT_LOG="$TMPROOT/autopilot.log"
+export GH_TOKEN="must-not-leak"
+export GITHUB_TOKEN="must-not-leak"
+export OPENAI_API_KEY="must-not-leak"
+export ANTHROPIC_API_KEY="must-not-leak"
+export HOME="$TMPROOT/caller-home"
+mkdir -p "$HOME/.config/gh"
+printf 'github.com: token\n' > "$HOME/.config/gh/hosts.yml"
+
+failures=0
+assert() {
+  local name="$1" cmd="$2"
+  if eval "$cmd"; then
+    printf 'ok - %s\n' "$name"
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+eligibility="$TMPROOT/eligibility.out"
+bash "$ROOT/scripts/pr-reviewer-eligibility.sh" claude-reviewer >"$eligibility" 2>"$eligibility.err"
+rc=$?
+assert "claude-reviewer is eligible" "[ '$rc' -eq 0 ]"
+assert "eligibility reports claude reviewer" "grep -q 'HOST=claude-reviewer' '$eligibility'"
+assert "eligibility reports reviewer manifest" "grep -q 'MANIFEST=.claude-reviewer/capabilities.yaml' '$eligibility'"
+global_skill_dir=$(yq -r '."claude-reviewer".global_skill_dir' "$ROOT/hosts/registry.yaml")
+project_skill_dir=$(yq -r '."claude-reviewer".project_skill_dir' "$ROOT/hosts/registry.yaml")
+assert "claude-reviewer has isolated global skill dir" "[ '$global_skill_dir' = '~/.claude-reviewer/skills' ]"
+assert "claude-reviewer has isolated project skill dir" "[ '$project_skill_dir' = '.claude-reviewer/skills' ]"
+
+normal="$TMPROOT/normal.out"
+if bash "$ROOT/scripts/pr-reviewer-eligibility.sh" claude-code >"$normal" 2>"$normal.err"; then
+  printf 'not ok - normal claude-code unexpectedly eligible\n' >&2
+  failures=$((failures + 1))
+else
+  assert "normal claude-code fails secret floor" "grep -q 'REASON=secret_scope_floor_unmet' '$normal'"
+fi
+
+MINI_REPO="$TMPROOT/mini-repo"
+mkdir -p "$MINI_REPO/scripts" "$MINI_REPO/hosts" "$MINI_REPO/.bad-claude-reviewer"
+cp "$ROOT/scripts/pr-reviewer-eligibility.sh" "$MINI_REPO/scripts/pr-reviewer-eligibility.sh"
+cp "$ROOT/scripts/lib-paths.sh" "$MINI_REPO/scripts/lib-paths.sh"
+cat > "$MINI_REPO/hosts/registry.yaml" <<'YAML'
+bad-claude-reviewer:
+  display_name: "Bad Claude Reviewer"
+  detect_binary: claude
+  capabilities_path: ".bad-claude-reviewer/capabilities.yaml"
+YAML
+cat > "$MINI_REPO/.bad-claude-reviewer/capabilities.yaml" <<'YAML'
+supports_hooks: false
+spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config {} --tools Read,Grep,Glob,Bash"
+block_for_event_strategy: tail
+tool_dialect: claude
+sandbox_profile: read-only
+secret_scope: none
+reviewer_profile: true
+YAML
+
+bad_tools="$TMPROOT/bad-tools.out"
+if bash "$MINI_REPO/scripts/pr-reviewer-eligibility.sh" bad-claude-reviewer >"$bad_tools" 2>"$bad_tools.err"; then
+  printf 'not ok - claude reviewer accepted appended Bash tool\n' >&2
+  failures=$((failures + 1))
+else
+  assert "claude reviewer rejects appended write tool" "grep -q 'REASON=write_tool_floor_unmet' '$bad_tools'"
+fi
+
+out="$TMPROOT/out.txt"
+bash "$ROOT/scripts/pr-headless-review.sh" 123 --review-host claude-reviewer --method auto >"$out" 2>"$out.err"
+rc=$?
+
+assert "headless claude review exits zero" "[ '$rc' -eq 0 ]"
+assert "review host reported" "grep -q 'PR_REVIEW_HOST=claude-reviewer' '$out'"
+assert "verdict parsed" "grep -q 'PR_REVIEW_VERDICT=approved' '$out'"
+assert "autopilot receives review host" "grep -q -- '--review-host claude-reviewer' '$AUTOPILOT_LOG'"
+
+if [ "$failures" -ne 0 ]; then
+  printf 'FAIL: %s assertion(s)\n' "$failures" >&2
+  sed -n '1,120p' "$eligibility.err" >&2 || true
+  sed -n '1,120p' "$out.err" >&2 || true
+  exit 1
+fi
+
+printf 'PASS: claude reviewer eligibility and headless review\n'


### PR DESCRIPTION
## Summary

Closes #321.

Adds a dedicated `claude-reviewer` host profile for Forge PR review gates without relaxing the reviewer floor for normal worker/reference adapters.

## Changes

- Add `.claude-reviewer/capabilities.yaml` with `reviewer_profile: true`, `secret_scope: none`, read-only sandbox declaration, and no-prompt headless Claude spawn semantics.
- Register `claude-reviewer` in `hosts/registry.yaml`.
- Extend `scripts/pr-reviewer-eligibility.sh` with Claude-specific enforcement: `-p`, `dontAsk`, project-only settings, disabled slash commands, no session persistence, strict MCP config, and read-only tools.
- Document that future PR reviewers require dedicated `<host>-reviewer` profiles rather than relaxing the gate.
- Add fixture coverage proving `claude-reviewer` passes, normal `claude-code` fails, and headless review env-scrubbing holds.

## Verification

- `scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh`
- `scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh`
- `scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh`
- `scripts/test-fixtures/318-pr-headless-review/test-pr-autopilot-head-race.sh`
- `scripts/pr-reviewer-eligibility.sh codex-reviewer`
- `scripts/pr-reviewer-eligibility.sh claude-reviewer`
- `bash -n scripts/pr-reviewer-eligibility.sh scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh scripts/pr-headless-review.sh scripts/pr-autopilot.sh`
- `scripts/lint-host-agnostic.sh` (existing warning: `.codex/capabilities.yaml` Argus secret scope)
- `scripts/lint-architecture.sh` (existing warnings: missing mode-pack fixtures / budget drift / snapshot freshness / Codex Argus secret scope)
- `scripts/lint-comms-boundary.sh` (existing warning: `chanakya/reopen` missing schema ref)
- `scripts/lint-debrief-writers.sh`

Review notes: REVIEW.md walked before commit. No new runtime writes outside `/tmp`; no user-input path; normal `claude-code` remains ineligible.
