### PR TITLE
Improve brief shape and summary slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ STUDIO_TRACK=<track>             # session-start shortcut for /studio work <trac
 /argus                           # review current worktree (auto-invoked by Achilles pre-merge)
 /argus T001                      # review a specific task's worktree standalone
 /chanakya                        # describe features → get a master plan
-/chanakya brief T001             # generate a self-contained worker brief
+/chanakya brief T001             # generate a reviewer-ready XS/S/M worker brief
 /chanakya brief-review T001      # checklist pass over an authored brief (warn-tier, pre-dispatch)
 /chanakya ship T001,T002         # brief + dispatch to Achilles in one step
 /chanakya brief-all              # brief every pending task in priority order
@@ -353,7 +353,7 @@ For unattended Achilles workers, combine the writable root with `--ask-for-appro
 ## How It Works (30-second version)
 
 1. **Chanakya** turns your feature description into prioritized tasks with IDs (`T001`, `T002`, …).
-2. **Chanakya** writes a self-contained brief per task (Figma specs, codebase pointers, acceptance criteria).
+2. **Chanakya** writes a compact, self-contained brief per executable task (Figma specs, codebase pointers, measurable acceptance criteria, verification evidence). Broad L-sized work stays as a parent planning task unless explicitly waived.
 3. **Achilles** reads the brief, implements in an isolated worktree, self-reviews, gates on green build, merges back, and drops a debrief.
 4. **Chanakya** sweeps the inbox, marks tasks done, briefs follow-ups, tracks build/test debt.
 5. When tasks accumulate: `/chanakya test-manifest` or `/chanakya test-flow` → tick boxes → `/chanakya review-feedback` → verified.

--- a/_shared/contracts/brief-formats/impl-brief.md
+++ b/_shared/contracts/brief-formats/impl-brief.md
@@ -1,6 +1,8 @@
 # Shared: Implementation Brief Format
 
-Write to `~/.dev-studio/<project>/plans/chanakya-tasks/<task-id>-<slug>.md`:
+Write the `body:` for `~/.dev-studio/<project>/plans/briefs/<brief-id>.yaml`.
+
+Implementation briefs are executable worker instructions. Default to XS/S/M slices. Use L only for parent planning containers, or add an explicit L-size waiver when the whole implementation truly must dispatch as one Achilles task.
 
 ```markdown
 # Task Brief: <task-id> — <Title>
@@ -12,7 +14,7 @@ Write to `~/.dev-studio/<project>/plans/chanakya-tasks/<task-id>-<slug>.md`:
 
 ## Objective
 
-<Clear description of what to build/fix and why>
+<One concise description of the behavior/output to build/fix and why. Prefer "after this, X happens when Y" over broad intent.>
 
 ## Priority & Complexity
 
@@ -29,6 +31,11 @@ Write to `~/.dev-studio/<project>/plans/chanakya-tasks/<task-id>-<slug>.md`:
   <!-- thinking-budget tier; orthogonal to Size. A crash-fix can be S-size and warrant `high`
        because diagnosis is the cost driver, not diff size. -->
   Rationale: <one line — what about THIS task drove the effort tier>
+
+<!-- Required only when Size is L and dispatch_agent is Achilles. Omit for XS/S/M. -->
+## Split Rationale
+
+<Why this could not be split into XS/S/M executable briefs, or why this L item is a parent planning/design container rather than a direct Achilles implementation brief.>
 
 ## Churn Layer
 
@@ -127,13 +134,18 @@ Before starting, load these skills for guidance:
 
 ## Acceptance Criteria
 
-1. <Specific, testable criterion>
-2. <Another criterion>
+1. <Specific, binary criterion tied to changed behavior/output>
+2. <Another criterion that is unit-testable, UI-testable, quantifiable, or manually verifiable>
 3. Accessibility identifiers defined for all interactive elements
 4. Dependencies injected via protocols where specified in Test Seams
 5. All user-visible strings use `"keyName".localized` — no hardcoded literals, new keys in all three `.lproj` files
 
-## Out of Scope
+## Verification / Evidence
+
+- <Exact unit/UI/manual verification Achilles should run or produce>
+- <Expected evidence in the debrief: command output, screenshot, test name, or manual observation>
+
+## Non-goals / Out of Scope
 
 - <Explicit boundaries>
 - Writing tests (handled by sub-tasks <task-id-a>, <task-id-b>, <task-id-c>)

--- a/_shared/rules/brief-model-effort.md
+++ b/_shared/rules/brief-model-effort.md
@@ -22,6 +22,10 @@ The first two govern **thinking cost**. The third governs **diff cost**. They ar
 - A small (`S`) crash fix can warrant `Opus / high` because diagnosis is the cost driver, not the diff.
 - A large (`L`) mechanical refactor (rename across N files) can warrant `Sonnet / low` because the work is well-specified and pattern-matchable.
 
+## Size defaults
+
+Executable Achilles implementation briefs default to `XS`, `S`, or `M`. Use `L` for parent planning containers, design epics, release buckets, or explicitly waived implementation briefs only. A direct Achilles `L` implementation brief must explain why splitting would be less safe or less reviewable.
+
 ## Model defaults by task shape
 
 Pick one when you author the brief, or run `scripts/recommend-model.sh` for the structured `recommended_models` payload. Override with rationale.

--- a/_shared/schemas/brief.md
+++ b/_shared/schemas/brief.md
@@ -8,7 +8,7 @@ type: reference
 
 Per-brief artifact written to `~/.dev-studio/<project>/plans/briefs/<brief-id>.yaml`. Replaces the markdown briefs that previously lived at `plans/chanakya-tasks/<task-id>-<type>.md`. One file per brief; a task may have many briefs across rework cycles (each with a distinct `id`, same `task_id`).
 
-Version 3.8.0 makes the executable brief quality contract lintable. New direct-to-Achilles implementation briefs must be XS/S/M by default, carry explicit objective / non-goals / measurable acceptance / verification evidence, and include structured model recommendations. L-sized Achilles implementation briefs require an explicit waiver or split rationale. Legacy briefs below 3.8.0 are not retroactively blocked.
+Version 3.8.0 makes the executable brief quality contract lintable. New direct-to-Achilles implementation briefs must be XS/S/M by default, carry explicit objective / non-goals / measurable acceptance / verification evidence, and include structured model recommendations. L-sized Achilles implementation briefs require an explicit waiver or split rationale. Legacy briefs below 3.8.0 are not retroactively blocked. `write_brief_artifact` callers opt into this gate with `schema_version=3.8.0`; legacy migration/backfill paths stay below 3.8.0 unless they can satisfy the full contract.
 
 Version 3.6.0 adds `recommended_models`, a task-level best-result and fast-turnaround recommendation pair resolved from `_shared/rules/model-recommendation.md` and `_shared/schemas/model-catalog.yaml`. Additive over 3.5.0; readers on 3.0.0+ ignore unknown fields.
 

--- a/_shared/schemas/brief.md
+++ b/_shared/schemas/brief.md
@@ -4,9 +4,11 @@ description: YAML shape for Chanakya-authored Achilles briefs under plans/briefs
 type: reference
 ---
 
-# Brief Schema (`brief@3.7.0`)
+# Brief Schema (`brief@3.8.0`)
 
 Per-brief artifact written to `~/.dev-studio/<project>/plans/briefs/<brief-id>.yaml`. Replaces the markdown briefs that previously lived at `plans/chanakya-tasks/<task-id>-<type>.md`. One file per brief; a task may have many briefs across rework cycles (each with a distinct `id`, same `task_id`).
+
+Version 3.8.0 makes the executable brief quality contract lintable. New direct-to-Achilles implementation briefs must be XS/S/M by default, carry explicit objective / non-goals / measurable acceptance / verification evidence, and include structured model recommendations. L-sized Achilles implementation briefs require an explicit waiver or split rationale. Legacy briefs below 3.8.0 are not retroactively blocked.
 
 Version 3.6.0 adds `recommended_models`, a task-level best-result and fast-turnaround recommendation pair resolved from `_shared/rules/model-recommendation.md` and `_shared/schemas/model-catalog.yaml`. Additive over 3.5.0; readers on 3.0.0+ ignore unknown fields.
 
@@ -24,9 +26,9 @@ Version 3.1.0 bumped from the 3.x object-envelope form introduced in Phase 2.5 â
 
 ```yaml
 schema_version:
-  # brief@3.7.0
+  # brief@3.8.0
   name: brief
-  version: 3.7.0
+  version: 3.8.0
   min_reader: 3.0.0
   deprecated_at: null
 id: 0190f52a-6e11-7c01-8a77-11a05a9e2b4c        # UUIDv7
@@ -85,6 +87,22 @@ body: |
   # figma cross-refs, risk notes. Fields above are the machine-readable
   # contract; `body` is the writer's narrative for Achilles.
 ```
+
+## Executable Brief Quality Contract (3.8.0)
+
+New executable briefs are worker instructions, not planning epics. They should be compact enough for worker context and concrete enough for Argus to review without reconstructing intent.
+
+Required for `brief@3.8.0+` before a brief transitions to `ready`:
+
+1. `size` defaults to `xs`, `s`, or `m` for direct Achilles implementation work.
+2. `size: l` is allowed for parent epics, design/planning containers, or an explicitly waived Achilles implementation brief. A waived L implementation brief must include a non-empty `## L-size reason`, `## Size waiver`, `## Split rationale`, or `## Why not split` section in `body`.
+3. `body` includes a non-empty `## Objective` section: one concise changed behavior/output statement.
+4. `body` includes explicit `## Out of Scope`, `## Non-goals`, or `## Non-goals / Out of Scope`.
+5. `acceptance` is non-empty and written as binary, measurable, UI-testable, unit-testable, or manually verifiable criteria.
+6. `body` includes `## Verification`, `## Evidence`, `## Verification / Evidence`, or `## Expected Evidence` with the expected proof Achilles should produce.
+7. `recommended_models` is populated with `best_result`, `fast_turnaround`, and a task-specific rationale.
+
+Long background, raw research, and design discussion belong in linked context docs or the compact `summary`, not in the executable worker brief. The brief can reference files and patterns, but it does not need to prescribe exact coordinates unless they affect the expected behavior.
 
 ## Fields
 
@@ -161,6 +179,7 @@ Unparseable briefs (malformed YAML preamble, missing task-id) land in `archive/2
 
 | Version | Landed | Changes |
 |---|---|---|
+| 3.8.0 | 2026-05-01 | Added lintable executable brief quality contract (#323): XS/S/M default for Achilles implementation briefs, explicit L-size waiver, objective, non-goals, measurable acceptance, verification evidence, and structured model recommendations. |
 | 3.7.0 | 2026-04-30 | Added optional `base_branch` for explicit dispatch bases (#374). Additive; `min_reader: 3.0.0`. |
 | 3.6.0 | 2026-04-30 | Added optional `recommended_models` pair for task-level model selection (#65). Additive; `min_reader: 3.0.0`. |
 | 3.5.0 | 2026-04-28 | Promoted `legacy_task_id` to documented field (#296). Auto-resolved by `write_brief_artifact`; `validate-brief.sh` enforces presence. Fixes Achilles dispatch failure on hand-authored briefs. Additive; `min_reader: 3.0.0`. |

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T01:08:14Z",
+  "generated_at": "2026-05-01T01:11:58Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T01:07:43Z",
+  "generated_at": "2026-05-01T01:08:14Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T00:54:19Z",
+  "generated_at": "2026-05-01T01:07:43Z",
   "agents": [
     {
       "name": "studio",
@@ -406,7 +406,7 @@
           "name": "brief-review",
           "path": "chanakya/modes/brief-review.md",
           "type": "mode-pack",
-          "description": "Checklist-driven quality pass over an authored brief before dispatch. Warn-tier, not block — ships even with findings. Catches brief defects that cascade into rework. Runs standalone via `/chanakya brief-review <task-id>`; not auto-invoked.",
+          "description": "Checklist-driven quality pass over an authored brief before dispatch. Warn-tier, not block. Catches brief defects before worker rework.",
           "reads": ["plans/briefs/*.yaml                            # canonical brief", "plans/tasks/<task-id>.yaml                     # parent task for context (type, size, links)"],
           "writes": ["events/<date>.jsonl                            # brief_review_flagged event per run with findings"],
           "snapshots": [],

--- a/chanakya/README.md
+++ b/chanakya/README.md
@@ -255,9 +255,10 @@ Chanakya: "Got it. One task:
 You:     Yes
 
 Chanakya: [fetches Figma context, scans related files, inlines design specs]
-          "Brief ready at chanakya-tasks/T001-onboarding-flow.md.
+          "Brief ready at plans/briefs/<brief-id>.yaml.
            It includes: screen states from Figma, design tokens, files to
-           modify, patterns to follow, acceptance criteria.
+           modify, patterns to follow, measurable acceptance criteria,
+           non-goals, verification evidence, and model recommendations.
            
            Ready to launch a worker?"
 ```

--- a/chanakya/docs.html
+++ b/chanakya/docs.html
@@ -596,11 +596,11 @@ cd generic-dev-studio
     </div>
     <div class="cmd-card">
       <code>/chanakya brief T001</code>
-      <span>Generate a self-contained brief (implementation or test brief) with Figma context</span>
+      <span>Generate a compact, reviewer-ready worker brief. Executable implementation briefs default to XS/S/M slices with measurable acceptance criteria, explicit non-goals, verification evidence, and model recommendations. L-sized work stays as a parent planning task unless explicitly waived.</span>
     </div>
     <div class="cmd-card">
       <code>/chanakya brief-review T001</code>
-      <span>Checklist pass (C1&ndash;C10) over an authored brief &mdash; catches acceptance-criteria drift, prescriptive tech, deliverable-path collisions, task-ID leakage, missing non-goals/concurrency stance. Warn-tier, not block.</span>
+      <span>Checklist pass over an authored brief &mdash; catches acceptance-criteria drift, prescriptive tech, deliverable-path collisions, task-ID leakage, missing non-goals/concurrency stance, oversized executable scope, and weak verification evidence. Warn-tier, not block.</span>
     </div>
     <div class="cmd-card">
       <code>/chanakya review</code>

--- a/chanakya/modes/brief-review.md
+++ b/chanakya/modes/brief-review.md
@@ -1,6 +1,6 @@
 ---
 name: Chanakya Brief-Review
-description: Checklist-driven quality pass over an authored brief before dispatch. Warn-tier, not block — ships even with findings. Catches brief defects that cascade into rework. Runs standalone via `/chanakya brief-review <task-id>`; not auto-invoked.
+description: Checklist-driven quality pass over an authored brief before dispatch. Warn-tier, not block. Catches brief defects before worker rework.
 type: mode-pack
 schema_version: 1
 transition_notes: _shared/patterns/dual-write-transition.md
@@ -15,7 +15,7 @@ writes:
 
 # Mode: Brief-Review (`/chanakya brief-review <task-id>`)
 
-Walk the checklist below against the brief for `<task-id>`. Emit one `brief_review_flagged` event at the end with the finding count. **Warn-tier, not block** — a brief with findings is still dispatchable. This mode exists because a single anti-pattern in a root brief propagates to every inherited impl brief; catching it pre-dispatch is an order of magnitude cheaper than backporting fixes across a mid-flight task track (see issue #104 for the cascade that motivated this).
+Walk the checklist below against the brief for `<task-id>`. Emit one `brief_review_flagged` event at the end with the finding count. **Warn-tier, not block** — a brief with findings is still dispatchable. The hard pre-ready gate lives in `scripts/validate-brief.sh`; this mode is the human-readable review pass that catches quality defects, weak scope, and bad model recommendations before they cascade into worker rework.
 
 ## Step 1 — Load
 
@@ -75,6 +75,12 @@ Two flag conditions:
    - Rationale missing or generic ("seems right" / "default") — the rule requires a one-line rationale specific to THIS task.
 
 Surface as a finding; don't auto-correct. The author owns the recommendation.
+
+### C12 — Executable task sizing and verification evidence
+
+For direct-to-Achilles implementation briefs, is the task sized as `XS`, `S`, or `M` by default? If `Size: L`, confirm it is either a parent planning/design container that will not dispatch directly, or the body carries a clear L-size waiver / split rationale. Flag vague waivers like "too big to split".
+
+Also confirm the brief has a verification/evidence section that can become test guidance: unit test names, UI journey, manual observation, expected command, screenshot, or debrief evidence. "Verify it works" is not evidence.
 
 ## Step 3 — Emit event + report
 

--- a/chanakya/modes/brief.md
+++ b/chanakya/modes/brief.md
@@ -20,7 +20,7 @@ writes:
 
 # Mode: Brief Generation (`/chanakya brief <task-id>`)
 
-This is the most critical mode. The brief must be **completely self-contained** — a worker reads ONLY this file.
+This is the most critical mode. The brief must be **completely self-contained** — a worker reads ONLY this file. It must also be compact enough to execute: author executable Achilles briefs as XS/S/M slices by default, with measurable acceptance and verification evidence that Argus can evaluate without guessing intent.
 
 Snapshots: `snapshots/briefs.json` (tolerates 5-minute freshness — regenerate via `scripts/chanakya-snap.sh briefs` if older; fallback is `scripts/query-plans.sh --kind=task,brief`). `snapshots/debt.json` is checked on entry to refuse under block state (fallback: `scripts/query-plans.sh --kind=debt`).
 
@@ -108,9 +108,21 @@ Skip when `affinity.touchpoints` is already non-empty, or the task has no "Files
 - Dependent task: note the base branch
 - Include exact git commands to create the worktree (Achilles handles the actual worktree add; the brief only names conventions)
 
+## Step 5B — Shape executable scope
+
+Before writing an implementation brief, decide whether the task is executable or a parent planning container:
+
+- **Executable worker task:** direct Achilles or Apollo work. Default `size` to `xs`, `s`, or `m`. If the loaded task is `size: l`, split it into smaller child tasks before dispatch unless the user has explicitly waived splitting.
+- **Parent planning task:** design container, epic, release bucket, or broad workstream. It can remain `size: l`, but do not dispatch it directly to Achilles; author child executable briefs instead.
+- **Waived L implementation:** allowed only with an explicit `## L-size reason`, `## Size waiver`, `## Split rationale`, or `## Why not split` section in the body. The reason must explain why one worker context is safer than splitting.
+
+Every executable brief must include: concise objective, explicit non-goals / out-of-scope, measurable acceptance criteria, verification/evidence guidance, structured model recommendations, and dependencies/handoff notes only when they affect execution. Long background belongs in linked design/context docs or in the ≤500-token `summary`, not in the worker body.
+
 ## Step 6 — Write the brief (type-aware)
 
-Render the type-specific narrative from the template corresponding to the task type (see §6A-D below) into a tempfile, then call `write_brief_artifact` — it writes the YAML canonical form (schema `_shared/schemas/brief.md`, `brief@3.3.0`), emits `brief_state_changed null → draft`, and regenerates `plans/index.yaml`.
+Render the type-specific narrative from the template corresponding to the task type (see §6A-D below) into a tempfile, then call `write_brief_artifact` — it writes the YAML canonical form (schema `_shared/schemas/brief.md`, `brief@3.8.0`), emits `brief_state_changed null → draft`, and regenerates `plans/index.yaml`.
+
+`brief@3.8.0` turns the quality bar into a pre-ready lint gate via `scripts/validate-brief.sh`. See `_shared/schemas/brief.md` §Executable Brief Quality Contract for the exact checked fields.
 
 ### Summary (`brief@3.2.0`, required for new briefs)
 
@@ -167,6 +179,7 @@ write_brief_artifact "$BRIEF_UUID" "<parent-task-uuid>" "<type>" "<size>" \
   legacy_task_id=<T-number> \
   slug=<short-kebab-slug> \
   summary="<one-sentence change>. <one-sentence why>. <one-sentence key constraint>." \
+  recommended_models='{"best_result":{"tier":"sonnet","model_id":"claude-sonnet-default","reasoning_effort":"medium"},"fast_turnaround":{"tier":"haiku","model_id":"claude-haiku-default","reasoning_effort":"low"},"rationale":"Small implementation against established patterns."}' \
   body_file="$BODY_FILE"
 
 # Self-review before flipping to ready: lints the summary slice and (if any

--- a/chanakya/modes/brief.md
+++ b/chanakya/modes/brief.md
@@ -120,7 +120,7 @@ Every executable brief must include: concise objective, explicit non-goals / out
 
 ## Step 6 — Write the brief (type-aware)
 
-Render the type-specific narrative from the template corresponding to the task type (see §6A-D below) into a tempfile, then call `write_brief_artifact` — it writes the YAML canonical form (schema `_shared/schemas/brief.md`, `brief@3.8.0`), emits `brief_state_changed null → draft`, and regenerates `plans/index.yaml`.
+Render the type-specific narrative from the template corresponding to the task type (see §6A-D below) into a tempfile, then call `write_brief_artifact` with `schema_version=3.8.0` — it writes the YAML canonical form (schema `_shared/schemas/brief.md`, `brief@3.8.0`), emits `brief_state_changed null → draft`, and regenerates `plans/index.yaml`.
 
 `brief@3.8.0` turns the quality bar into a pre-ready lint gate via `scripts/validate-brief.sh`. See `_shared/schemas/brief.md` §Executable Brief Quality Contract for the exact checked fields.
 
@@ -176,6 +176,7 @@ BRIEF_UUID=$(mint_uuidv7)
 # pass `state=ready` to skip draft entirely when the brief is final at mint.
 write_brief_artifact "$BRIEF_UUID" "<parent-task-uuid>" "<type>" "<size>" \
   awaiting_user=false \
+  schema_version=3.8.0 \
   legacy_task_id=<T-number> \
   slug=<short-kebab-slug> \
   summary="<one-sentence change>. <one-sentence why>. <one-sentence key constraint>." \

--- a/chanakya/modes/dispatch-ready.md
+++ b/chanakya/modes/dispatch-ready.md
@@ -27,7 +27,7 @@ scripts/query-tasks.sh --dispatch-ready --format=json
 
 Render the result grouped by `train` (tasks without a train fall under `ad-hoc`). Within each train group, sort by `priority` ascending (`p0` first), then `updated_at` ascending so the longest-briefed task surfaces first.
 
-For each row, surface five columns: `<id>  <priority>  <effort_minutes|->  <recommended_model|->  <title>`, then a continuation line carrying the brief's `summary` slice (≤500 tokens, schema `_shared/schemas/brief.md` § summary). `query-tasks.sh --format=json` already includes `priority`, `effort_minutes`, and `recommended_model` — render directly, then resolve each task's live brief and pull `summary`:
+For each row, surface six columns: `<id>  <priority>  <effort_minutes|->  <recommended_model|->  <title>  <summary|->`. `query-tasks.sh --format=json` includes `priority`, `effort_minutes`, `recommended_model`, and `brief_summary` from the linked brief, so this mode uses the compact slice without loading the full brief body:
 
 ```bash
 scripts/query-tasks.sh --dispatch-ready --format=json \
@@ -35,10 +35,8 @@ scripts/query-tasks.sh --dispatch-ready --format=json \
            | "## " + (.[0].train // "ad-hoc"),
              (sort_by(.priority, .updated_at)[]
               | [.id, .priority, (.effort_minutes // "-" | tostring),
-                 (.recommended_model // "-"), .title] | @tsv)'
+                 (.recommended_model // "-"), .title, (.brief_summary // "-")] | @tsv)'
 ```
-
-For each rendered row, look up the latest dispatchable brief (`scripts/query-plans.sh --kind=brief --task=<task-id> --state=ready,dispatched`) and append `  └─ <summary first sentence>` underneath. When `summary` is null (legacy brief, pre-3.2.0), render `  └─ (no summary; pre-3.2.0 brief)` so the gap is visible without forcing a full-brief read.
 
 ## Empty result
 

--- a/chanakya/modes/intake.md
+++ b/chanakya/modes/intake.md
@@ -73,10 +73,13 @@ The heuristic is deliberately simple (Jaccard over title tokens + touchpoint glo
 ## Step 3 — Tier tasks
 
 Classify each task:
-- **Plan-worthy** (features, refactors, multi-module work) → gets a brief
+- **Plan-worthy executable** (features, refactors, multi-module work that can be completed by one worker) → gets an Achilles/Apollo brief
+- **Parent planning container** (epic, broad rewrite, design/planning arc, release bucket) → stays as a parent task; split into child executable tasks before dispatch
 - **Direct** (bug fixes, small tweaks, single-file changes) → logged as `direct` type, no brief needed
 
 Tell the user: "T001 and T002 need briefs (multi-file features). T003 is a simple bug fix — send it directly to Achilles when ready."
+
+Default executable task size is `xs`, `s`, or `m`. Avoid `l` for direct Achilles implementation tasks; if a candidate remains `l`, either split it now or mark it as a parent planning container and create child tasks. A direct L implementation brief requires an explicit waiver later in `/chanakya brief`.
 
 ## Step 4 — Expand into task groups
 
@@ -161,7 +164,7 @@ LEGACY_ID=$(scripts/next-task-id.sh)             # default block
 TASK_UUID=$(mint_uuidv7)
 write_task_artifact "$TASK_UUID" proposed "<title>" \
   legacy_task_id="$LEGACY_ID" \
-  size=<s|m|l> \
+  size=<xs|s|m|l> \
   type=<feature|bugfix|refactor|test-unit|test-integration|test-ui|direct>
 ```
 
@@ -170,6 +173,8 @@ The helper initializes `links.{brief,debrief,reviews,release,feedback}` to their
 For sub-tasks (T268a/b/c under T268), call `write_task_artifact` once per sub-task with `legacy_task_id=T268a` etc. The parent/child relationship lives in the human-readable title prefix and in the `plans/index.yaml` rollup (the index generator clusters on title prefix). `task@1.0.0` does not encode a `group` field — keeping the schema narrow is deliberate.
 
 **XS tasks.** `size=xs` is introduced separately for trivial direct tasks. Emit `type=direct` together with `size=xs` for those.
+
+**L tasks.** Use `size=l` for parent planning containers or explicitly waived implementation tasks only. If the work is executable, prefer multiple `xs`/`s`/`m` children with measurable acceptance criteria over one broad L worker brief.
 
 ## Step 7 — Propose parallelization
 

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T01:08:16Z",
+  "generated_at": "2026-05-01T01:11:57Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T01:08:09Z",
+  "generated_at": "2026-05-01T01:08:16Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T00:54:18Z",
+  "generated_at": "2026-05-01T01:08:09Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},
@@ -31,7 +31,7 @@
     {"name": "argus.code-quality", "source": "argus/modes/code-quality.md", "agent": "argus", "mode": "code-quality", "description": "Stage 2 of two-stage Argus review. Cross-file regressions, edge cases, diff anomalies, secrets, base-branch staleness, M/L test run, TDD red→green. Runs iff Stage 1 returned approved or flagged. Previously the sole Argus pass; split 2026-04-23."},
     {"name": "argus.spec-compliance", "source": "argus/modes/spec-compliance.md", "agent": "argus", "mode": "spec-compliance", "description": "Stage 1 of the two-stage Argus review. Narrow check — does the diff match the brief? Nothing extra, nothing missed. Runs before code-quality. Drawn from obra/superpowers/subagent-driven-development."},
     {"name": "chanakya.blocked-by", "source": "chanakya/modes/blocked-by.md", "agent": "chanakya", "mode": "blocked-by", "description": "Reverse predecessors lookup. Given a task id, list every task whose predecessors[] contains it — i.e. every task whose dispatch is blocked on this one shipping."},
-    {"name": "chanakya.brief-review", "source": "chanakya/modes/brief-review.md", "agent": "chanakya", "mode": "brief-review", "description": "Checklist-driven quality pass over an authored brief before dispatch. Warn-tier, not block — ships even with findings. Catches brief defects that cascade into rework. Runs standalone via `/chanakya brief-review <task-id>`; not auto-invoked."},
+    {"name": "chanakya.brief-review", "source": "chanakya/modes/brief-review.md", "agent": "chanakya", "mode": "brief-review", "description": "Checklist-driven quality pass over an authored brief before dispatch. Warn-tier, not block. Catches brief defects before worker rework."},
     {"name": "chanakya.brief", "source": "chanakya/modes/brief.md", "agent": "chanakya", "mode": "brief", "description": "Brief Generation + Brief-All composite. Writes self-contained Achilles briefs with Figma + codebase context. Runs a similarity probe before authoring (populates `similar_to`, offers duplicate-fold)."},
     {"name": "chanakya.compact", "source": "chanakya/modes/compact.md", "agent": "chanakya", "mode": "compact", "description": "Archive verified tasks, regenerate Dashboard + Module Index + Blocked list, trim changelog, optionally sweep artifacts. Includes implicit feedback-archive + index regeneration."},
     {"name": "chanakya.digest", "source": "chanakya/modes/digest.md", "agent": "chanakya", "mode": "digest", "description": "State-change rollup over a time window (day/week/month). Groups task_state_changed events by destination state, with per-train breakdowns. Default window is day."},

--- a/scripts/chanakya-snap.sh
+++ b/scripts/chanakya-snap.sh
@@ -87,15 +87,29 @@ produce_briefs() {
     return $?
   fi
 
+  local briefs_dir="$PROJECT_ROOT/plans/briefs"
   local entries
-  entries=$(yq -o=json '{
-    "id": (.legacy_task_id // .id),
-    "title": (.title // ""),
-    "raw_state": (.state // "unknown"),
-    "priority": (.legacy_priority // ""),
-    "complexity": (.legacy_complexity // ((.size // "") | upcase)),
-    "updated_at": (.updated_at // "")
-  }' "$tasks_dir"/*.yaml 2>/dev/null | jq -s '.')
+  entries=$(
+    for task_yaml in "$tasks_dir"/*.yaml; do
+      [ -f "$task_yaml" ] || continue
+      local brief_id summary_json task_json
+      brief_id=$(yq -r '.links.brief // ""' "$task_yaml" 2>/dev/null || echo "")
+      summary_json='null'
+      if [ -n "$brief_id" ] && [ -f "$briefs_dir/${brief_id}.yaml" ]; then
+        summary_json=$(yq -o=json '.summary // null' "$briefs_dir/${brief_id}.yaml" 2>/dev/null || echo 'null')
+        printf '%s' "$summary_json" | jq empty >/dev/null 2>&1 || summary_json='null'
+      fi
+      task_json=$(yq -o=json '{
+        "id": (.legacy_task_id // .id),
+        "title": (.title // ""),
+        "raw_state": (.state // "unknown"),
+        "priority": (.legacy_priority // ""),
+        "complexity": (.legacy_complexity // ((.size // "") | upcase)),
+        "updated_at": (.updated_at // "")
+      }' "$task_yaml" 2>/dev/null || echo '{}')
+      printf '%s' "$task_json" | jq --argjson summary "$summary_json" '. + {summary: $summary}'
+    done | jq -s '.'
+  )
 
   if [ -z "$entries" ] || ! printf '%s' "$entries" | jq empty 2>/dev/null; then
     emit_snap_event snapshot_failed '{"domain":"briefs","error":"yq_failed"}'
@@ -119,7 +133,7 @@ produce_briefs() {
     | map(select(.raw_state as $rs | ["merged","verified","archived","cancelled","superseded"] | index($rs) | not))
     | sort_by(.updated_at) | reverse
     | .[0:30]
-    | map({id, title: title50(.title), status, priority, complexity})
+    | map({id, title: title50(.title), status, priority, complexity, summary})
     | {tasks: ., shown: length, by_status: $by_status, total: $total_all}
   ')
 

--- a/scripts/lib-ledger.sh
+++ b/scripts/lib-ledger.sh
@@ -750,7 +750,7 @@ write_brief_artifact() {
 
   local payload
   payload=$({
-    printf 'schema_version: {name: brief, version: 3.5.0, min_reader: 3.0.0, deprecated_at: null}\n'
+    printf 'schema_version: {name: brief, version: 3.8.0, min_reader: 3.0.0, deprecated_at: null}\n'
     printf 'id: %s\n' "$uuid"
     printf 'task_id: %s\n' "$task_uuid"
     printf 'type: %s\n' "$type"

--- a/scripts/lib-ledger.sh
+++ b/scripts/lib-ledger.sh
@@ -707,15 +707,26 @@ write_brief_artifact() {
     return 2
   fi
 
-  # Strip mint-intent kvs from REST_ARGS so they don't leak into the YAML payload.
+  local _schema_version="3.7.0"
+
+  # Strip writer-control kvs from REST_ARGS so they don't leak into the YAML payload.
   local _new_rest=() _kvf
   for _kvf in "${_LW_REST_ARGS[@]+"${_LW_REST_ARGS[@]}"}"; do
     case "$_kvf" in
       state=*|awaiting_user=*) ;;
+      schema_version=*) _schema_version="${_kvf#schema_version=}" ;;
       *) _new_rest+=("$_kvf") ;;
     esac
   done
   _LW_REST_ARGS=("${_new_rest[@]+"${_new_rest[@]}"}")
+
+  case "$_schema_version" in
+    3.7.0|3.8.0) ;;
+    *)
+      printf 'write_brief_artifact: schema_version=%s invalid (supported: 3.7.0, 3.8.0)\n' "$_schema_version" >&2
+      return 2
+      ;;
+  esac
 
   local _final_state="draft"
   [ "$_explicit_state" = "ready" ] && _final_state="ready"
@@ -750,7 +761,7 @@ write_brief_artifact() {
 
   local payload
   payload=$({
-    printf 'schema_version: {name: brief, version: 3.8.0, min_reader: 3.0.0, deprecated_at: null}\n'
+    printf 'schema_version: {name: brief, version: %s, min_reader: 3.0.0, deprecated_at: null}\n' "$_schema_version"
     printf 'id: %s\n' "$uuid"
     printf 'task_id: %s\n' "$task_uuid"
     printf 'type: %s\n' "$type"

--- a/scripts/query-tasks.sh
+++ b/scripts/query-tasks.sh
@@ -12,7 +12,8 @@
 #
 # Filters compose with AND. Default output is TSV:
 #   <id>\t<state>\t<train|->\t<title>\t<updated_at>
-# --format=json emits a JSON array.
+# --format=json emits a JSON array including `brief_summary` when the task's
+# linked brief carries the compact summary slice.
 #
 # --dispatch-ready implies --state=briefed and additionally requires every
 # predecessor in {merged, verified, archived}.
@@ -70,6 +71,7 @@ if [ ! -d "$TASKS_DIR" ]; then
   printf 'error: tasks dir not found: %s\n' "$TASKS_DIR" >&2
   exit 2
 fi
+BRIEFS_DIR=$(resolve_briefs_dir_for "$PROJECT")
 
 # Project each task file into a small JSON record. Missing 1.1.0 fields
 # (train, predecessors) default so jq predicates do not choke on
@@ -77,16 +79,23 @@ fi
 ALL=$(
   for f in "$TASKS_DIR"/*.yaml; do
     [ -f "$f" ] || continue
+    brief_id=$(yq -r '.links.brief // ""' "$f" 2>/dev/null || echo "")
+    brief_summary='null'
+    if [ -n "$brief_id" ] && [ -f "$BRIEFS_DIR/${brief_id}.yaml" ]; then
+      brief_summary=$(yq -o=json '.summary // null' "$BRIEFS_DIR/${brief_id}.yaml" 2>/dev/null || echo 'null')
+      printf '%s' "$brief_summary" | jq empty >/dev/null 2>&1 || brief_summary='null'
+    fi
     yq -o=json '.' "$f" 2>/dev/null \
-      | jq '{
+      | jq --argjson brief_summary "$brief_summary" '. as $task | {
           id, title, state,
           train: (.train // null),
           predecessors: (.predecessors // []),
           priority: (.priority // "p2"),
           effort_minutes: (.effort_minutes // null),
           recommended_model: (.recommended_model // null),
+          brief_summary: $brief_summary,
           updated_at,
-          history_at: ((.history // []) | (last.at // .updated_at))
+          history_at: ((($task.history // []) | last.at) // $task.updated_at)
         }'
   done | jq -s '.'
 )

--- a/scripts/status-render-tasks.sh
+++ b/scripts/status-render-tasks.sh
@@ -3,11 +3,11 @@
 #
 # Accepts a briefs snapshot payload (or fallback-equivalent). Prints a markdown
 # table of active tasks with Priority / Status / Complexity / Branch columns.
-# `done` rows are prefixed with an asterisk so the caller can annotate
-# "awaiting verification" in prose.
+# Briefed / in-progress rows with a populated `summary` field get a continuation
+# line carrying the compact brief slice.
 #
 # Input shape (minimum fields on each task): id, title, priority, status,
-# complexity, branch. Extra fields are ignored.
+# complexity, branch. Optional: summary. Extra fields are ignored.
 
 set -u
 umask 022
@@ -28,5 +28,17 @@ printf '| ID   | Title                                    | Priority | Status   
 printf '|------|------------------------------------------|----------|-------------|------------|-----------------|\n'
 printf '%s' "$payload" | jq -r '
   .tasks[] |
-  "| \(.id // "—") | \(.title // "—" | .[0:40]) | \(.priority // "—") | \(.status // "—") | \(.complexity // "—") | \(.branch // "—") |"
+  def clean_summary:
+    (.summary // "")
+    | gsub("[\r\n\t]+"; " ")
+    | gsub("  +"; " ")
+    | sub("^ +"; "")
+    | sub(" +$"; "");
+  (
+    "| \(.id // "—") | \(.title // "—" | .[0:40]) | \(.priority // "—") | \(.status // "—") | \(.complexity // "—") | \(.branch // "—") |"
+  ),
+  (
+    select((.status == "briefed" or .status == "in-progress") and (clean_summary != ""))
+    | "  └─ \(clean_summary)"
+  )
 '

--- a/scripts/task-load-spec.sh
+++ b/scripts/task-load-spec.sh
@@ -16,6 +16,8 @@
 #                               omits an explicit Type: line)
 #   ACCEPTANCE_JSON='<json-array>'
 #   BASE_BRANCH=<branch>        (optional explicit dispatch base from brief)
+#   BRIEF_SUMMARY=<string>      (only when BRIEF_SLICE=summary)
+#   BRIEF_SUMMARY_TOKENS=<n>    (only when BRIEF_SLICE=summary)
 #
 # Usage:
 #   eval "$(scripts/task-load-spec.sh <task-id-or-empty>)"
@@ -28,6 +30,7 @@
 #      `/chanakya reopen <task-id>` for a formal state-machine reopen.
 #   6  brief exists but is not ready for dispatch. Override with
 #      ACHILLES_ALLOW_NON_READY_BRIEF=1 only for intentional recovery.
+#   7  BRIEF_SLICE=summary requested but no summary slice exists.
 
 set -u
 umask 022
@@ -53,6 +56,8 @@ if [ -z "$TASK_ID" ]; then
   emit_assign SIZE ""
   emit_assign TYPE ""
   emit_assign BASE_BRANCH ""
+  emit_assign BRIEF_SUMMARY ""
+  emit_assign BRIEF_SUMMARY_TOKENS ""
   printf "ACCEPTANCE_JSON='[]'\n"
   exit 0
 fi
@@ -65,6 +70,8 @@ SIZE=""
 TYPE=""
 ACCEPTANCE_JSON='[]'
 BASE_BRANCH=""
+BRIEF_SUMMARY=""
+BRIEF_SUMMARY_TOKENS=""
 NON_READY_STATE=""
 
 # _try_brief_candidate — test one brief YAML for dispatchable state, populate
@@ -221,12 +228,52 @@ fi
 [ -z "$SIZE" ] && SIZE=m
 [ -z "$TYPE" ] && TYPE=feature
 
+estimate_summary_tokens() {
+  local summary="$1" words
+  words=$(printf '%s' "$summary" | wc -w | tr -d ' ')
+  printf '%d' "$(( (words * 13) / 10 ))"
+}
+
+if [ "${BRIEF_SLICE:-}" = "summary" ]; then
+  if [ "${BRIEF_PATH##*.}" != "yaml" ]; then
+    cat >&2 <<EOF
+error: BRIEF_SLICE=summary requested for task '$TASK_ID', but resolved brief is a legacy artifact with no summary field.
+  Re-author or backfill the YAML brief summary before using the compact slice.
+EOF
+    exit 7
+  fi
+  if ! command -v yq >/dev/null 2>&1; then
+    printf 'error: BRIEF_SLICE=summary requires yq to read %s\n' "$BRIEF_PATH" >&2
+    exit 7
+  fi
+  BRIEF_SUMMARY=$(yq -r '.summary // ""' "$BRIEF_PATH" 2>/dev/null || echo "")
+  if [ -z "$BRIEF_SUMMARY" ]; then
+    cat >&2 <<EOF
+error: BRIEF_SLICE=summary requested for task '$TASK_ID', but brief '$BRIEF_UUID' has no summary.
+  Load the full brief in an interactive context, or backfill summary before using cheap-read mode.
+EOF
+    exit 7
+  fi
+  BRIEF_SUMMARY_TOKENS=$(estimate_summary_tokens "$BRIEF_SUMMARY")
+  summary_event_data=$(jq -nc \
+    --arg brief_uuid "$BRIEF_UUID" \
+    --arg reason "caller_request" \
+    --argjson summary_tokens_est "$BRIEF_SUMMARY_TOKENS" \
+    '{brief_uuid:$brief_uuid, summary_tokens_est:$summary_tokens_est, reason:$reason}' 2>/dev/null \
+    || printf '{"brief_uuid":"%s","summary_tokens_est":%s,"reason":"caller_request"}' "$BRIEF_UUID" "$BRIEF_SUMMARY_TOKENS")
+  emit_event_keyed achilles task brief_summary_used "$TASK_ID" "$summary_event_data" \
+    --idem-key "$(idem_key achilles brief_summary_used "$BRIEF_UUID" "task=$TASK_ID;tokens=$BRIEF_SUMMARY_TOKENS")" \
+    >/dev/null 2>&1 || true
+fi
+
 emit_assign TASK_MODE brief
 emit_assign BRIEF_PATH "$BRIEF_PATH"
 emit_assign BRIEF_UUID "$BRIEF_UUID"
 emit_assign SIZE "$SIZE"
 emit_assign TYPE "$TYPE"
 emit_assign BASE_BRANCH "$BASE_BRANCH"
+emit_assign BRIEF_SUMMARY "$BRIEF_SUMMARY"
+emit_assign BRIEF_SUMMARY_TOKENS "$BRIEF_SUMMARY_TOKENS"
 # Single-quote the JSON to survive eval without re-escaping internal quotes.
 # ACCEPTANCE_JSON is producer-controlled (yq output); no single quotes possible.
 printf "ACCEPTANCE_JSON='%s'\n" "$ACCEPTANCE_JSON"

--- a/scripts/test-fixtures/256-brief-summary/test-brief-summary.sh
+++ b/scripts/test-fixtures/256-brief-summary/test-brief-summary.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/brief-summary.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="$TMP/home"
+export ACHILLES_PROJECT="brief-summary-project"
+
+PROJECT_ROOT="$HOME/.dev-studio/$ACHILLES_PROJECT"
+TASK_ID="0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11"
+BRIEF_ID="0190f52a-6e11-7c01-8a77-11a05a9e2b4c"
+SUMMARY="Adopt OS_LOG categories for the photo-editor pipeline. Replaces ad-hoc print(). Don't change log formatting at call sites -- only routing."
+
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq required"; exit 0; }
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq required"; exit 0; }
+
+mkdir -p "$PROJECT_ROOT/plans/tasks" "$PROJECT_ROOT/plans/briefs" "$PROJECT_ROOT/events"
+
+cat > "$PROJECT_ROOT/plans/tasks/$TASK_ID.yaml" <<YAML
+schema_version: {name: task, version: 1.1.0, min_reader: 1.0.0, deprecated_at: null}
+id: $TASK_ID
+legacy_task_id: "T256"
+title: Brief summary cheap-read slice
+state: briefed
+type: feature
+size: s
+priority: p1
+effort_minutes: 30
+recommended_model: sonnet
+train: brief-shape
+predecessors: []
+links: {brief: $BRIEF_ID}
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-01T00:00:00Z
+YAML
+
+cat > "$PROJECT_ROOT/plans/briefs/$BRIEF_ID.yaml" <<YAML
+schema_version: {name: brief, version: 3.8.0, min_reader: 3.0.0, deprecated_at: null}
+id: $BRIEF_ID
+task_id: $TASK_ID
+legacy_task_id: "T256"
+type: impl
+size: s
+state: ready
+created_at: 2026-05-01T00:00:00Z
+updated_at: 2026-05-01T00:00:00Z
+figma: null
+reads: []
+writes: []
+acceptance: ["Routes existing print calls through OS_LOG categories."]
+testability: []
+rework_of: null
+summary: "$SUMMARY"
+body: |
+  ## Objective
+  Route photo-editor logging through OS_LOG categories.
+YAML
+
+"$ROOT/scripts/lint-brief.sh" "$PROJECT_ROOT/plans/briefs/$BRIEF_ID.yaml" >/dev/null
+
+long_brief="$TMP/long.yaml"
+{
+  sed '/^summary:/,$d' "$PROJECT_ROOT/plans/briefs/$BRIEF_ID.yaml"
+  printf 'summary: "'
+  awk 'BEGIN { for (i=0; i<390; i++) printf "word " }'
+  printf '"\nbody: |\n  ## Objective\n  Too long.\n'
+} > "$long_brief"
+if "$ROOT/scripts/lint-brief.sh" "$long_brief" >"$TMP/long.out" 2>&1; then
+  echo "FAIL: long summary lint passed unexpectedly" >&2
+  exit 1
+fi
+grep -q 'E_SUMMARY_TOO_LONG' "$TMP/long.out"
+
+"$ROOT/scripts/chanakya-snap.sh" briefs >/dev/null
+"$ROOT/scripts/status-render-tasks.sh" < "$PROJECT_ROOT/.runtime/state/chanakya-snapshots/briefs.json" > "$TMP/status.md"
+grep -q 'Brief summary cheap-read slice' "$TMP/status.md"
+grep -q 'Adopt OS_LOG categories for the photo-editor pipeline' "$TMP/status.md"
+
+"$ROOT/scripts/query-tasks.sh" --dispatch-ready --format=json > "$TMP/dispatch.json"
+jq -e --arg summary "$SUMMARY" '.[0].brief_summary == $summary' "$TMP/dispatch.json" >/dev/null
+
+BRIEF_SLICE=summary "$ROOT/scripts/task-load-spec.sh" T256 > "$TMP/spec.env"
+grep -q '^BRIEF_SUMMARY=' "$TMP/spec.env"
+grep -q '^BRIEF_SUMMARY_TOKENS=' "$TMP/spec.env"
+grep -q 'brief_summary_used' "$PROJECT_ROOT/events/"*.jsonl
+
+echo "PASS: brief summary slice"

--- a/scripts/test-fixtures/323-brief-quality/test-brief-quality.sh
+++ b/scripts/test-fixtures/323-brief-quality/test-brief-quality.sh
@@ -105,6 +105,31 @@ YAML
 bash "$ROOT/scripts/validate-brief.sh" "$TMPROOT/legacy.yaml" >"$TMPROOT/legacy.out" 2>"$TMPROOT/legacy.err"
 legacy_rc=$?
 
+export HOME="$TMPROOT/home"
+export ACHILLES_PROJECT="brief-quality-project"
+mkdir -p "$HOME/.dev-studio/$ACHILLES_PROJECT/plans/tasks" \
+  "$HOME/.dev-studio/$ACHILLES_PROJECT/plans/briefs" \
+  "$HOME/.dev-studio/$ACHILLES_PROJECT/events"
+# shellcheck source=../../../scripts/lib-ledger.sh
+. "$ROOT/scripts/lib-ledger.sh"
+
+writer_task_uuid=$(mint_uuidv7)
+writer_default_uuid=$(mint_uuidv7)
+writer_38_uuid=$(mint_uuidv7)
+write_task_artifact "$writer_task_uuid" proposed "Writer schema test" >/dev/null
+printf '## Objective\nWriter schema test.\n' > "$TMPROOT/writer-body.md"
+write_brief_artifact "$writer_default_uuid" "$writer_task_uuid" impl s \
+  awaiting_user=false \
+  body_file="$TMPROOT/writer-body.md" >/dev/null
+write_brief_artifact "$writer_38_uuid" "$writer_task_uuid" impl s \
+  awaiting_user=false \
+  schema_version=3.8.0 \
+  acceptance='["Writer opt-in acceptance is objectively verifiable."]' \
+  recommended_models='{"best_result":{"tier":"sonnet","reasoning_effort":"medium"},"fast_turnaround":{"tier":"haiku","reasoning_effort":"low"},"rationale":"Fixture opt-in."}' \
+  body_file="$TMPROOT/writer-body.md" >/dev/null
+writer_default_version=$(yq -r '.schema_version.version' "$HOME/.dev-studio/$ACHILLES_PROJECT/plans/briefs/$writer_default_uuid.yaml")
+writer_38_version=$(yq -r '.schema_version.version' "$HOME/.dev-studio/$ACHILLES_PROJECT/plans/briefs/$writer_38_uuid.yaml")
+
 assert "valid brief@3.8.0 quality contract passes" "[ $good_rc -eq 0 ]"
 assert "weak brief@3.8.0 fails" "[ $bad_rc -ne 0 ]"
 assert "weak brief failure names quality rules" "grep -q 'R-QUAL-OBJECTIVE' '$TMPROOT/bad.err' && grep -q 'R-QUAL-MODEL' '$TMPROOT/bad.err'"
@@ -112,6 +137,8 @@ assert "L executable brief without waiver fails" "[ $l_no_waiver_rc -ne 0 ]"
 assert "L executable failure names size rule" "grep -q 'R-QUAL-SIZE' '$TMPROOT/l-no-waiver.err'"
 assert "L executable brief with split rationale passes" "[ $l_waiver_rc -eq 0 ]"
 assert "pre-3.8 legacy brief is not retroactively blocked" "[ $legacy_rc -eq 0 ]"
+assert "writer defaults legacy/backfill briefs below 3.8" "[ '$writer_default_version' = '3.7.0' ]"
+assert "writer supports explicit brief@3.8.0 opt-in" "[ '$writer_38_version' = '3.8.0' ]"
 
 printf '%s assertions, %s failures\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/scripts/test-fixtures/323-brief-quality/test-brief-quality.sh
+++ b/scripts/test-fixtures/323-brief-quality/test-brief-quality.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Regression fixture for the brief quality contract.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t brief-quality.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+write_good() {
+  local path="$1" size="${2:-s}" extra_body="${3:-}"
+  cat > "$path" <<YAML
+schema_version: {name: brief, version: 3.8.0, min_reader: 3.0.0, deprecated_at: null}
+id: brief-323-good
+task_id: ""
+type: impl
+size: $size
+state: draft
+acceptance:
+  - Settings screen shows the retry banner only after a failed sync response.
+  - Tapping Retry invokes SyncService.retry once in the unit test harness.
+testability: []
+recommended_models:
+  best_result: {tier: sonnet, model_id: claude-sonnet-default, reasoning_effort: medium}
+  fast_turnaround: {tier: haiku, model_id: claude-haiku-default, reasoning_effort: low}
+  rationale: "Small implementation against an existing sync pattern."
+summary: "Add retry banner for failed settings sync. It gives users a clear recovery path. Keep service injection unchanged."
+body: |
+  # Task Brief: T323 - Retry banner
+
+  ## Objective
+  Show a retry banner on the settings screen after sync failure and route the Retry action through the existing sync service.
+
+$extra_body
+  ## Acceptance Criteria
+  1. Settings screen shows the retry banner only after a failed sync response.
+  2. Tapping Retry invokes SyncService.retry once in the unit test harness.
+
+  ## Verification / Evidence
+  - Run SettingsSyncViewModelTests.retryBanner.
+  - Debrief includes the test output or a manual note explaining why it was not run.
+
+  ## Non-goals / Out of Scope
+  - Do not change sync scheduling.
+  - Do not redesign settings layout.
+YAML
+}
+
+write_good "$TMPROOT/good.yaml"
+bash "$ROOT/scripts/validate-brief.sh" "$TMPROOT/good.yaml" >"$TMPROOT/good.out" 2>"$TMPROOT/good.err"
+good_rc=$?
+
+cat > "$TMPROOT/bad.yaml" <<'YAML'
+schema_version: {name: brief, version: 3.8.0, min_reader: 3.0.0, deprecated_at: null}
+id: brief-323-bad
+task_id: ""
+type: impl
+size: s
+state: draft
+acceptance:
+  - The experience feels polished and works well.
+testability: []
+summary: "Bad brief."
+body: |
+  # Task Brief: T323 - Bad
+YAML
+bash "$ROOT/scripts/validate-brief.sh" "$TMPROOT/bad.yaml" >"$TMPROOT/bad.out" 2>"$TMPROOT/bad.err"
+bad_rc=$?
+
+write_good "$TMPROOT/l-no-waiver.yaml" l
+bash "$ROOT/scripts/validate-brief.sh" "$TMPROOT/l-no-waiver.yaml" >"$TMPROOT/l-no-waiver.out" 2>"$TMPROOT/l-no-waiver.err"
+l_no_waiver_rc=$?
+
+write_good "$TMPROOT/l-waiver.yaml" l "  ## Split Rationale
+  This touches one generated migration boundary where splitting would create two incompatible intermediate states."
+bash "$ROOT/scripts/validate-brief.sh" "$TMPROOT/l-waiver.yaml" >"$TMPROOT/l-waiver.out" 2>"$TMPROOT/l-waiver.err"
+l_waiver_rc=$?
+
+cat > "$TMPROOT/legacy.yaml" <<'YAML'
+schema_version: {name: brief, version: 3.7.0, min_reader: 3.0.0, deprecated_at: null}
+id: brief-323-legacy
+task_id: ""
+type: impl
+size: s
+state: draft
+acceptance: []
+testability: []
+body: |
+  # Legacy brief shape
+YAML
+bash "$ROOT/scripts/validate-brief.sh" "$TMPROOT/legacy.yaml" >"$TMPROOT/legacy.out" 2>"$TMPROOT/legacy.err"
+legacy_rc=$?
+
+assert "valid brief@3.8.0 quality contract passes" "[ $good_rc -eq 0 ]"
+assert "weak brief@3.8.0 fails" "[ $bad_rc -ne 0 ]"
+assert "weak brief failure names quality rules" "grep -q 'R-QUAL-OBJECTIVE' '$TMPROOT/bad.err' && grep -q 'R-QUAL-MODEL' '$TMPROOT/bad.err'"
+assert "L executable brief without waiver fails" "[ $l_no_waiver_rc -ne 0 ]"
+assert "L executable failure names size rule" "grep -q 'R-QUAL-SIZE' '$TMPROOT/l-no-waiver.err'"
+assert "L executable brief with split rationale passes" "[ $l_waiver_rc -eq 0 ]"
+assert "pre-3.8 legacy brief is not retroactively blocked" "[ $legacy_rc -eq 0 ]"
+
+printf '%s assertions, %s failures\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/validate-brief.sh
+++ b/scripts/validate-brief.sh
@@ -13,6 +13,9 @@
 #     When parent task type=bug: brief must have non-empty `reproducer:` YAML
 #     field (brief@3.4.0+) OR a non-empty ## Steps to Reproduce section in body.
 #     Fails loud if neither is present.
+#   R-QUAL-* — executable brief quality contract for brief@3.8.0+.
+#     New direct-to-Achilles implementation briefs must be small enough to
+#     execute, objectively reviewable, and carry verification guidance.
 #
 # Usage:  scripts/validate-brief.sh <brief.yaml>
 # Exit:   0 pass, 1 block-level violation(s), 2 bad args / unreadable brief
@@ -39,6 +42,35 @@ command -v yq >/dev/null 2>&1 || { printf 'validate-brief: yq required\n' >&2; e
 FAILURES=0
 fail() { printf 'validate-brief [BLOCK] %s\n' "$1" >&2; FAILURES=$((FAILURES + 1)); }
 warn() { printf 'validate-brief [WARN]  %s\n' "$1" >&2; }
+
+version_ge() {
+  # Returns true when $1 >= $2 for dotted numeric versions.
+  awk -v a="$1" -v b="$2" '
+    BEGIN {
+      na=split(a, av, "."); nb=split(b, bv, ".")
+      n=(na>nb?na:nb)
+      for (i=1; i<=n; i++) {
+        ai=(av[i] == "" ? 0 : av[i]) + 0
+        bi=(bv[i] == "" ? 0 : bv[i]) + 0
+        if (ai > bi) exit 0
+        if (ai < bi) exit 1
+      }
+      exit 0
+    }'
+}
+
+body_section_has_content() {
+  local body="$1" heading_regex="$2"
+  printf '%s' "$body" | awk -v heading="$heading_regex" '
+    BEGIN { in_s=0 }
+    $0 ~ heading { in_s=1; next }
+    in_s && /^[[:space:]]*##[[:space:]]+/ { exit }
+    in_s && $0 !~ /^[[:space:]]*$/ && $0 !~ /^[[:space:]]*<!--[[:space:]]*/ {
+      found=1
+    }
+    END { exit(found ? 0 : 1) }
+  '
+}
 
 # ---------- R-BUG-1 — reproducer required for bug briefs ----------
 
@@ -75,6 +107,53 @@ if [ "$BRIEF_TYPE" = "bug" ]; then
 
   if [ -z "$REPRODUCER_FIELD" ] && [ -z "$REPRO_BODY" ]; then
     fail "Bug brief (task_id=$TASK_ID) has no reproducer: field and no ## Steps to Reproduce in body. Add steps before flipping to ready (brief@3.4.0, #220 A2-1)."
+  fi
+fi
+
+# ---------- R-QUAL-* — executable brief quality contract (brief@3.8.0+) ----------
+
+SCHEMA_VERSION=$(yq -r '.schema_version.version // "0.0.0"' "$BRIEF")
+if version_ge "$SCHEMA_VERSION" "3.8.0"; then
+  BODY=$(yq -r '.body // ""' "$BRIEF")
+  SIZE=$(yq -r '.size // ""' "$BRIEF" | tr '[:upper:]' '[:lower:]')
+  KIND=$(yq -r '.type // ""' "$BRIEF")
+  DISPATCH_AGENT=$(yq -r '.dispatch_agent // "achilles"' "$BRIEF")
+
+  # Parent epics and planning containers should not be direct Achilles briefs.
+  # If a large implementation brief really must dispatch, the waiver must be
+  # explicit so Argus can review the risk instead of guessing author intent.
+  if [ "$DISPATCH_AGENT" = "achilles" ] && [ "$KIND" = "impl" ] && [ "$SIZE" = "l" ]; then
+    if ! body_section_has_content "$BODY" '^[[:space:]]*##[[:space:]]+(L-size [Rr]eason|Size [Ww]aiver|Split [Rr]ationale|Why not split)'; then
+      fail "R-QUAL-SIZE: brief@3.8.0 executable Achilles impl brief has size=l without an explicit L-size reason or split rationale. Split to xs/s/m, or add a waiver section explaining why this must dispatch as one worker task."
+    fi
+  fi
+
+  if ! body_section_has_content "$BODY" '^[[:space:]]*##[[:space:]]+Objective'; then
+    fail "R-QUAL-OBJECTIVE: brief@3.8.0 requires a concise non-empty ## Objective section."
+  fi
+
+  ACCEPTANCE_LEN=$(yq -r '.acceptance // [] | length' "$BRIEF" 2>/dev/null || echo 0)
+  if [ "${ACCEPTANCE_LEN:-0}" -eq 0 ]; then
+    fail "R-QUAL-ACCEPTANCE: brief@3.8.0 requires non-empty structured acceptance criteria Argus can evaluate."
+  else
+    subjective=$(yq -r '.acceptance[]? // ""' "$BRIEF" \
+      | grep -Eni '\b(smooth|seamless|intuitive|nice|better|good|clean|proper|reasonable|works well|feels|polished)\b' \
+      | head -1 || true)
+    if [ -n "$subjective" ]; then
+      fail "R-QUAL-ACCEPTANCE: acceptance criterion is subjective instead of objectively verifiable: $subjective"
+    fi
+  fi
+
+  if ! body_section_has_content "$BODY" '^[[:space:]]*##[[:space:]]+(Out of Scope|Non-goals|Non-goals / Out of Scope)'; then
+    fail "R-QUAL-NON-GOALS: brief@3.8.0 requires explicit non-goals / out-of-scope."
+  fi
+
+  if ! body_section_has_content "$BODY" '^[[:space:]]*##[[:space:]]+(Verification|Evidence|Verification / Evidence|Expected Evidence)'; then
+    fail "R-QUAL-VERIFY: brief@3.8.0 requires a verification/evidence section with expected proof or test guidance."
+  fi
+
+  if ! yq -e '.recommended_models.best_result.tier and .recommended_models.best_result.reasoning_effort and .recommended_models.fast_turnaround.tier and .recommended_models.fast_turnaround.reasoning_effort and .recommended_models.rationale' "$BRIEF" >/dev/null 2>&1; then
+    fail "R-QUAL-MODEL: brief@3.8.0 requires structured recommended_models with best_result, fast_turnaround, and rationale."
   fi
 fi
 

--- a/tests/mode-packs/chanakya/brief.yaml
+++ b/tests/mode-packs/chanakya/brief.yaml
@@ -1,0 +1,25 @@
+# Skill-testing fixture for chanakya/modes/brief.md
+# Proves: executable-scope shaping + pre-ready brief quality gate.
+schema: 1
+pack: chanakya/modes/brief.md
+scenario: |
+  A user asks Chanakya to brief a broad implementation task marked Size L:
+  "modernize the whole settings sync flow." Explain what Chanakya must do
+  before handing work to Achilles. Name the scope-shaping decision, the
+  required sections/evidence for an executable brief, and the lint script
+  that blocks weak brief@3.8.0 artifacts before they become ready.
+failure_signals:
+  - "(?i)send.*(entire|whole).*to achilles"
+  - "(?i)L.*(fine|okay|normal).*(implementation|worker)"
+  - "(?i)(ask|need).*(more context|which files)"
+success_signals:
+  - "XS/S/M"
+  - "(?i)(split|child).*task"
+  - "validate-brief.sh"
+  - "brief@3.8.0"
+  - "(?i)(verification|evidence)"
+notes: |
+  The mode pack is load-bearing because a generic planner may preserve the
+  user's broad L task as one implementation brief. The pack tells Chanakya
+  to distinguish parent planning containers from executable worker tasks and
+  to rely on the versioned quality gate before ready-dispatch.

--- a/tests/mode-packs/chanakya/intake.yaml
+++ b/tests/mode-packs/chanakya/intake.yaml
@@ -1,0 +1,24 @@
+# Skill-testing fixture for chanakya/modes/intake.md
+# Proves: parent planning containers are separated from executable tasks.
+schema: 1
+pack: chanakya/modes/intake.md
+scenario: |
+  During intake, the user describes one broad arc: "rewrite onboarding,
+  account creation, notification permission, and analytics handoff." Walk
+  through how Chanakya should tier and size this before task artifacts are
+  written. Explain when to create a parent planning container, what sizes
+  executable child tasks should default to, and when a direct task can be XS.
+failure_signals:
+  - "(?i)one.*(large|L).*task"
+  - "(?i)brief.*whole.*arc"
+  - "(?i)(ask|need).*(more detail|clarification).*before.*classify"
+success_signals:
+  - "(?i)parent planning container"
+  - "XS"
+  - "S"
+  - "M"
+  - "(?i)child.*executable"
+notes: |
+  The fixture catches the failure mode where intake treats L as the normal
+  implementation size instead of splitting broad work into reviewer-ready
+  executable slices.


### PR DESCRIPTION
## Summary
- add brief@3.8 quality checks for executable Chanakya briefs
- carry compact brief summaries through status, dispatch-ready, and Achilles summary-slice loading
- keep legacy/backfill writer output below brief@3.8 unless callers explicitly opt into the stricter contract

## Verification
- scripts/test-fixtures/323-brief-quality/test-brief-quality.sh
- scripts/test-fixtures/256-brief-summary/test-brief-summary.sh
- bash -n on edited scripts
- scripts/lint-architecture.sh --staged
- scripts/lint-mode-pack.sh --staged
- scripts/lint-host-agnostic.sh --staged (existing Argus secret-scope warning only)

Closes #323
Closes #256