### PR TITLE
Fix Claude reviewer startup

### DIFF
--- a/.claude-reviewer/capabilities.yaml
+++ b/.claude-reviewer/capabilities.yaml
@@ -6,7 +6,7 @@
 # reviewer sessions must be no-prompt, read-only, and receive no inherited
 # GitHub/API token environment from the parent studio session.
 supports_hooks: false
-spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config {} --tools Read,Grep,Glob"
+spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config .claude-reviewer/mcp-empty.json --tools=Read,Grep,Glob"
 block_for_event_strategy: tail
 tool_dialect: claude
 sandbox_profile: read-only

--- a/.claude-reviewer/mcp-empty.json
+++ b/.claude-reviewer/mcp-empty.json
@@ -1,0 +1,1 @@
+{"mcpServers":{}}

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-04-30T10:48:42Z",
+  "generated_at": "2026-04-30T11:14:52Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-30T10:48:41Z",
+  "generated_at": "2026-04-30T11:14:48Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -190,7 +190,7 @@ PROMPT
 spawn_argv=( $spawn_command )
 review_prompt="Read $payload, review PR $pr_url at HEAD $head_sha, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
 
-if ! env -i \
+if ! ( cd "$REPO_ROOT" && env -i \
     PATH="$PATH" \
     HOME="$reviewer_home" \
     LANG="${LANG:-C.UTF-8}" \
@@ -200,7 +200,7 @@ if ! env -i \
     REVIEW_PAYLOAD="$payload" \
     PR_URL="$pr_url" \
     PR_HEAD_SHA="$head_sha" \
-    "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err"; then
+    "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err" ); then
   printf 'pr-headless-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
   sed -n '1,80p' "$summary.err" >&2 || true
   exit 1

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -174,7 +174,7 @@ PROMPT
 spawn_argv=( $spawn_command )
 review_prompt="Read $payload, review the staged studio diff, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
 
-if ! env -i \
+if ! ( cd "$REPO_ROOT" && env -i \
     PATH="$PATH" \
     HOME="$reviewer_home" \
     LANG="${LANG:-C.UTF-8}" \
@@ -183,7 +183,7 @@ if ! env -i \
     STUDIO_HOST="$REVIEW_HOST" \
     REVIEW_PAYLOAD="$payload" \
     STAGED_PATCH_ID="$patch_id" \
-    "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err"; then
+    "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err" ); then
   printf 'pre-commit-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
   sed -n '1,80p' "$summary.err" >&2 || true
   exit 1

--- a/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
+++ b/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
@@ -42,7 +42,14 @@ case " $* " in
   *) printf 'claude reviewer inherited MCP config\n' >&2; exit 8 ;;
 esac
 case " $* " in
-  *" --tools Read,Grep,Glob "*) ;;
+  *" --mcp-config .claude-reviewer/mcp-empty.json "*) ;;
+  *) printf 'claude reviewer did not use isolated MCP config file\n' >&2; exit 13 ;;
+esac
+[ -f ".claude-reviewer/mcp-empty.json" ] || { printf 'claude reviewer launched outside repo root\n' >&2; exit 14; }
+grep -q '"mcpServers"[[:space:]]*:[[:space:]]*{}' ".claude-reviewer/mcp-empty.json" \
+  || { printf 'claude reviewer MCP config is not empty\n' >&2; exit 15; }
+case " $* " in
+  *" --tools=Read,Grep,Glob "*) ;;
   *) printf 'claude reviewer did not use read-only tools\n' >&2; exit 9 ;;
 esac
 
@@ -146,7 +153,7 @@ bad-claude-reviewer:
 YAML
 cat > "$MINI_REPO/.bad-claude-reviewer/capabilities.yaml" <<'YAML'
 supports_hooks: false
-spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config {} --tools Read,Grep,Glob,Bash"
+spawn_command: "claude -p --permission-mode dontAsk --setting-sources project --disable-slash-commands --no-session-persistence --strict-mcp-config --mcp-config .claude-reviewer/mcp-empty.json --tools=Read,Grep,Glob,Bash"
 block_for_event_strategy: tail
 tool_dialect: claude
 sandbox_profile: read-only


### PR DESCRIPTION
## Summary
- replace the inline empty MCP JSON with a schema-valid checked-in empty config file
- pass Claude reviewer tools with --tools=... so the prompt remains a prompt argument
- launch PR/pre-commit reviewer subprocesses from the repo root so the config path resolves consistently

## Verification
- bash scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-autopilot-head-race.sh
- git diff --check
- scripts/lint-host-agnostic.sh --staged (0 errors, 1 existing warning)
- scripts/pre-commit-review.sh --review-host codex-reviewer (approved)