### PR TITLE
Fix chain runner report printf bullets

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T01:19:21Z",
+  "generated_at": "2026-05-01T01:25:22Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T01:19:20Z",
+  "generated_at": "2026-05-01T01:25:21Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -268,13 +268,13 @@ generate_run_report() {
 
   {
     printf '# Studio Chain Run Report\n\n'
-    printf '- Run UUID: `%s`\n' "$RUN_ID"
-    printf '- Manifest: `%s`\n' "$MANIFEST"
-    printf '- Status: `%s`\n' "$status"
-    printf '- Started: `%s`\n' "$RUN_STARTED_TS"
-    printf '- Ended: `%s`\n' "$ended_ts"
-    printf '- Duration: `%ss`\n' "$duration_s"
-    [ -n "$failure_reason" ] && printf '- Failure reason: `%s`\n' "$failure_reason"
+    printf -- '- Run UUID: `%s`\n' "$RUN_ID"
+    printf -- '- Manifest: `%s`\n' "$MANIFEST"
+    printf -- '- Status: `%s`\n' "$status"
+    printf -- '- Started: `%s`\n' "$RUN_STARTED_TS"
+    printf -- '- Ended: `%s`\n' "$ended_ts"
+    printf -- '- Duration: `%ss`\n' "$duration_s"
+    [ -n "$failure_reason" ] && printf -- '- Failure reason: `%s`\n' "$failure_reason"
     printf '\n## Chains And Issues\n\n'
     if [ "$summary_count" -gt 0 ]; then
       jq -r -s '
@@ -287,9 +287,9 @@ generate_run_report() {
     fi
     printf '\n## PRs And Review\n\n'
     if [ -n "$FINAL_PR_URL" ]; then
-      printf '- PR URL: %s\n' "$FINAL_PR_URL"
+      printf -- '- PR URL: %s\n' "$FINAL_PR_URL"
     else
-      printf '- PR URL: not opened\n'
+      printf -- '- PR URL: not opened\n'
     fi
     printf '\n## Telemetry Gaps\n\n'
     if [ "$summary_count" -gt 0 ]; then
@@ -300,7 +300,7 @@ generate_run_report() {
         end
       ' "$SUMMARY_ROOT"/*.json
     else
-      printf '- worker_summary_missing: all issues\n'
+      printf -- '- worker_summary_missing: all issues\n'
     fi
     printf '\n## Improvement Candidates\n\n'
     if [ "$summary_count" -gt 0 ]; then


### PR DESCRIPTION
Fixes a Bash portability bug in the chain-runner report writer: Markdown bullet formats beginning with '-' must use `printf --`, otherwise report generation exits with `printf: - : invalid option`.\n\nVerification:\n- `bash -n scripts/studio-chain-runner.sh`\n- `rg -n "printf '-" scripts/studio-chain-runner.sh` returned no matches\n- `git diff --check`\n- pre-commit hooks