### PR TITLE
Clarify IMGLY expert skill is machine-local

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-04-30T15:12:52Z",
+  "generated_at": "2026-04-30T15:17:04Z",
   "agents": [
     {
       "name": "studio",

--- a/apollo/_shared/integrations/imgly-and-metal.md
+++ b/apollo/_shared/integrations/imgly-and-metal.md
@@ -13,7 +13,7 @@ The boundary is load-bearing: Apollo retains measurement and verification author
 
 ## Receiving skill
 
-`imgly-engine-expert` ships through studio global skill sync into each host's global skill directory, with project-local `.claude/skills/imgly-engine-expert/` accepted as a legacy fallback. It owns the CE.SDK API surface, block-management patterns, scope system, and the project's Imgly playbook. Apollo never reads its internals — only its name (for the `delegate:` line on a recommendation) and its handoff envelope (defined below).
+`imgly-engine-expert` is a machine-local or project-local skill resolved from the current host's skill directories; it is not shipped as a studio-owned repo skill. It owns the CE.SDK API surface, block-management patterns, scope system, and the project's Imgly playbook. Apollo never reads its internals — only its name (for the `delegate:` line on a recommendation) and its handoff envelope (defined below).
 
 If the current host cannot resolve the skill from global or project-local skill directories, Apollo cannot delegate; the recommendation refuses with the standard refusal block (`apollo/_shared/primitives/evidence-gate.md` § Refusal protocol) and names "no Imgly delegation surface available" as the unblock.
 

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-30T15:12:50Z",
+  "generated_at": "2026-04-30T15:17:03Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- update Apollo IMGLY/Metal delegation contract to say imgly-engine-expert is machine-local or project-local
- clarify it is not shipped as a studio-owned repo skill

## Verification
- pre-commit hooks on commit
- git diff --check