### PR TITLE
Add reviewer model catalog policy

### DIFF
--- a/.claude-reviewer/capabilities.yaml
+++ b/.claude-reviewer/capabilities.yaml
@@ -6,7 +6,7 @@
 # reviewer sessions must be no-prompt, read-only, and receive no inherited
 # GitHub/API token environment from the parent studio session.
 supports_hooks: false
-spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config {} --tools Read,Grep,Glob"
+spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config .claude-reviewer/mcp-empty.json --tools Read,Grep,Glob"
 block_for_event_strategy: tail
 tool_dialect: claude
 sandbox_profile: read-only

--- a/.claude-reviewer/mcp-empty.json
+++ b/.claude-reviewer/mcp-empty.json
@@ -1,0 +1,1 @@
+{"mcpServers":{}}

--- a/.claude/skills/studio/docs.html
+++ b/.claude/skills/studio/docs.html
@@ -352,9 +352,9 @@
       <li>No writes outside <code>~/.dev-studio/&lt;project&gt;/audit/</code> (audit reports in <code>--report</code> mode). Everything else is read-only chat output + file edits you approve.</li>
     </ul>
     <h3>PR autopilot</h3>
-    <p>Routine studio PRs run <code>scripts/pr-headless-review.sh &lt;pr&gt;</code>. The script selects an eligible no-secret reviewer host, captures <code>STUDIO_REVIEW_VERDICT</code>, posts the <code>studio:pr-review-gate</code> comment, and merges only when the verdict is not <code>blocked</code>. Merge cleanup deletes the remote branch and refreshes refs with <code>git fetch --prune</code>.</p>
+    <p>Routine studio PRs run <code>scripts/pr-headless-review.sh &lt;pr&gt;</code>. The script resolves <code>_shared/rules/model-policy.yaml</code> against <code>_shared/schemas/model-catalog.yaml</code>, selects an eligible no-secret reviewer host from a different provider family than the implementation host when known, captures <code>STUDIO_REVIEW_VERDICT</code>, posts the <code>studio:pr-review-gate</code> comment, and merges only when the verdict is not <code>blocked</code>. Merge cleanup deletes the remote branch and refreshes refs with <code>git fetch --prune</code>.</p>
     <h3>Commit gate</h3>
-    <p>The repo hook runs <code>scripts/pre-commit-review.sh</code> on the staged diff after local architecture and privacy gates. Only <code>approved</code> and <code>approved_with_fixes</code> allow the commit. User bypass is explicit with <code>STUDIO_BYPASS_REVIEW=1 git commit ...</code> and emits <code>precommit_review_bypassed</code>.</p>
+    <p>The repo hook runs <code>scripts/pre-commit-review.sh</code> on the staged diff after local architecture and privacy gates. The same checked-in model policy controls reviewer host, model, and reasoning effort. Only <code>approved</code> and <code>approved_with_fixes</code> allow the commit. User bypass is explicit with <code>STUDIO_BYPASS_REVIEW=1 git commit ...</code> and emits <code>precommit_review_bypassed</code>.</p>
   </div>
 </section>
 

--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,16 +19,16 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
-| 2 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
-| 3 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
-| 4 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
-| 5 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
-| 6 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
-| 7 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Release/status logic must not depend on a forbidden top-level endpoint. |
-| 8 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Ensures no active prose or writer still mutates retired legacy surfaces. |
-| 9 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
-| 10 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Closes paths where flagged reviews or sibling merges can pass the merge boundary unsafely. |
+| 1 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
+| 2 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
+| 3 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
+| 4 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
+| 5 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
+| 6 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Release/status logic must not depend on a forbidden top-level endpoint. |
+| 7 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Ensures no active prose or writer still mutates retired legacy surfaces. |
+| 8 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
+| 9 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Closes paths where flagged reviews or sibling merges can pass the merge boundary unsafely. |
+| 10 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed without follow-up tasks. |
 
 ## Safety-Floor Queue
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ scripts/waive-start.sh argus "<reason>" "<sunset_trigger>"  # open a structured 
 scripts/waive-lift.sh argus                                 # lift the pause; reports merges-skipped count
 scripts/backfill-orphan-debriefs.sh [--apply] [--quiet]     # recover tasks that finished but slipped the master plan
 scripts/forge-latency-report.sh --days 14                   # stage-level Forge task latency from event logs
-scripts/pre-commit-review.sh                                # no-secret reviewer gate over staged diff; blocks commit on `blocked`
-scripts/pr-headless-review.sh <pr>                          # run no-secret reviewer gate, then merge if non-blocked
+scripts/pre-commit-review.sh                                # policy-resolved no-secret reviewer gate; blocks commit on `blocked`
+scripts/pr-headless-review.sh <pr>                          # policy-resolved reviewer gate, then merge if non-blocked
 ```
 
 **Minimal-intervention by default.** Chanakya runs end-to-end without stopping for confirmation. The only points where it pauses are: Slack publish, first-time config writes (`--configure-token`, `--configure`), merge conflicts, and `--wait` mode feedback windows.

--- a/_shared/rules/model-policy.yaml
+++ b/_shared/rules/model-policy.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+catalog: "../schemas/model-catalog.yaml"
+last_verified_at: "2026-04-30"
+
+roles:
+  implementer.heavyweight:
+    description: "Non-trivial implementation, schema migration, cross-module change, or crash/root-cause work."
+    candidate_adapters: [claude-code, codex]
+    reasoning_effort: high
+    provider_preferences:
+      - provider_family: anthropic
+        model_id: claude-opus-4-6
+      - provider_family: openai
+        model_id: gpt-5.5
+
+  reviewer.heavyweight:
+    description: "Forge PR review, Argus-style regression review, and any non-trivial code-quality gate."
+    candidate_adapters: [claude-reviewer, codex-reviewer]
+    require_independent_provider_family: true
+    reasoning_effort: high
+    fallback_role: reviewer.fallback
+    provider_preferences:
+      - provider_family: anthropic
+        model_id: claude-opus-4-6
+      - provider_family: openai
+        model_id: gpt-5.5
+
+  reviewer.fallback:
+    description: "Reviewer fallback when heavyweight model/profile is unavailable; still must preserve provider-family independence unless explicitly bypassed."
+    candidate_adapters: [claude-reviewer, codex-reviewer]
+    require_independent_provider_family: true
+    reasoning_effort: medium
+    provider_preferences:
+      - provider_family: anthropic
+        model_id: claude-sonnet-4-6
+      - provider_family: openai
+        model_id: gpt-5.4
+
+bypass:
+  same_provider_family:
+    env: STUDIO_REVIEW_ALLOW_SAME_FAMILY
+    allowed_value: "1"
+    requirement: "Explicit user-approved bypass only. Normal review and merge paths block when no independent reviewer family is eligible."

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-04-29T23:47:22Z",
+  "generated_at": "2026-04-30T00:21:16Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/model-catalog.yaml
+++ b/_shared/schemas/model-catalog.yaml
@@ -1,0 +1,89 @@
+schema_version: 1
+last_verified_at: "2026-04-30"
+refresh:
+  cadence: "every 3-4 weeks, plus manual refresh on explicit user request or provider/model failure"
+  checklist:
+    - "Verify OpenAI model IDs against https://platform.openai.com/docs/models and https://platform.openai.com/docs/guides/latest-model."
+    - "Verify Anthropic model IDs and aliases against https://docs.anthropic.com/en/docs/about-claude/models."
+    - "Update last_verified_at and source_url fields in the same change as any default-model change."
+    - "Run the PR reviewer fixtures after changing adapter defaults or role policy."
+
+provider_families:
+  openai:
+    display_name: "OpenAI"
+    source_url: "https://platform.openai.com/docs/models"
+  anthropic:
+    display_name: "Anthropic"
+    source_url: "https://docs.anthropic.com/en/docs/about-claude/models"
+
+models:
+  gpt-5.5:
+    provider_family: openai
+    display_name: "GPT-5.5"
+    role_suitability: [implementer.heavyweight, reviewer.heavyweight]
+    reasoning_effort_supported: [none, low, medium, high, xhigh]
+    default_reasoning_effort: high
+    stable_aliases: []
+    snapshot_ids: []
+    source_url: "https://platform.openai.com/docs/guides/latest-model"
+    last_verified_at: "2026-04-30"
+    verification_evidence: "OpenAI model table lists Model ID gpt-5.5."
+    notes: "OpenAI docs list gpt-5.5 as the flagship model for complex reasoning and coding."
+  gpt-5.4:
+    provider_family: openai
+    display_name: "GPT-5.4"
+    role_suitability: [implementer.heavyweight, reviewer.fallback]
+    reasoning_effort_supported: [none, low, medium, high, xhigh]
+    default_reasoning_effort: high
+    stable_aliases: []
+    snapshot_ids: []
+    source_url: "https://platform.openai.com/docs/models"
+    last_verified_at: "2026-04-30"
+    verification_evidence: "OpenAI model table lists Model ID gpt-5.4."
+    notes: "Fallback OpenAI reasoning model for coding and professional work when GPT-5.5 is unavailable."
+  claude-opus-4-6:
+    provider_family: anthropic
+    display_name: "Claude Opus 4.6"
+    role_suitability: [implementer.heavyweight, reviewer.heavyweight]
+    reasoning_effort_supported: [medium, high]
+    default_reasoning_effort: high
+    stable_aliases: [claude-opus-4-6]
+    snapshot_ids: []
+    source_url: "https://docs.anthropic.com/en/docs/about-claude/models"
+    last_verified_at: "2026-04-30"
+    verification_evidence: "Pre-commit reviewer verified the official Claude table lists claude-opus-4-6."
+    notes: "Initial Opus-tier reviewer default; bump through the sparse catalog refresh path when the installed reviewer CLI and official docs agree on a newer Opus slug."
+  claude-sonnet-4-6:
+    provider_family: anthropic
+    display_name: "Claude Sonnet 4.6"
+    role_suitability: [implementer.heavyweight, reviewer.fallback]
+    reasoning_effort_supported: [medium, high]
+    default_reasoning_effort: high
+    stable_aliases: [claude-sonnet-4-6]
+    snapshot_ids: []
+    source_url: "https://docs.anthropic.com/en/docs/about-claude/models"
+    last_verified_at: "2026-04-30"
+    verification_evidence: "Anthropic latest comparison lists Claude API ID claude-sonnet-4-6."
+    notes: "Fallback high-capability Claude model when Opus-tier review is unavailable."
+
+adapters:
+  claude-code:
+    provider_family: anthropic
+    default_model_id: claude-opus-4-6
+    model_flag: "--model"
+    effort_flag: "--effort"
+  claude-reviewer:
+    provider_family: anthropic
+    default_model_id: claude-opus-4-6
+    model_flag: "--model"
+    effort_flag: "--effort"
+  codex:
+    provider_family: openai
+    default_model_id: gpt-5.5
+    model_flag: "--model"
+    effort_config_key: model_reasoning_effort
+  codex-reviewer:
+    provider_family: openai
+    default_model_id: gpt-5.5
+    model_flag: "--model"
+    effort_config_key: model_reasoning_effort

--- a/chanakya/docs.html
+++ b/chanakya/docs.html
@@ -800,7 +800,7 @@ cd generic-dev-studio
   </table>
 
   <h3>Model Recommendations</h3>
-  <p>Per-agent model defaults &mdash; tune for cost/quality without losing capability where it matters.</p>
+  <p>Per-agent model defaults &mdash; tune for cost/quality without losing capability where it matters. Forge reviewer gates resolve current host/model policy from <code>_shared/rules/model-policy.yaml</code> and refreshable model IDs from <code>_shared/schemas/model-catalog.yaml</code>.</p>
   <table class="decision-table">
     <thead><tr><th>Agent</th><th>Default</th><th>When to upgrade / downgrade</th></tr></thead>
     <tbody>

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-29T23:47:20Z",
+  "generated_at": "2026-04-30T00:21:15Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/hosts/registry.yaml
+++ b/hosts/registry.yaml
@@ -9,8 +9,13 @@
 # Schema versioned via _shared/standards/host-registry.json (validated by
 # scripts/lint-skill-prose.sh when present).
 #
-# Required fields: display_name, global_skill_dir, detect_binary.
+# Required fields: display_name, provider_family, global_skill_dir, detect_binary.
 # Optional fields marked below. Empty required values reject at lint time.
+#
+# provider_family: stable company/model-family key used by reviewer policy.
+# Dedicated profiles from the same provider (for example codex and
+# codex-reviewer) share one family so review gates can enforce independent
+# reviewer selection.
 #
 # detect_binary: checked by `sync-host-skills.sh --all` to skip hosts whose
 # CLI is not installed on this machine. Value is a binary name resolved via
@@ -23,6 +28,7 @@
 
 claude-code:
   display_name: "Claude Code"
+  provider_family: anthropic
   detect_binary: claude
   global_skill_dir: "~/.claude/skills"
   project_skill_dir: ".claude/skills"
@@ -35,6 +41,7 @@ claude-code:
 
 claude-reviewer:
   display_name: "Claude Code Reviewer"
+  provider_family: anthropic
   detect_binary: claude
   global_skill_dir: "~/.claude-reviewer/skills"
   project_skill_dir: ".claude-reviewer/skills"
@@ -47,6 +54,7 @@ claude-reviewer:
 
 codex:
   display_name: "OpenAI Codex CLI"
+  provider_family: openai
   detect_binary: codex
   global_skill_dir: "~/.codex/skills"
   project_skill_dir: ".codex/skills"
@@ -59,6 +67,7 @@ codex:
 
 codex-reviewer:
   display_name: "OpenAI Codex CLI Reviewer"
+  provider_family: openai
   detect_binary: codex
   global_skill_dir: "~/.codex/skills"
   project_skill_dir: ".codex/skills"
@@ -71,6 +80,7 @@ codex-reviewer:
 
 gemini-cli:
   display_name: "Gemini CLI"
+  provider_family: google
   detect_binary: gemini
   global_skill_dir: "~/.gemini/skills"
   project_skill_dir: ".gemini/skills"
@@ -82,6 +92,7 @@ gemini-cli:
 
 cursor:
   display_name: "Cursor"
+  provider_family: anthropic
   detect_binary: cursor
   global_skill_dir: "~/.cursor/skills"
   project_skill_dir: ".cursor/skills"
@@ -92,6 +103,7 @@ cursor:
 
 windsurf:
   display_name: "Windsurf"
+  provider_family: anthropic
   detect_binary: windsurf
   global_skill_dir: "~/.windsurf/skills"
   project_skill_dir: ".windsurf/skills"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -135,8 +135,8 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
 scripts/pr-reviewer-eligibility.sh claude-reviewer      # same reviewer floor for Claude Code
-scripts/pre-commit-review.sh                            # run eligible reviewer against staged diff; accepts approved/approved_with_fixes only
-scripts/pr-headless-review.sh <pr>                      # run eligible reviewer, post gate, merge if non-blocked
+scripts/pre-commit-review.sh                            # resolve reviewer model policy, review staged diff, accept approved/approved_with_fixes only
+scripts/pr-headless-review.sh <pr>                      # resolve independent reviewer model policy, post gate, merge if non-blocked
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
 scripts/pr-merge-finalize.sh <pr> --method auto         # <4 commits=rebase, larger main=merge commit, then fetch/prune
 

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -57,33 +57,88 @@ yaml_field() {
     | tr -d '"'"'"
 }
 
-eligible_hosts() {
-  local registry="$REPO_ROOT/hosts/registry.yaml" host manifest reviewer_profile
-  [ -f "$registry" ] || return 1
+host_family() {
+  local host="$1" registry="$REPO_ROOT/hosts/registry.yaml" family
+  family=$(yq -r ".\"$host\".provider_family // \"\"" "$registry" 2>/dev/null || true)
+  [ -n "$family" ] && [ "$family" != "null" ] && { printf '%s\n' "$family"; return 0; }
+  yq -r ".adapters.\"$host\".provider_family // \"\"" "$REPO_ROOT/_shared/schemas/model-catalog.yaml" 2>/dev/null || true
+}
+
+policy_model_for() {
+  local role="$1" family="$2" policy="$REPO_ROOT/_shared/rules/model-policy.yaml" model
+  model=$(yq -r ".roles.\"$role\".provider_preferences[] | select(.provider_family == \"$family\") | .model_id" "$policy" 2>/dev/null | head -1)
+  [ -n "$model" ] && [ "$model" != "null" ] && { printf '%s\n' "$model"; return 0; }
+  yq -r ".adapters.\"$REVIEW_HOST\".default_model_id // \"\"" "$REPO_ROOT/_shared/schemas/model-catalog.yaml" 2>/dev/null || true
+}
+
+policy_effort_for() {
+  local role="$1" policy="$REPO_ROOT/_shared/rules/model-policy.yaml"
+  yq -r ".roles.\"$role\".reasoning_effort // \"\"" "$policy" 2>/dev/null || true
+}
+
+resolve_policy_reviewer() {
+  local role="reviewer.heavyweight" policy="$REPO_ROOT/_shared/rules/model-policy.yaml"
+  local implementation_host="${STUDIO_IMPLEMENTATION_HOST:-${STUDIO_IMPLEMENTER_HOST:-${STUDIO_HOST:-}}}"
+  local excluded_family="" host family require_independent allow_same
+
+  [ -f "$policy" ] || return 1
+  if [ -n "$implementation_host" ]; then
+    excluded_family=$(host_family "$implementation_host")
+  fi
+  require_independent=$(yq -r ".roles.\"$role\".require_independent_provider_family // false" "$policy")
+  allow_same="${STUDIO_REVIEW_ALLOW_SAME_FAMILY:-0}"
+
   while IFS= read -r host; do
-    [ -n "$host" ] || continue
-    manifest=$(resolve_capabilities_manifest "$host" "$REPO_ROOT" 2>/dev/null || true)
-    [ -n "$manifest" ] && [ -f "$manifest" ] || continue
-    reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
-    [ "$reviewer_profile" = "true" ] || continue
+    [ -n "$host" ] && [ "$host" != "null" ] || continue
+    family=$(host_family "$host")
+    if [ "$require_independent" = "true" ] && [ "$allow_same" != "1" ] && [ -n "$excluded_family" ] && [ "$family" = "$excluded_family" ]; then
+      continue
+    fi
     if "$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$host" >/dev/null 2>&1; then
       printf '%s\n' "$host"
+      return 0
     fi
-  done < <(yq -r 'keys | .[]' "$registry" 2>/dev/null)
+  done < <(yq -r ".roles.\"$role\".candidate_adapters[]" "$policy" 2>/dev/null)
+
+  return 1
+}
+
+append_policy_model_args() {
+  local host="$1" model="$2" effort="$3"
+  [ -n "$model" ] && [ "$model" != "null" ] || return 0
+  case "$host" in
+    claude*|*claude*)
+      spawn_argv+=(--model "$model")
+      [ -n "$effort" ] && [ "$effort" != "null" ] && spawn_argv+=(--effort "$effort")
+      ;;
+    codex*|*codex*)
+      spawn_argv+=(--model "$model")
+      [ -n "$effort" ] && [ "$effort" != "null" ] && spawn_argv+=(-c "model_reasoning_effort=$effort")
+      ;;
+  esac
+}
+
+enforce_independent_reviewer_family() {
+  local implementation_host="${STUDIO_IMPLEMENTATION_HOST:-${STUDIO_IMPLEMENTER_HOST:-${STUDIO_HOST:-}}}"
+  local implementation_family=""
+  [ -n "$implementation_host" ] || return 0
+  implementation_family=$(host_family "$implementation_host")
+  [ -n "$implementation_family" ] && [ "$implementation_family" != "null" ] || return 0
+  if [ "${STUDIO_REVIEW_ALLOW_SAME_FAMILY:-0}" != "1" ] && [ "$REVIEW_FAMILY" = "$implementation_family" ]; then
+    printf 'pr-headless-review: reviewer host family must differ from implementation host family (implementation_host=%s, implementation_family=%s, review_host=%s)\n' \
+      "$implementation_host" "$implementation_family" "$REVIEW_HOST" >&2
+    printf 'pr-headless-review: explicit user-approved bypass requires STUDIO_REVIEW_ALLOW_SAME_FAMILY=1\n' >&2
+    exit 1
+  fi
 }
 
 if [ -z "$REVIEW_HOST" ]; then
-  hosts=()
-  while IFS= read -r host; do
-    [ -n "$host" ] && hosts+=("$host")
-  done < <(eligible_hosts)
-  [ "${#hosts[@]}" -gt 0 ] || {
+  REVIEW_HOST=$(resolve_policy_reviewer) || {
     printf 'pr-headless-review: no eligible reviewer hosts found\n' >&2
+    impl="${STUDIO_IMPLEMENTATION_HOST:-${STUDIO_IMPLEMENTER_HOST:-${STUDIO_HOST:-unknown}}}"
+    printf 'pr-headless-review: implementation host family excluded by policy (implementation_host=%s); explicit bypass requires STUDIO_REVIEW_ALLOW_SAME_FAMILY=1\n' "$impl" >&2
     exit 1
   }
-  pr_num=$(gh pr view "$PR" --json number --jq '.number') \
-    || { printf 'pr-headless-review: failed to read PR %s\n' "$PR" >&2; exit 1; }
-  REVIEW_HOST="${hosts[$(( pr_num % ${#hosts[@]} ))]}"
 fi
 
 eligibility=$("$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST") || {
@@ -94,6 +149,11 @@ eligibility=$("$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST") || {
 manifest=$(printf '%s\n' "$eligibility" | sed -n 's/^MANIFEST=//p' | head -1)
 spawn_command=$(printf '%s\n' "$eligibility" | sed -n 's/^SPAWN_COMMAND=//p' | head -1)
 [ -n "$spawn_command" ] || { printf 'pr-headless-review: missing spawn command for %s\n' "$REVIEW_HOST" >&2; exit 1; }
+REVIEW_FAMILY=$(host_family "$REVIEW_HOST")
+enforce_independent_reviewer_family
+REVIEW_ROLE="reviewer.heavyweight"
+REVIEW_MODEL_ID=$(policy_model_for "$REVIEW_ROLE" "$REVIEW_FAMILY")
+REVIEW_REASONING_EFFORT=$(policy_effort_for "$REVIEW_ROLE")
 
 pr_json=$(gh pr view "$PR" --json number,title,url,baseRefName,headRefName,headRefOid,author,commits) \
   || { printf 'pr-headless-review: failed to read PR %s\n' "$PR" >&2; exit 1; }
@@ -143,6 +203,7 @@ PROMPT
 
 # shellcheck disable=SC2206
 spawn_argv=( $spawn_command )
+append_policy_model_args "$REVIEW_HOST" "$REVIEW_MODEL_ID" "$REVIEW_REASONING_EFFORT"
 review_prompt="Read $payload, review PR $pr_url at HEAD $head_sha, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
 
 if ! env -i \
@@ -179,6 +240,9 @@ esac
 
 printf 'PR_REVIEW_HOST=%s\n' "$REVIEW_HOST"
 printf 'PR_REVIEW_MANIFEST=%s\n' "$manifest"
+printf 'PR_REVIEW_PROVIDER_FAMILY=%s\n' "$REVIEW_FAMILY"
+printf 'PR_REVIEW_MODEL=%s\n' "$REVIEW_MODEL_ID"
+printf 'PR_REVIEW_REASONING_EFFORT=%s\n' "$REVIEW_REASONING_EFFORT"
 printf 'PR_REVIEW_VERDICT=%s\n' "$verdict"
 
 "$AUTOPILOT" "$PR" \

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -43,6 +43,81 @@ yaml_field() {
     | tr -d '"'"'"
 }
 
+host_family() {
+  local host="$1" registry="$REPO_ROOT/hosts/registry.yaml" family
+  family=$(yq -r ".\"$host\".provider_family // \"\"" "$registry" 2>/dev/null || true)
+  [ -n "$family" ] && [ "$family" != "null" ] && { printf '%s\n' "$family"; return 0; }
+  yq -r ".adapters.\"$host\".provider_family // \"\"" "$REPO_ROOT/_shared/schemas/model-catalog.yaml" 2>/dev/null || true
+}
+
+policy_model_for() {
+  local role="$1" family="$2" policy="$REPO_ROOT/_shared/rules/model-policy.yaml" model
+  model=$(yq -r ".roles.\"$role\".provider_preferences[] | select(.provider_family == \"$family\") | .model_id" "$policy" 2>/dev/null | head -1)
+  [ -n "$model" ] && [ "$model" != "null" ] && { printf '%s\n' "$model"; return 0; }
+  yq -r ".adapters.\"$REVIEW_HOST\".default_model_id // \"\"" "$REPO_ROOT/_shared/schemas/model-catalog.yaml" 2>/dev/null || true
+}
+
+policy_effort_for() {
+  local role="$1" policy="$REPO_ROOT/_shared/rules/model-policy.yaml"
+  yq -r ".roles.\"$role\".reasoning_effort // \"\"" "$policy" 2>/dev/null || true
+}
+
+resolve_policy_reviewer() {
+  local role="reviewer.heavyweight" policy="$REPO_ROOT/_shared/rules/model-policy.yaml"
+  local implementation_host="${STUDIO_IMPLEMENTATION_HOST:-${STUDIO_IMPLEMENTER_HOST:-${STUDIO_HOST:-}}}"
+  local excluded_family="" host family require_independent allow_same
+
+  [ -f "$policy" ] || return 1
+  if [ -n "$implementation_host" ]; then
+    excluded_family=$(host_family "$implementation_host")
+  fi
+  require_independent=$(yq -r ".roles.\"$role\".require_independent_provider_family // false" "$policy")
+  allow_same="${STUDIO_REVIEW_ALLOW_SAME_FAMILY:-0}"
+
+  while IFS= read -r host; do
+    [ -n "$host" ] && [ "$host" != "null" ] || continue
+    family=$(host_family "$host")
+    if [ "$require_independent" = "true" ] && [ "$allow_same" != "1" ] && [ -n "$excluded_family" ] && [ "$family" = "$excluded_family" ]; then
+      continue
+    fi
+    if "$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$host" >/dev/null 2>&1; then
+      printf '%s\n' "$host"
+      return 0
+    fi
+  done < <(yq -r ".roles.\"$role\".candidate_adapters[]" "$policy" 2>/dev/null)
+
+  return 1
+}
+
+append_policy_model_args() {
+  local host="$1" model="$2" effort="$3"
+  [ -n "$model" ] && [ "$model" != "null" ] || return 0
+  case "$host" in
+    claude*|*claude*)
+      spawn_argv+=(--model "$model")
+      [ -n "$effort" ] && [ "$effort" != "null" ] && spawn_argv+=(--effort "$effort")
+      ;;
+    codex*|*codex*)
+      spawn_argv+=(--model "$model")
+      [ -n "$effort" ] && [ "$effort" != "null" ] && spawn_argv+=(-c "model_reasoning_effort=$effort")
+      ;;
+  esac
+}
+
+enforce_independent_reviewer_family() {
+  local implementation_host="${STUDIO_IMPLEMENTATION_HOST:-${STUDIO_IMPLEMENTER_HOST:-${STUDIO_HOST:-}}}"
+  local implementation_family=""
+  [ -n "$implementation_host" ] || return 0
+  implementation_family=$(host_family "$implementation_host")
+  [ -n "$implementation_family" ] && [ "$implementation_family" != "null" ] || return 0
+  if [ "${STUDIO_REVIEW_ALLOW_SAME_FAMILY:-0}" != "1" ] && [ "$REVIEW_FAMILY" = "$implementation_family" ]; then
+    printf 'pre-commit-review: reviewer host family must differ from implementation host family (implementation_host=%s, implementation_family=%s, review_host=%s)\n' \
+      "$implementation_host" "$implementation_family" "$REVIEW_HOST" >&2
+    printf 'pre-commit-review: explicit user-approved bypass requires STUDIO_REVIEW_ALLOW_SAME_FAMILY=1\n' >&2
+    exit 1
+  fi
+}
+
 emit_gate_event() {
   command -v emit_event_keyed >/dev/null 2>&1 || return 0
   local event="$1" verdict="$2" host="$3" patch_id="$4" bypass_source="${5:-}"
@@ -60,21 +135,6 @@ emit_gate_event() {
     data="{\"verdict\":\"$verdict\",\"review_host\":\"$host\",\"patch_id\":\"$patch_id\",\"bypass_source\":\"$bypass_source\"}"
   fi
   emit_event_keyed studio commit "$event" "" "$data" --idem-key "precommit:$event:$patch_id" >/dev/null 2>&1 || true
-}
-
-eligible_hosts() {
-  local registry="$REPO_ROOT/hosts/registry.yaml" host manifest reviewer_profile
-  [ -f "$registry" ] || return 1
-  while IFS= read -r host; do
-    [ -n "$host" ] || continue
-    manifest=$(resolve_capabilities_manifest "$host" "$REPO_ROOT" 2>/dev/null || true)
-    [ -n "$manifest" ] && [ -f "$manifest" ] || continue
-    reviewer_profile=$(yaml_field "$manifest" reviewer_profile)
-    [ "$reviewer_profile" = "true" ] || continue
-    if "$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$host" >/dev/null 2>&1; then
-      printf '%s\n' "$host"
-    fi
-  done < <(yq -r 'keys | .[]' "$registry" 2>/dev/null)
 }
 
 if git diff --cached --quiet --exit-code; then
@@ -96,16 +156,13 @@ fi
 command -v yq >/dev/null 2>&1 || { printf 'pre-commit-review: yq is required\n' >&2; exit 1; }
 
 if [ -z "$REVIEW_HOST" ]; then
-  hosts=()
-  while IFS= read -r host; do
-    [ -n "$host" ] && hosts+=("$host")
-  done < <(eligible_hosts)
-  [ "${#hosts[@]}" -gt 0 ] || {
+  REVIEW_HOST=$(resolve_policy_reviewer) || {
     printf 'pre-commit-review: no eligible reviewer hosts found\n' >&2
+    impl="${STUDIO_IMPLEMENTATION_HOST:-${STUDIO_IMPLEMENTER_HOST:-${STUDIO_HOST:-unknown}}}"
+    printf 'pre-commit-review: implementation host family excluded by policy (implementation_host=%s); explicit bypass requires STUDIO_REVIEW_ALLOW_SAME_FAMILY=1\n' "$impl" >&2
     printf 'bypass (explicit user override only): STUDIO_BYPASS_REVIEW=1 git commit ...\n' >&2
     exit 1
   }
-  REVIEW_HOST="${hosts[0]}"
 fi
 
 eligibility=$("$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST") || {
@@ -116,6 +173,11 @@ eligibility=$("$SCRIPT_DIR/pr-reviewer-eligibility.sh" "$REVIEW_HOST") || {
 manifest=$(printf '%s\n' "$eligibility" | sed -n 's/^MANIFEST=//p' | head -1)
 spawn_command=$(printf '%s\n' "$eligibility" | sed -n 's/^SPAWN_COMMAND=//p' | head -1)
 [ -n "$spawn_command" ] || { printf 'pre-commit-review: missing spawn command for %s\n' "$REVIEW_HOST" >&2; exit 1; }
+REVIEW_FAMILY=$(host_family "$REVIEW_HOST")
+enforce_independent_reviewer_family
+REVIEW_ROLE="reviewer.heavyweight"
+REVIEW_MODEL_ID=$(policy_model_for "$REVIEW_ROLE" "$REVIEW_FAMILY")
+REVIEW_REASONING_EFFORT=$(policy_effort_for "$REVIEW_ROLE")
 
 tmpdir=$(mktemp -d -t pre-commit-review.XXXXXX)
 trap 'rm -rf "$tmpdir"' EXIT
@@ -165,6 +227,7 @@ PROMPT
 
 # shellcheck disable=SC2206
 spawn_argv=( $spawn_command )
+append_policy_model_args "$REVIEW_HOST" "$REVIEW_MODEL_ID" "$REVIEW_REASONING_EFFORT"
 review_prompt="Read $payload, review the staged studio diff, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
 
 if ! env -i \
@@ -194,6 +257,9 @@ case "$verdict" in
   approved|approved_with_fixes)
     printf 'PRECOMMIT_REVIEW_HOST=%s\n' "$REVIEW_HOST"
     printf 'PRECOMMIT_REVIEW_MANIFEST=%s\n' "$manifest"
+    printf 'PRECOMMIT_REVIEW_PROVIDER_FAMILY=%s\n' "$REVIEW_FAMILY"
+    printf 'PRECOMMIT_REVIEW_MODEL=%s\n' "$REVIEW_MODEL_ID"
+    printf 'PRECOMMIT_REVIEW_REASONING_EFFORT=%s\n' "$REVIEW_REASONING_EFFORT"
     printf 'PRECOMMIT_REVIEW_VERDICT=%s\n' "$verdict"
     sed -n '1,120p' "$summary"
     emit_gate_event precommit_review_passed "$verdict" "$REVIEW_HOST" "$patch_id" ""

--- a/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
+++ b/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
@@ -168,8 +168,26 @@ rc=$?
 
 assert "headless claude review exits zero" "[ '$rc' -eq 0 ]"
 assert "review host reported" "grep -q 'PR_REVIEW_HOST=claude-reviewer' '$out'"
+assert "review model reported" "grep -q 'PR_REVIEW_MODEL=claude-opus-4-6' '$out'"
+assert "review effort reported" "grep -q 'PR_REVIEW_REASONING_EFFORT=high' '$out'"
 assert "verdict parsed" "grep -q 'PR_REVIEW_VERDICT=approved' '$out'"
 assert "autopilot receives review host" "grep -q -- '--review-host claude-reviewer' '$AUTOPILOT_LOG'"
+
+policy_out="$TMPROOT/policy-default.out"
+STUDIO_IMPLEMENTATION_HOST=codex bash "$ROOT/scripts/pr-headless-review.sh" 123 --method auto >"$policy_out" 2>"$policy_out.err"
+policy_rc=$?
+assert "policy default exits zero" "[ '$policy_rc' -eq 0 ]"
+assert "policy excludes implementation provider family" "grep -q 'PR_REVIEW_HOST=claude-reviewer' '$policy_out'"
+assert "policy reports anthropic provider family" "grep -q 'PR_REVIEW_PROVIDER_FAMILY=anthropic' '$policy_out'"
+
+same_family_err="$TMPROOT/same-family.err"
+if STUDIO_IMPLEMENTATION_HOST=claude-code bash "$ROOT/scripts/pr-headless-review.sh" 123 --review-host claude-reviewer --method auto \
+    >"$TMPROOT/same-family.out" 2>"$same_family_err"; then
+  printf 'not ok - explicit same-family reviewer unexpectedly allowed\n' >&2
+  failures=$((failures + 1))
+else
+  assert "explicit same-family reviewer blocks without bypass" "grep -q 'reviewer host family must differ' '$same_family_err'"
+fi
 
 if [ "$failures" -ne 0 ]; then
   printf 'FAIL: %s assertion(s)\n' "$failures" >&2

--- a/scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
+++ b/scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
@@ -15,6 +15,9 @@ cat > "$BIN/yq" <<'SH'
 #!/usr/bin/env bash
 expr="$2"
 case "$expr" in
+  *provider_family*) printf 'openai\n' ;;
+  *provider_preferences*) printf 'gpt-5.5\n' ;;
+  *reasoning_effort*) printf 'high\n' ;;
   *detect_binary*) printf 'codex\n' ;;
   *capabilities_path*) printf '.codex-reviewer/capabilities.yaml\n' ;;
   *) printf 'unexpected yq expression: %s\n' "$expr" >&2; exit 2 ;;

--- a/scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
+++ b/scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
@@ -16,6 +16,9 @@ cat > "$BIN/yq" <<'SH'
 #!/usr/bin/env bash
 expr="$2"
 case "$expr" in
+  *provider_family*) printf 'openai\n' ;;
+  *provider_preferences*) printf 'gpt-5.5\n' ;;
+  *reasoning_effort*) printf 'high\n' ;;
   *detect_binary*) printf 'codex\n' ;;
   *capabilities_path*) printf '.codex-reviewer/capabilities.yaml\n' ;;
   *) printf 'unexpected yq expression: %s\n' "$expr" >&2; exit 2 ;;


### PR DESCRIPTION
## Summary
- Add checked-in model catalog and reviewer/implementer model policy for OpenAI and Anthropic families.
- Resolve PR and pre-commit reviewer host/model/effort from policy while enforcing provider-family independence, including explicit review-host selections.
- Update docs and Forge reliability lookup for #322.

Closes #322

## Verification
- bash -n scripts/pr-headless-review.sh scripts/pre-commit-review.sh scripts/pr-reviewer-eligibility.sh
- yq shape checks for _shared/schemas/model-catalog.yaml and _shared/rules/model-policy.yaml
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh
- bash scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh
- scripts/lint-host-agnostic.sh --staged (existing W_ARGUS_SECRET_SCOPE warning)
- scripts/lint-build-invocations.sh
- git diff --check
- pre-commit reviewer gate: approved via codex-reviewer

portable: yes