### PR TITLE
Show Claude reviewer startup stdout failures

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-04-30T11:23:07Z",
+  "generated_at": "2026-04-30T11:29:11Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-30T11:23:07Z",
+  "generated_at": "2026-04-30T11:29:09Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -95,6 +95,22 @@ yaml_field() {
     | tr -d '"'"'"
 }
 
+print_reviewer_failure() {
+  local stdout_file="$1" stderr_file="$2"
+  printf 'pr-headless-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
+  if [ -s "$stderr_file" ]; then
+    printf 'pr-headless-review: reviewer stderr (first 80 lines):\n' >&2
+    sed -n '1,80p' "$stderr_file" >&2 || true
+  fi
+  if [ -s "$stdout_file" ]; then
+    printf 'pr-headless-review: reviewer stdout (first 80 lines):\n' >&2
+    sed -n '1,80p' "$stdout_file" >&2 || true
+  fi
+  if [ ! -s "$stderr_file" ] && [ ! -s "$stdout_file" ]; then
+    printf 'pr-headless-review: reviewer produced no stdout/stderr before exit\n' >&2
+  fi
+}
+
 eligible_hosts() {
   local registry="$REPO_ROOT/hosts/registry.yaml" host manifest reviewer_profile
   [ -f "$registry" ] || return 1
@@ -201,8 +217,7 @@ if ! ( cd "$REPO_ROOT" && env -i \
     PR_URL="$pr_url" \
     PR_HEAD_SHA="$head_sha" \
     "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err" ); then
-  printf 'pr-headless-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
-  sed -n '1,80p' "$summary.err" >&2 || true
+  print_reviewer_failure "$summary" "$summary.err"
   exit 1
 fi
 

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -44,6 +44,22 @@ yaml_field() {
     | tr -d '"'"'"
 }
 
+print_reviewer_failure() {
+  local stdout_file="$1" stderr_file="$2"
+  printf 'pre-commit-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
+  if [ -s "$stderr_file" ]; then
+    printf 'pre-commit-review: reviewer stderr (first 80 lines):\n' >&2
+    sed -n '1,80p' "$stderr_file" >&2 || true
+  fi
+  if [ -s "$stdout_file" ]; then
+    printf 'pre-commit-review: reviewer stdout (first 80 lines):\n' >&2
+    sed -n '1,80p' "$stdout_file" >&2 || true
+  fi
+  if [ ! -s "$stderr_file" ] && [ ! -s "$stdout_file" ]; then
+    printf 'pre-commit-review: reviewer produced no stdout/stderr before exit\n' >&2
+  fi
+}
+
 emit_gate_event() {
   command -v emit_event_keyed >/dev/null 2>&1 || return 0
   local event="$1" verdict="$2" host="$3" patch_id="$4" bypass_source="${5:-}"
@@ -184,8 +200,7 @@ if ! ( cd "$REPO_ROOT" && env -i \
     REVIEW_PAYLOAD="$payload" \
     STAGED_PATCH_ID="$patch_id" \
     "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err" ); then
-  printf 'pre-commit-review: reviewer host failed: %s\n' "$REVIEW_HOST" >&2
-  sed -n '1,80p' "$summary.err" >&2 || true
+  print_reviewer_failure "$summary" "$summary.err"
   exit 1
 fi
 

--- a/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
+++ b/scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
@@ -16,6 +16,9 @@ cat > "$BIN/claude" <<'SH'
 case " $* " in
   *" --help "*) printf 'claude fixture help\n'; exit 0 ;;
 esac
+case " $* " in
+  *"stdout-fail"*) printf 'fixture startup stdout\n'; exit 17 ;;
+esac
 
 case " $* " in
   *" -p "*|*" --print "*) ;;
@@ -73,6 +76,7 @@ case "$1 $2" in
   "pr view")
     case " $* " in
       *" --jq .number "*|*" --jq "*) printf '123\n' ;;
+      *" stdout-fail "*) printf '{"number":124,"title":"Fixture PR","url":"https://github.com/owner/repo/pull/stdout-fail","baseRefName":"main","headRefName":"feature","headRefOid":"abc124","author":{"login":"author"},"commits":[{"oid":"abc124"}]}\n' ;;
       *) printf '{"number":123,"title":"Fixture PR","url":"https://github.com/owner/repo/pull/123","baseRefName":"main","headRefName":"feature","headRefOid":"abc123","author":{"login":"author"},"commits":[{"oid":"abc123"}]}\n' ;;
     esac
     ;;
@@ -177,6 +181,15 @@ assert "headless claude review exits zero" "[ '$rc' -eq 0 ]"
 assert "review host reported" "grep -q 'PR_REVIEW_HOST=claude-reviewer' '$out'"
 assert "verdict parsed" "grep -q 'PR_REVIEW_VERDICT=approved' '$out'"
 assert "autopilot receives review host" "grep -q -- '--review-host claude-reviewer' '$AUTOPILOT_LOG'"
+
+fail_out="$TMPROOT/fail-out.txt"
+if bash "$ROOT/scripts/pr-headless-review.sh" stdout-fail --review-host claude-reviewer --method auto >"$fail_out" 2>"$fail_out.err"; then
+  printf 'not ok - claude reviewer stdout failure unexpectedly succeeded\n' >&2
+  failures=$((failures + 1))
+else
+  assert "startup stdout failure labels stdout" "grep -q 'reviewer stdout' '$fail_out.err'"
+  assert "startup stdout failure includes detail" "grep -q 'fixture startup stdout' '$fail_out.err'"
+fi
 
 if [ "$failures" -ne 0 ]; then
   printf 'FAIL: %s assertion(s)\n' "$failures" >&2


### PR DESCRIPTION
## Summary
- print both stderr and stdout snippets when reviewer spawn exits non-zero
- add fixture coverage for Claude startup failures emitted on stdout

## Verification
- bash scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
- bash scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
- bash -n scripts/pr-headless-review.sh scripts/pre-commit-review.sh scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
- git diff --check
- scripts/lint-host-agnostic.sh --staged (0 errors, 1 existing warning)
- scripts/pre-commit-review.sh --review-host codex-reviewer (approved)

## Observed Claude reviewer failure
With this patch, the real immediate failure is visible as: `Not logged in · Please run /login`.