### PR TITLE
Add pre-commit review gate

### DIFF
--- a/.claude/skills/studio/docs.html
+++ b/.claude/skills/studio/docs.html
@@ -353,6 +353,8 @@
     </ul>
     <h3>PR autopilot</h3>
     <p>Routine studio PRs run <code>scripts/pr-headless-review.sh &lt;pr&gt;</code>. The script selects an eligible no-secret reviewer host, captures <code>STUDIO_REVIEW_VERDICT</code>, posts the <code>studio:pr-review-gate</code> comment, and merges only when the verdict is not <code>blocked</code>. Merge cleanup deletes the remote branch and refreshes refs with <code>git fetch --prune</code>.</p>
+    <h3>Commit gate</h3>
+    <p>The repo hook runs <code>scripts/pre-commit-review.sh</code> on the staged diff after local architecture and privacy gates. Only <code>approved</code> and <code>approved_with_fixes</code> allow the commit. User bypass is explicit with <code>STUDIO_BYPASS_REVIEW=1 git commit ...</code> and emits <code>precommit_review_bypassed</code>.</p>
   </div>
 </section>
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-commit hook for generic-dev-studio. Eight gates in order:
+# Pre-commit hook for generic-dev-studio. Nine gates in order:
 #   1.  update-surface-manifest.sh — regenerate + auto-stage docs-surface.json.
 #   1b. capability-manifest.sh --regen — regenerate + auto-stage the manifest.
 #   2.  lint-architecture.sh --staged — router/frontmatter/dup/surface checks.
@@ -13,10 +13,13 @@
 #   2f. lint-debrief-writers.sh --staged — block legacy markdown/misrouted
 #       active debrief write paths (#311).
 #   3.  privacy gate — reject if staged diff leaks another project's runtime.
+#   4.  pre-commit-review.sh — no-secret reviewer gate over the staged diff.
 #
 # Emergency bypass: `ARCH_LINT=0 git commit ...` skips gates 2/2b/2c/2d/2e/2f/3.
 # Gates 1+1b (manifest regens) always run because stale manifests leak
 # downstream.
+# Review bypass: `STUDIO_BYPASS_REVIEW=1 git commit ...` skips gate 4 and
+# emits a loud audit event. Assistants must not set it on their own initiative.
 
 set -u
 
@@ -45,11 +48,13 @@ if [ -x "$SCRIPTS/capability-manifest.sh" ]; then
   fi
 fi
 
+ARCH_GATES_ENABLED=1
 if [ "${ARCH_LINT:-1}" = "0" ]; then
   printf 'pre-commit: ARCH_LINT=0 — skipping architecture + privacy gates (emergency bypass)\n' >&2
-  exit 0
+  ARCH_GATES_ENABLED=0
 fi
 
+if [ "$ARCH_GATES_ENABLED" = "1" ]; then
 # Gate 2 — architecture linter.
 if [ -x "$SCRIPTS/lint-architecture.sh" ]; then
   "$SCRIPTS/lint-architecture.sh" --staged
@@ -164,6 +169,18 @@ if [ -n "$leaks" ]; then
   printf 'E_PRIVACY_LEAK:staged diff references other-project runtime: %s | strip other-project paths or abstract to <project> placeholder\n' "$leaks" >&2
   printf 'bypass (emergencies only): ARCH_LINT=0 git commit ...\n' >&2
   exit 1
+fi
+fi
+
+# Gate 4 — staged-diff reviewer.
+if [ -x "$SCRIPTS/pre-commit-review.sh" ]; then
+  "$SCRIPTS/pre-commit-review.sh"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf '\npre-commit: staged-diff review gate failed\n' >&2
+    printf 'bypass (explicit user override only): STUDIO_BYPASS_REVIEW=1 git commit ...\n' >&2
+    exit 1
+  fi
 fi
 
 exit 0

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ scripts/fleet-cleanup.sh [--dry-run|--all]  # soft sweep / full teardown
 scripts/waive-start.sh argus "<reason>" "<sunset_trigger>"  # open a structured pause
 scripts/waive-lift.sh argus                                 # lift the pause; reports merges-skipped count
 scripts/backfill-orphan-debriefs.sh [--apply] [--quiet]     # recover tasks that finished but slipped the master plan
+scripts/pre-commit-review.sh                                # no-secret reviewer gate over staged diff; blocks commit on `blocked`
 scripts/pr-headless-review.sh <pr>                          # run no-secret reviewer gate, then merge if non-blocked
 ```
 
@@ -260,13 +261,13 @@ brew install fswatch coreutils yq jq
 
 ### Git hooks (contributors only)
 
-After cloning this repo to contribute back, enable the architecture + privacy pre-commit hook:
+After cloning this repo to contribute back, enable the architecture, privacy, and staged-review pre-commit hook:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-The hook regenerates `docs-surface.json`, runs `scripts/lint-architecture.sh --staged`, and blocks other-project runtime paths from leaking into commits. Error codes and fix recipes live in `_shared/rules/enforcement-contract.md`. Emergency bypass: `ARCH_LINT=0 git commit ...` (hotfixes only).
+The hook regenerates `docs-surface.json`, runs the architecture/privacy gates, then runs `scripts/pre-commit-review.sh` against the staged diff. Commits proceed only on `approved` or `approved_with_fixes`. Error codes and fix recipes live in `_shared/rules/enforcement-contract.md`. Emergency lint bypass: `ARCH_LINT=0 git commit ...` (hotfixes only). Review bypass is separate and explicit: `STUDIO_BYPASS_REVIEW=1 git commit ...`; assistants must not set it on their own initiative, and the bypass emits `precommit_review_bypassed`.
 
 ### One-time directories (per project)
 

--- a/_shared/contracts/events.md
+++ b/_shared/contracts/events.md
@@ -86,6 +86,14 @@ Use `printf '%s\n'` (not `echo`) — portable and avoids trailing-space issues.
 | `task_rescued` | Worker moved a task to `rescue/` — either `timeout` (rc=124 from `gtimeout`) or `silent_stuck` (rc=0 with no debrief written). Emitted by `scripts/achilles-worker.sh`. Visible equivalent of the rescue file, so Chanakya can surface + push without polling worker directories. | `reason` (`timeout`\|`silent_stuck`), `timeout_s` (only on timeout), `rc`, `debrief_written` (0\|1), `worker` (`worker-N`) |
 | `self_review_iterated` | Step 5 triggered a fix-and-rerun — a material finding was found, fixed, and the skill stack re-invoked. Only emitted when `iteration >= 2` (i.e. the cap was reached). Paired with `self_review_path` pointing to the written artifact under `plans/self-reviews/`. | `iteration` (always 2 at cap), `converged` (false if material findings remained after the fix), `material_skills` (array of skill names that returned `material`) |
 
+### Studio events
+
+| Event | Emitted when | Typical `data` keys |
+|---|---|---|
+| `precommit_review_passed` | `scripts/pre-commit-review.sh` received `approved` or `approved_with_fixes` for the staged diff. | `verdict`, `review_host`, `branch`, `head`, `patch_id` |
+| `precommit_review_blocked` | `scripts/pre-commit-review.sh` received `blocked` for the staged diff and rejected the commit. | `verdict`, `review_host`, `branch`, `head`, `patch_id` |
+| `precommit_review_bypassed` | User explicitly skipped the staged-diff review gate with `STUDIO_BYPASS_REVIEW=1` or `--bypass-review`. Assistants must not set this bypass on their own initiative. | `verdict` (`bypassed`), `review_host`, `branch`, `head`, `patch_id`, `bypass_source` (`env`\|`flag`) |
+
 ### Argus events
 
 | Event | Emitted when | Typical `data` keys |

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-04-29T08:59:39Z",
+  "generated_at": "2026-04-29T22:18:48Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-29T08:59:38Z",
+  "generated_at": "2026-04-29T22:18:47Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -134,6 +134,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
 scripts/pr-reviewer-eligibility.sh claude-reviewer      # same reviewer floor for Claude Code
+scripts/pre-commit-review.sh                            # run eligible reviewer against staged diff; accepts approved/approved_with_fixes only
 scripts/pr-headless-review.sh <pr>                      # run eligible reviewer, post gate, merge if non-blocked
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
 scripts/pr-merge-finalize.sh <pr> --method auto         # <4 commits=rebase, larger main=merge commit, then fetch/prune

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# pre-commit-review.sh — run an eligible no-secret reviewer on the staged diff.
+#
+# Usage:
+#   scripts/pre-commit-review.sh [--review-host <host>] [--bypass-review]
+#
+# The reviewer sees only a generated payload and the staged patch. The parent
+# shell owns the commit and any audit event emission.
+
+set -u
+umask 022
+
+usage() {
+  printf 'usage: pre-commit-review.sh [--review-host <host>] [--bypass-review]\n' >&2
+  exit 2
+}
+
+REVIEW_HOST="${STUDIO_REVIEW_HOST:-}"
+BYPASS_REVIEW=0
+CALLER_HOME="${HOME:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --review-host) REVIEW_HOST="${2:?--review-host requires a value}"; shift 2 ;;
+    --bypass-review) BYPASS_REVIEW=1; shift ;;
+    *) printf 'pre-commit-review: unknown flag %s\n' "$1" >&2; usage ;;
+  esac
+done
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+# shellcheck source=lib-ledger.sh
+. "$SCRIPT_DIR/lib-ledger.sh" 2>/dev/null || true
+
+yaml_field() {
+  local file="$1" key="$2"
+  grep -E "^${key}:[[:space:]]" "$file" 2>/dev/null \
+    | head -1 \
+    | sed "s/^${key}:[[:space:]]*//" \
+    | tr -d '"'"'"
+}
+
+emit_gate_event() {
+  command -v emit_event_keyed >/dev/null 2>&1 || return 0
+  local event="$1" verdict="$2" host="$3" patch_id="$4" bypass_source="${5:-}"
+  local data
+  if command -v jq >/dev/null 2>&1; then
+    data=$(jq -cn \
+      --arg verdict "$verdict" \
+      --arg host "$host" \
+      --arg branch "$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)" \
+      --arg head "$(git rev-parse --short HEAD 2>/dev/null || true)" \
+      --arg patch_id "$patch_id" \
+      --arg bypass_source "$bypass_source" \
+      '{verdict:$verdict,review_host:$host,branch:$branch,head:$head,patch_id:$patch_id,bypass_source:$bypass_source}')
+  else
+    data="{\"verdict\":\"$verdict\",\"review_host\":\"$host\",\"patch_id\":\"$patch_id\",\"bypass_source\":\"$bypass_source\"}"
+  fi
+  emit_event_keyed studio commit "$event" "" "$data" --idem-key "precommit:$event:$patch_id" >/dev/null 2>&1 || true
+}
+
+eligible_hosts() {
+  local registry="$REPO_ROOT/hosts/registry.yaml" host manifest reviewer_profile
+  [ -f "$registry" ] || return 1
+  while IFS= read -r host; do
+    [ -n "$host" ] || continue
+    manifest=$(resolve_capabilities_manifest "$host" "$REPO_ROOT" 2>/dev/null || true)
+    [ -n "$manifest" ] && [ -f "$manifest" ] || continue
+    reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
+    [ "$reviewer_profile" = "true" ] || continue
+    if "$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$host" >/dev/null 2>&1; then
+      printf '%s\n' "$host"
+    fi
+  done < <(yq -r 'keys | .[]' "$registry" 2>/dev/null)
+}
+
+if git diff --cached --quiet --exit-code; then
+  printf 'pre-commit-review: no staged diff; skipping reviewer gate\n' >&2
+  exit 0
+fi
+
+patch_id=$(git diff --cached --patch | git patch-id --stable 2>/dev/null | awk '{print $1}' | head -1)
+[ -n "$patch_id" ] || patch_id="unknown"
+
+if [ "${STUDIO_BYPASS_REVIEW:-0}" = "1" ] || [ "$BYPASS_REVIEW" -eq 1 ]; then
+  source="env"
+  [ "$BYPASS_REVIEW" -eq 1 ] && source="flag"
+  printf 'pre-commit-review: STUDIO REVIEW GATE BYPASSED by explicit user override (%s)\n' "$source" >&2
+  emit_gate_event precommit_review_bypassed bypassed "${REVIEW_HOST:-none}" "$patch_id" "$source"
+  exit 0
+fi
+
+command -v yq >/dev/null 2>&1 || { printf 'pre-commit-review: yq is required\n' >&2; exit 1; }
+
+if [ -z "$REVIEW_HOST" ]; then
+  hosts=()
+  while IFS= read -r host; do
+    [ -n "$host" ] && hosts+=("$host")
+  done < <(eligible_hosts)
+  [ "${#hosts[@]}" -gt 0 ] || {
+    printf 'pre-commit-review: no eligible reviewer hosts found\n' >&2
+    printf 'bypass (explicit user override only): STUDIO_BYPASS_REVIEW=1 git commit ...\n' >&2
+    exit 1
+  }
+  REVIEW_HOST="${hosts[0]}"
+fi
+
+eligibility=$("$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST") || {
+  printf '%s\n' "$eligibility" >&2
+  printf 'pre-commit-review: reviewer host is not eligible: %s\n' "$REVIEW_HOST" >&2
+  exit 1
+}
+manifest=$(printf '%s\n' "$eligibility" | sed -n 's/^MANIFEST=//p' | head -1)
+spawn_command=$(printf '%s\n' "$eligibility" | sed -n 's/^SPAWN_COMMAND=//p' | head -1)
+[ -n "$spawn_command" ] || { printf 'pre-commit-review: missing spawn command for %s\n' "$REVIEW_HOST" >&2; exit 1; }
+
+tmpdir=$(mktemp -d -t pre-commit-review.XXXXXX)
+trap 'rm -rf "$tmpdir"' EXIT
+payload="$tmpdir/review-payload.md"
+summary="$tmpdir/reviewer-summary.md"
+reviewer_home="$tmpdir/reviewer-home"
+mkdir -p "$reviewer_home"
+
+reviewer_codex_home=""
+case "$REVIEW_HOST" in
+  codex*|*codex*)
+    reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-${CALLER_HOME:+$CALLER_HOME/.codex}}}"
+    [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] || {
+      printf 'pre-commit-review: codex reviewer auth home not found; set CODEX_REVIEWER_HOME or CODEX_HOME\n' >&2
+      exit 1
+    }
+    ;;
+esac
+
+{
+  printf '# Studio Pre-Commit Review Payload\n\n'
+  printf 'Metadata:\n\n'
+  printf '%s\n' "- repository: $(basename "$REPO_ROOT")"
+  printf '%s\n' "- branch: $(git symbolic-ref --quiet --short HEAD 2>/dev/null || printf unknown)"
+  printf '%s\n' "- head: $(git rev-parse HEAD 2>/dev/null || printf unknown)"
+  printf '%s\n\n' "- patch_id: $patch_id"
+  cat <<'PROMPT'
+Review this staged studio diff against REVIEW.md and the repository-specific rules.
+
+Return a concise report with exactly one machine-readable verdict line:
+
+STUDIO_REVIEW_VERDICT=approved
+STUDIO_REVIEW_VERDICT=approved_with_fixes
+STUDIO_REVIEW_VERDICT=blocked
+
+Use `blocked` only for critical blockers: data loss, broken routing, unsafe
+runtime behavior, permission/auth changes, base-branch bypass, failing required
+checks, merge conflicts, or repo-rule violations. This is a pre-commit review:
+do not edit files, do not stage files, do not commit, and do not bypass this
+gate.
+
+PROMPT
+  printf '\nStaged diff:\n\n```diff\n'
+  git diff --cached --patch
+  printf '\n```\n'
+} > "$payload"
+
+# shellcheck disable=SC2206
+spawn_argv=( $spawn_command )
+review_prompt="Read $payload, review the staged studio diff, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
+
+if ! env -i \
+    PATH="$PATH" \
+    HOME="$reviewer_home" \
+    LANG="${LANG:-C.UTF-8}" \
+    USER="${USER:-}" \
+    ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
+    STUDIO_HOST="$REVIEW_HOST" \
+    REVIEW_PAYLOAD="$payload" \
+    STAGED_PATCH_ID="$patch_id" \
+    "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err"; then
+  printf 'pre-commit-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
+  sed -n '1,80p' "$summary.err" >&2 || true
+  exit 1
+fi
+
+verdict_count=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary" | wc -l | tr -d ' ')
+verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary")
+if [ "$verdict_count" != "1" ]; then
+  printf 'pre-commit-review: reviewer must emit exactly one STUDIO_REVIEW_VERDICT line (found %s)\n' "$verdict_count" >&2
+  sed -n '1,120p' "$summary" >&2 || true
+  exit 1
+fi
+
+case "$verdict" in
+  approved|approved_with_fixes)
+    printf 'PRECOMMIT_REVIEW_HOST=%s\n' "$REVIEW_HOST"
+    printf 'PRECOMMIT_REVIEW_MANIFEST=%s\n' "$manifest"
+    printf 'PRECOMMIT_REVIEW_VERDICT=%s\n' "$verdict"
+    sed -n '1,120p' "$summary"
+    emit_gate_event precommit_review_passed "$verdict" "$REVIEW_HOST" "$patch_id" ""
+    ;;
+  blocked)
+    printf 'pre-commit-review: reviewer blocked commit\n' >&2
+    sed -n '1,120p' "$summary" >&2 || true
+    emit_gate_event precommit_review_blocked "$verdict" "$REVIEW_HOST" "$patch_id" ""
+    exit 1
+    ;;
+  *)
+    printf 'pre-commit-review: reviewer did not emit a valid STUDIO_REVIEW_VERDICT line\n' >&2
+    sed -n '1,120p' "$summary" >&2 || true
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
+++ b/scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verifies a blocked staged-diff verdict rejects the commit gate.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t precommit-review-blocked.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+REPO="$TMPROOT/repo"
+mkdir -p "$BIN" "$REPO"
+
+cat > "$BIN/yq" <<'SH'
+#!/usr/bin/env bash
+expr="$2"
+case "$expr" in
+  *detect_binary*) printf 'codex\n' ;;
+  *capabilities_path*) printf '.codex-reviewer/capabilities.yaml\n' ;;
+  *) printf 'unexpected yq expression: %s\n' "$expr" >&2; exit 2 ;;
+esac
+SH
+chmod +x "$BIN/yq"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'codex fixture help\n'; exit 0 ;;
+esac
+printf 'critical blocker\n'
+printf 'STUDIO_REVIEW_VERDICT=blocked\n'
+SH
+chmod +x "$BIN/codex"
+
+export PATH="$BIN:$PATH"
+export HOME="$TMPROOT/caller-home"
+mkdir -p "$HOME/.codex"
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name Test
+printf 'one\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -qm initial
+printf 'two\n' >> "$REPO/file.txt"
+git -C "$REPO" add file.txt
+
+if (cd "$REPO" && bash "$ROOT/scripts/pre-commit-review.sh" --review-host codex-reviewer >"$TMPROOT/out" 2>"$TMPROOT/err"); then
+  printf 'FAIL: blocked verdict was accepted\n' >&2
+  exit 1
+fi
+
+grep -q 'reviewer blocked commit' "$TMPROOT/err" || {
+  printf 'FAIL: blocked verdict did not explain rejection\n' >&2
+  sed -n '1,80p' "$TMPROOT/err" >&2 || true
+  exit 1
+}
+
+printf 'PASS: pre-commit review rejects blocked verdict\n'

--- a/scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh
+++ b/scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Verifies explicit user bypass skips the reviewer and emits an audit event.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t precommit-review-bypass.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+REPO="$TMPROOT/repo"
+mkdir -p "$BIN" "$REPO"
+
+cat > "$BIN/yq" <<'SH'
+#!/usr/bin/env bash
+printf 'yq should not be called during bypass\n' >&2
+exit 9
+SH
+chmod +x "$BIN/yq"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+printf 'codex should not be called during bypass\n' >&2
+exit 8
+SH
+chmod +x "$BIN/codex"
+
+export PATH="$BIN:$PATH"
+export HOME="$TMPROOT/caller-home"
+export STUDIO_BYPASS_REVIEW=1
+mkdir -p "$HOME/.codex"
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name Test
+printf 'one\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -qm initial
+printf 'two\n' >> "$REPO/file.txt"
+git -C "$REPO" add file.txt
+
+if ! (cd "$REPO" && bash "$ROOT/scripts/pre-commit-review.sh" >"$TMPROOT/out" 2>"$TMPROOT/err"); then
+  printf 'FAIL: explicit bypass failed\n' >&2
+  sed -n '1,80p' "$TMPROOT/err" >&2 || true
+  exit 1
+fi
+
+grep -q 'STUDIO REVIEW GATE BYPASSED' "$TMPROOT/err" || {
+  printf 'FAIL: bypass was not loud\n' >&2
+  exit 1
+}
+if ! find "$HOME/.dev-studio" -type f -name '*.jsonl' -print0 2>/dev/null \
+    | xargs -0 grep -q 'precommit_review_bypassed'; then
+  printf 'FAIL: bypass audit event not emitted\n' >&2
+  find "$HOME/.dev-studio" -type f -maxdepth 5 -print 2>/dev/null >&2 || true
+  exit 1
+fi
+
+printf 'PASS: pre-commit review bypass is loud and audited\n'

--- a/scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
+++ b/scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Verifies the staged-diff review gate accepts approved verdicts and keeps the
+# reviewer environment scrubbed.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t precommit-review.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+REPO="$TMPROOT/repo"
+mkdir -p "$BIN" "$REPO"
+
+cat > "$BIN/yq" <<'SH'
+#!/usr/bin/env bash
+expr="$2"
+case "$expr" in
+  *detect_binary*) printf 'codex\n' ;;
+  *capabilities_path*) printf '.codex-reviewer/capabilities.yaml\n' ;;
+  *) printf 'unexpected yq expression: %s\n' "$expr" >&2; exit 2 ;;
+esac
+SH
+chmod +x "$BIN/yq"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'codex fixture help\n'; exit 0 ;;
+esac
+[ -n "${REVIEW_PAYLOAD:-}" ] && [ -f "$REVIEW_PAYLOAD" ] || exit 3
+grep -q 'Staged diff:' "$REVIEW_PAYLOAD" || exit 7
+[ ! -f "$HOME/.config/gh/hosts.yml" ] || { printf 'reviewer inherited caller HOME\n' >&2; exit 5; }
+[ -n "${CODEX_HOME:-}" ] && [ -d "$CODEX_HOME" ] || { printf 'reviewer missing explicit CODEX_HOME\n' >&2; exit 6; }
+case "${GH_TOKEN:-}${GITHUB_TOKEN:-}${OPENAI_API_KEY:-}${ANTHROPIC_API_KEY:-}" in
+  "") ;;
+  *) printf 'secret leaked into reviewer env\n' >&2; exit 4 ;;
+esac
+printf 'review summary\n'
+printf 'STUDIO_REVIEW_VERDICT=approved_with_fixes\n'
+SH
+chmod +x "$BIN/codex"
+
+export PATH="$BIN:$PATH"
+export GH_TOKEN="must-not-leak"
+export GITHUB_TOKEN="must-not-leak"
+export OPENAI_API_KEY="must-not-leak"
+export ANTHROPIC_API_KEY="must-not-leak"
+export HOME="$TMPROOT/caller-home"
+mkdir -p "$HOME/.config/gh" "$HOME/.codex"
+printf 'github.com: token\n' > "$HOME/.config/gh/hosts.yml"
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name Test
+printf 'one\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -qm initial
+printf 'two\n' >> "$REPO/file.txt"
+git -C "$REPO" add file.txt
+
+out="$TMPROOT/out.txt"
+err="$TMPROOT/err.txt"
+if ! (cd "$REPO" && bash "$ROOT/scripts/pre-commit-review.sh" --review-host codex-reviewer >"$out" 2>"$err"); then
+  printf 'FAIL: pre-commit review rejected approved_with_fixes\n' >&2
+  sed -n '1,120p' "$err" >&2 || true
+  exit 1
+fi
+
+grep -q 'PRECOMMIT_REVIEW_HOST=codex-reviewer' "$out" || {
+  printf 'FAIL: review host not reported\n' >&2
+  exit 1
+}
+grep -q 'PRECOMMIT_REVIEW_VERDICT=approved_with_fixes' "$out" || {
+  printf 'FAIL: verdict not reported\n' >&2
+  exit 1
+}
+
+printf 'PASS: pre-commit review accepts approved verdict\n'


### PR DESCRIPTION
## Summary
- add scripts/pre-commit-review.sh to run the no-secret reviewer pipeline against staged diffs before commit
- wire the repo pre-commit hook so only approved/approved_with_fixes commits proceed, with STUDIO_BYPASS_REVIEW=1 as a loud audited user override
- document precommit_review_* events and add focused shell fixtures for approved, blocked, and bypass flows

Closes #342

## Verification
- scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
- scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
- scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh
- scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
- scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh
- bash -n scripts/pre-commit-review.sh .githooks/pre-commit scripts/test-fixtures/342-precommit-review/test-precommit-review.sh scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh
- scripts/lint-architecture.sh --staged (0 errors; existing warnings)
- scripts/lint-skill-prose.sh --staged
- scripts/lint-build-invocations.sh --staged
- scripts/lint-comms-boundary.sh --staged (0 errors; existing warning)
- scripts/lint-mode-pack.sh --staged
- scripts/lint-debrief-writers.sh --staged
- scripts/pre-commit-review.sh --review-host codex-reviewer (approved)
- STUDIO_REVIEW_HOST=codex-reviewer git commit ... (hook reviewer approved)

## Notes
The first real pre-commit review blocked an ARCH_LINT=0 path that would have skipped Gate 4; this PR fixes that so ARCH_LINT only skips architecture/privacy gates. Review bypass remains separate via STUDIO_BYPASS_REVIEW=1.