### PR TITLE
Add workflow improvement chain manifest

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-04-30T23:51:14Z",
+  "generated_at": "2026-04-30T23:58:52Z",
   "agents": [
     {
       "name": "studio",

--- a/chains/workflow-measurement-improvements.yaml
+++ b/chains/workflow-measurement-improvements.yaml
@@ -1,0 +1,64 @@
+# Model-suggested workflow improvement chains from the 2026-05-01 studio session.
+#
+# Run a dry-run first:
+#   scripts/studio-chain-runner.sh chains/workflow-measurement-improvements.yaml --dry-run
+#
+# Execute with the default recommended host:
+#   scripts/studio-chain-runner.sh chains/workflow-measurement-improvements.yaml --host codex
+#
+# Notes:
+# - The closed umbrella issue #197 is intentionally not included.
+# - Chains are sequenced so foundational telemetry/measurement work lands before
+#   parallelization and efficiency tuning work.
+# - Issue IDs are unique across chains because the runner closes issues after a
+#   chain PR succeeds.
+
+schema_version: 1
+chains:
+  - name: field-telemetry-mvp
+    base: main
+    branch: feature/field-telemetry-mvp
+    host: auto
+    issues: [388, 25, 367]
+
+  - name: workflow-economics-and-baselines
+    base: main
+    branch: feature/workflow-economics-and-baselines
+    host: auto
+    issues: [357]
+
+  - name: brief-shape-and-task-sizing
+    base: main
+    branch: feature/brief-shape-and-task-sizing
+    host: auto
+    issues: [323, 256]
+
+  - name: build-test-intelligence
+    base: main
+    branch: feature/build-test-intelligence
+    host: auto
+    issues: [308]
+
+  - name: review-and-model-efficiency
+    base: main
+    branch: feature/review-and-model-efficiency
+    host: auto
+    issues: [257]
+
+  - name: parallel-workflow-streams
+    base: main
+    branch: feature/parallel-workflow-streams
+    host: auto
+    issues: [94, 24, 255, 134, 218]
+
+  - name: achilles-capability-followups
+    base: main
+    branch: feature/achilles-capability-followups
+    host: auto
+    issues: [203, 213]
+
+  - name: automation-mode-preference
+    base: main
+    branch: feature/automation-mode-preference
+    host: auto
+    issues: [378]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-30T23:51:12Z",
+  "generated_at": "2026-04-30T23:58:50Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
Adds a reusable chain manifest for the model-suggested workflow measurement and improvement work discussed in the studio session.\n\nPath: `chains/workflow-measurement-improvements.yaml`\n\nVerification:\n- `yq -e '.schema_version == 1 and (.chains | length == 8)' chains/workflow-measurement-improvements.yaml`\n- `scripts/studio-chain-runner.sh chains/workflow-measurement-improvements.yaml --only field-telemetry-mvp --dry-run --host codex`