### PR TITLE
Track Forge blind-spot closure chain

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,16 +19,32 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
-| 2 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
-| 3 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
-| 4 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
-| 5 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
-| 6 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Repairs status drift where completed work looks pending. |
+| 1 | [#364](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/364) Analyze collection must be host-agnostic and `.dev-studio`-first | Makes the diagnostic surface trustworthy before we use it to judge blind spots. |
+| 2 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass suppresses event emission and sweep hooks | Closes direct artifact paths that make downstream hooks silently no-op. |
+| 3 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows | Makes event-log loss bounded and recoverable instead of falsely precise. |
+| 4 | [#226](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/226) Inbox sweep observability | Surfaces missing debriefs and handoff anomalies instead of waiting for manual investigation. |
+| 5 | [#241](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/241) Review-coverage metric in `/chanakya status` | Turns Argus dark periods into a visible process metric. |
+| 6 | [#362](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/362) `push-tf` must preflight GitHub auth before mutating build number | Prevents release workflows from creating partial external state before auth is proven. |
 | 7 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Release/status logic must not depend on a forbidden top-level endpoint. |
-| 8 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Ensures no active prose or writer still mutates retired legacy surfaces. |
-| 9 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
-| 10 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Closes paths where flagged reviews or sibling merges can pass the merge boundary unsafely. |
+| 8 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Gives reviewer/worker selection a maintained model source instead of hardcoded stale names. |
+| 9 | [#323](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/323) Improve Chanakya brief quality | Smaller, measurable briefs improve Achilles output, Argus review, and future test generation. |
+| 10 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Keeps the review gate available from deployed skills layouts. |
+
+## Active Chain: Forge blind-spot closure
+
+Label: `chain/forge-blindspots`
+
+Resolve in this order unless an urgent release fix is explicitly pulled forward:
+
+1. [#364](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/364) — make `/studio analyze` host-agnostic and `.dev-studio`-first.
+2. [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) — close ledger bypass paths that create artifacts without lifecycle/event hooks.
+3. [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) — make event-log reconstruction bounded and recoverable.
+4. [#226](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/226) — add sweep and handoff observability for missing debriefs and lifecycle anomalies.
+5. [#241](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/241) — expose review-coverage windows in status and push surfaces.
+6. [#362](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/362) — harden release preflight before build-number mutation.
+7. [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) — repair live-version lookup through app-scoped ASC APIs.
+
+Chain goal: artifacts and events reconcile cleanly; missing evidence is surfaced as `unknown` or repairable, not silently treated as absent.
 
 ## Safety-Floor Queue
 
@@ -38,14 +54,17 @@ These remain eligible during the Forge reliability freeze because they prevent s
 |---|---|---|---|
 | [#316](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/316) Sweep ingest silently skips lifecycle side effects when debrief facts are present but events are missing | Closed | Reliability bug | Inbox sweep must reconcile canonical debrief facts into queue drain, review-skip, audit, status, and follow-up signals. |
 | [#347](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/347) Measure Forge task latency after review-gate enforcement | Closed | Observability | Review-gate slowdown claims must be measured by stage so optimization targets evidence without weakening the safety floor. |
+| [#364](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/364) Analyze collection must be host-agnostic and `.dev-studio`-first | Open | Reliability bug | Analysis can falsely report no usable surface when runtime artifacts exist under `.dev-studio` but host-specific memory is missing. |
 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass with non-canonical task IDs suppresses event emission and sweep hooks | Open | Reliability bug | Direct artifact creation can bypass lib-ledger contracts and make downstream hooks silently no-op. |
 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows from sweeps | Open | Reliability bug | Event-log loss makes sweeps and analytics falsely precise unless gaps are bounded and recoverable. |
 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing from deployed skills layout | Open | Reliability bug | Review gate availability depends on host registry deployment and deterministic infra-failure handling. |
 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Open | Safety-floor hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Open | Safety-floor hardening | Closes paths where flagged reviews or sibling merges can pass the merge boundary unsafely. |
 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Open | Safety-floor hardening | Prevents `done_with_concerns` and structured follow-ups from being absorbed without tasks. |
+| [#226](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/226) Inbox sweep observability | Open | Observability | Handoff anomalies and missing debriefs should emit visible signals before they become stale status drift. |
 | [#241](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/241) Review-coverage metric in `/chanakya status` | Open | Observability | Makes review dark periods visible as a metric, not a post-hoc investigation. |
 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Open | Reliability bug | Status can show completed work as pending when debrief emission is missing. |
+| [#362](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/362) `push-tf` must preflight GitHub auth before mutating build number | Open | Reliability bug | Release workflows must prove required auth before creating partial external state. |
 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Open | Reliability bug | Release/status logic must not depend on a forbidden top-level endpoint. |
 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Open | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Closed | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |


### PR DESCRIPTION
## Summary

- marks the Forge blind-spot closure chain in `FORGE-RELIABILITY.md`
- moves the chain into the top of Up Next in priority order
- adds #364, #226, and #362 to the Safety-Floor Queue alongside the existing linked issues

## Chain

1. #364
2. #315
3. #314
4. #226
5. #241
6. #362
7. #97

## Verification

- pre-commit ran during commit; existing warning remains: `W_MISSING_SCHEMA_REF` for `chanakya/reopen`

Closes none; this is issue-graph bookkeeping.