### PR TITLE
Sync chain alias routing text

### DIFF
--- a/.claude/skills/studio/routing.yaml
+++ b/.claude/skills/studio/routing.yaml
@@ -32,7 +32,7 @@ invocation:
     - "update the workers"
     - "are the workers in sync"
     - "/studio work <track>"
-    - "/studio work chain <manifest>"
+    - "/studio work chain <manifest-or-name>"
     - "STUDIO_TRACK=<track>"
     - "/studio tf-push"
     - "/studio tf-push --dry-run"


### PR DESCRIPTION
Follow-up to PR #392: syncs the studio routing trigger text from <manifest> to <manifest-or-name>.\n\nVerification:\n- staged skill/mode lint\n- git diff --cached --check\n- short-name chain dry-run