### PR TITLE
Add Apollo scenario contract

### DIFF
--- a/_shared/contracts/apollo-scenario.schema.json
+++ b/_shared/contracts/apollo-scenario.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "apollo-scenario.schema.json",
+  "schema": 1,
+  "title": "Apollo Scenario",
+  "description": "Reusable performance scenario artifact consumed by Apollo mode packs. Captures user flow, cohort, preconditions, signposts, metric targets, expected artifacts, and compare axes.",
+  "type": "object",
+  "required": ["schema_version", "scenario_id", "scenario_version", "name", "intent", "app", "cohort", "preconditions", "flow", "signposts", "metric_targets", "capture", "expected_artifacts", "compare_axes"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "$ref": "debrief.schema.json#/$defs/schemaVersion" },
+    "scenario_id": { "type": "string", "pattern": "^[a-z][a-z0-9-]{2,80}$" },
+    "scenario_version": { "type": "integer", "minimum": 1 },
+    "name": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "intent": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "app": {
+      "type": "object",
+      "required": ["bundle_id", "build_configuration"],
+      "additionalProperties": false,
+      "properties": {
+        "bundle_id": { "type": "string", "minLength": 1 },
+        "scheme": { "type": ["string", "null"] },
+        "install_source": { "enum": ["xcode", "testflight", "app-store", "local-build", "unknown"] },
+        "build_configuration": { "enum": ["Debug", "Release", "Profiling", "TestFlight", "AppStore"] },
+        "build_identifier": { "type": ["string", "null"] }
+      }
+    },
+    "cohort": {
+      "type": "object",
+      "required": ["device", "os", "target_kind"],
+      "additionalProperties": false,
+      "properties": {
+        "device": { "type": "string", "minLength": 1 },
+        "os": { "type": "string", "minLength": 1 },
+        "target_kind": { "enum": ["real-device", "simulator", "field"] },
+        "udid": { "type": ["string", "null"] }
+      }
+    },
+    "preconditions": {
+      "type": "object",
+      "required": ["login_state", "network", "charging_state", "thermal_state", "screen_brightness_percent", "low_power_mode"],
+      "additionalProperties": false,
+      "properties": {
+        "login_state": { "type": "string", "minLength": 1 },
+        "network": { "enum": ["wifi", "cellular", "offline", "any"] },
+        "charging_state": { "enum": ["plugged-in", "unplugged", "any"] },
+        "thermal_state": { "enum": ["nominal", "fair", "serious", "critical", "any"] },
+        "screen_brightness_percent": { "type": "integer", "minimum": 0, "maximum": 100 },
+        "low_power_mode": { "type": "boolean" },
+        "notes": { "type": ["string", "null"], "maxLength": 1000 }
+      }
+    },
+    "flow": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["step", "action"],
+        "additionalProperties": false,
+        "properties": {
+          "step": { "type": "integer", "minimum": 1 },
+          "action": { "type": "string", "minLength": 1 },
+          "expected_screen": { "type": ["string", "null"] },
+          "human_note": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "signposts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "kind", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kind": { "enum": ["interval", "event"] },
+          "required": { "type": "boolean" },
+          "public_payload_keys": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "metric_targets": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["memory", "cpu", "thermal", "battery"] }
+    },
+    "capture": {
+      "type": "object",
+      "required": ["mode", "duration_s", "dwell_s", "tools"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": { "enum": ["human-run", "automated", "hybrid"] },
+        "duration_s": { "type": "integer", "minimum": 1 },
+        "dwell_s": { "type": "integer", "minimum": 0 },
+        "tools": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["xcode", "xctrace", "instruments", "xctest", "metrickit", "asc", "axe", "manual"] }
+        },
+        "instructions": { "type": ["string", "null"], "maxLength": 2000 }
+      }
+    },
+    "expected_artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["kind", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "kind": { "enum": ["trace", "mxmetric", "mxdiagnostic", "xcresult", "signpost", "energy-log", "asc-perf", "logarchive"] },
+          "template": { "type": ["string", "null"] },
+          "required": { "type": "boolean" }
+        }
+      }
+    },
+    "compare_axes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["scenario_id", "scenario_version", "cohort", "build_configuration", "signpost", "duration_s", "dwell_s", "template", "field_window"] }
+    },
+    "created_at": { "$ref": "debrief.schema.json#/$defs/rfc3339" }
+  }
+}

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T22:33:17Z",
+  "generated_at": "2026-05-01T22:43:10Z",
   "agents": [
     {
       "name": "studio",
@@ -304,7 +304,7 @@
       "name": "apollo",
       "router": "apollo/SKILL.md",
       "description": "iOS performance agent. Per-metric mode packs (memory/thermal/battery/cpu) under a strict-9 evidence gate. Refuses recommendations without hard evidence; auto-captures via the execution surface.",
-      "reads": ["apollo/_shared/integrations/imgly-and-metal.md", "apollo/_shared/primitives/evidence-gate.md", "apollo/_shared/primitives/instruments-index.md", "apollo/_shared/primitives/metrickit.md", "apollo/_shared/primitives/signposts.md", "apollo/_shared/primitives/source-map.md", "apollo/_shared/primitives/xctest-baselines.md", "~/.dev-studio/.runtime/host-capabilities.yaml", "~/.dev-studio/<project>/apollo/baselines/*.json", "~/.dev-studio/<project>/apollo/captures/**", "~/.dev-studio/<project>/apollo/deferred/*.yaml", "~/.dev-studio/<project>/events/**.jsonl"],
+      "reads": ["apollo/_shared/integrations/imgly-and-metal.md", "apollo/_shared/primitives/evidence-gate.md", "apollo/_shared/primitives/instruments-index.md", "apollo/_shared/primitives/metrickit.md", "apollo/_shared/primitives/signposts.md", "apollo/_shared/primitives/source-map.md", "apollo/_shared/primitives/xctest-baselines.md", "~/.dev-studio/.runtime/host-capabilities.yaml", "~/.dev-studio/<project>/apollo/baselines/*.json", "~/.dev-studio/<project>/apollo/captures/**", "~/.dev-studio/<project>/apollo/deferred/*.yaml", "~/.dev-studio/<project>/apollo/scenarios/*.yaml", "~/.dev-studio/<project>/events/**.jsonl"],
       "writes": ["~/.dev-studio/.runtime/locks/apollo/*", "~/.dev-studio/<project>/apollo/captures/<id>/**", "~/.dev-studio/<project>/apollo/deferred/<id>.yaml", "~/.dev-studio/<project>/apollo/recommendations/<id>.md", "~/.dev-studio/<project>/events/<today>.jsonl"],
       "modes": [
         {
@@ -334,7 +334,7 @@
           "path": "apollo/modes/measure.md",
           "type": "mode-pack",
           "description": "Capture-only mode for hard-evidence artifacts without recommending a fix. Pre-flight tool for Apollo perf briefs with empty evidence artifacts.",
-          "reads": ["~/.dev-studio/<project>/apollo/baselines/*.json", "~/.dev-studio/.runtime/host-capabilities.yaml"],
+          "reads": ["~/.dev-studio/<project>/apollo/baselines/*.json", "~/.dev-studio/<project>/apollo/scenarios/*.yaml", "~/.dev-studio/.runtime/host-capabilities.yaml"],
           "writes": ["~/.dev-studio/<project>/apollo/captures/<id>/**", "~/.dev-studio/<project>/events/<today>.jsonl", "~/.dev-studio/.runtime/locks/apollo/*"],
           "snapshots": [],
           "dry_run": false,

--- a/_shared/schemas/reader-versions.json
+++ b/_shared/schemas/reader-versions.json
@@ -11,5 +11,6 @@
   "agent-boot":        {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
   "plans-index":       {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
   "events-index":      {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
-  "capability-manifest": {"max_known": "1.0.0", "min_acceptable": "1.0.0"}
+  "capability-manifest": {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
+  "apollo-scenario":  {"max_known": "1.0.0", "min_acceptable": "1.0.0"}
 }

--- a/apollo/SKILL.md
+++ b/apollo/SKILL.md
@@ -105,9 +105,10 @@ Per-project Apollo state lives under `~/.dev-studio/<project>/apollo/` (resolved
 | `apollo/baselines/<metric>.json` | XCTest performance baselines per metric | mode pack |
 | `apollo/deferred/<id>.yaml` | Deferred-capture rows; drained by scheduled sweep | mode pack |
 | `apollo/recommendations/<id>.md` | Recommendation artifact (cited evidence + proposed fix) | mode pack |
+| `apollo/scenarios/<scenario-id>.yaml` | Reusable user-flow contract for repeatable captures | user, Chanakya, or mode pack |
 
 Machine-global resources (simulator semaphores, GPU queues) stay at `~/.dev-studio/.runtime/`. R4 split applies — workflow state per-project, physical-resource locks machine-global.
 
 ## Cross-refs
 
-Per-metric primitives and capture contracts: `apollo/_shared/primitives/` (evidence-gate, execution-surface, metrickit, signposts, xctest-baselines, instruments-index, organizer-asc, regression-detection). Imgly delegation: `apollo/_shared/integrations/imgly-and-metal.md`. Boot event: `_shared/contracts/agent-boot.md`. Completion claims: REVIEW.md R10.
+Per-metric primitives and capture contracts: `apollo/_shared/primitives/` (evidence-gate, execution-surface, metrickit, signposts, scenarios, xctest-baselines, instruments-index, organizer-asc, regression-detection). Imgly delegation: `apollo/_shared/integrations/imgly-and-metal.md`. Boot event: `_shared/contracts/agent-boot.md`. Completion claims: REVIEW.md R10.

--- a/apollo/_shared/primitives/scenarios.md
+++ b/apollo/_shared/primitives/scenarios.md
@@ -1,0 +1,73 @@
+---
+name: Apollo scenarios
+description: Reusable scenario artifact contract for Apollo captures. Records user flow, cohort, preconditions, signposts, metric targets, expected artifacts, and compare axes for repeatable performance analysis.
+type: reference
+schema_version: 1
+---
+
+# Apollo scenarios
+
+Apollo scenarios turn a user flow into a repeatable artifact. The runtime path is:
+
+```text
+~/.dev-studio/<project>/apollo/scenarios/<scenario-id>.yaml
+```
+
+The schema is `_shared/contracts/apollo-scenario.schema.json`. Validate with:
+
+```bash
+scripts/validate-contract.sh apollo-scenario <scenario.yaml>
+```
+
+## Required fields
+
+| Field | Purpose |
+|---|---|
+| `scenario_id` + `scenario_version` | Stable identity and version. Any flow, precondition, signpost, duration, or compare-axis change increments `scenario_version`. |
+| `app` | Names the app install/build source so Debug, Release, TestFlight, and App Store data do not mix silently. |
+| `cohort` | Pins device, OS, and target kind. Cross-cohort comparison fails the strict-9 gate unless explicitly downgraded to advisory. |
+| `preconditions` | Records conditions that perturb performance: login, network, charging, thermal state, brightness, and Low Power Mode. |
+| `flow` | Ordered human-readable steps. Steps do not require automation; human-run Xcode/device sessions are valid. |
+| `signposts` | Points of interest Apollo expects in the artifact. Required signposts missing from local traces fail with `reason: signpost_missing`. |
+| `metric_targets` | One or more of `memory`, `cpu`, `thermal`, `battery`. Mode packs read only their target rows but preserve the full scenario. |
+| `capture` | Names whether the run is `human-run`, `automated`, or `hybrid`, the duration/dwell, and the tool family. |
+| `expected_artifacts` | Names the artifact types Apollo should collect or ask the user to supply. |
+| `compare_axes` | The axes that must match between baseline, observed, and post-fix captures. |
+
+## Artifact sidecar link
+
+Every capture sidecar that used a scenario records the scenario identity:
+
+```yaml
+scenario:
+  path: ~/.dev-studio/<project>/apollo/scenarios/feed-scroll-cpu.yaml
+  id: feed-scroll-cpu
+  version: 1
+  compare_axes: [scenario_id, scenario_version, cohort, build_configuration, signpost, duration_s, template]
+```
+
+The sidecar link is mandatory when a mode was invoked with `--scenario <id-or-path>`. Apollo refuses post-fix verification if the pre-fix and post-fix sidecars name different `scenario_id`, `scenario_version`, or mode-specific compare axes.
+
+## Human-run flow
+
+Human-run scenarios are first-class. Apollo may guide the user through Xcode and Instruments, but the scenario remains the source of truth:
+
+1. **READ** the scenario and validate it.
+   Before: user invokes `/apollo <mode> --scenario <id-or-path>` or supplies a scenario path.
+   After: mode, cohort, preconditions, flow, signposts, expected artifacts, and compare axes are known.
+
+2. **CHECK** host capabilities.
+   Before: capture mode and tools are known.
+   After: Apollo either drives available automation or emits a human-run checklist with the same scenario fields.
+
+3. **RECORD** the completed artifact sidecar.
+   Before: artifact exists under `apollo/captures/<id>/`.
+   After: sidecar links to the scenario path, id, version, and compare axes.
+
+## See also
+
+- `_shared/contracts/apollo-scenario.schema.json`
+- `apollo/_shared/primitives/signposts.md`
+- `apollo/_shared/primitives/regression-detection.md`
+- `apollo/_shared/primitives/evidence-gate.md`
+- `apollo/modes/measure.md`

--- a/apollo/modes/battery.md
+++ b/apollo/modes/battery.md
@@ -39,6 +39,8 @@ The mode treats four energy signal classes as distinct — diagnostic question, 
 
 Source-map rows: `apollo/_shared/primitives/source-map.md` §Mode row index → battery. This mode cites source-map row IDs for Apple / WWDC authority, then cites local primitives for operational gates.
 
+Scenario input: this mode accepts `--scenario <id-or-path>` per `apollo/_shared/primitives/scenarios.md`; scenario fields replace inline workload/cohort/signpost/dwell prose when present.
+
 ## Reproducible vs non-reproducible (WWDC25 226 split)
 
 | Track | When the signal lives there | Authoritative artifacts | What auto-capture can do |
@@ -326,6 +328,7 @@ The Imgly carve-out matches thermal mode. Imgly knowledge lives in the dedicated
 - `apollo/_shared/primitives/source-map.md` — Apple / WWDC source rows for battery (`SRC-BATT-*`, `SRC-NET-WWDC21-10212`, `SRC-METRICKIT-WWDC20-10081`, `SRC-ORG-WWDC21-10087`, `SRC-XCT-PERF`)
 - `apollo/_shared/primitives/mode-pack-scaffold.md` — five-phase pipeline framing, Phase 4 handoff contract, Phase 5 outcome state machine, procedure steps 5–8 boilerplate
 - `apollo/_shared/primitives/evidence-gate.md` — strict-9 contract + refusal protocol the phase gates feed into
+- `apollo/_shared/primitives/scenarios.md` — reusable user-flow contract for repeatable captures
 - `apollo/_shared/primitives/metrickit.md` — `MXAppRunTimeMetric`, `MXCPUMetric`, `MXGPUMetric`, `MXDisplayMetric`, `MXNetworkTransferMetric`, `MXDiskIOMetric`, `MXAnimationMetric`, `MXCPUExceptionDiagnostic`, `MXDiskWriteExceptionDiagnostic` schemas
 - `apollo/_shared/primitives/signposts.md` — `OSSignposter` shape + privacy default the signal table enforces
 - `apollo/_shared/primitives/instruments-index.md` — Power Profiler / Energy Log / Network / Location / Display details + capture commands

--- a/apollo/modes/cpu.md
+++ b/apollo/modes/cpu.md
@@ -39,6 +39,8 @@ CPU is a first-class Apollo mode. It is not a thermal subcase: the user may care
 
 Source-map rows: `apollo/_shared/primitives/source-map.md` §Mode row index -> cpu. CPU mode cites source-map row IDs for Apple / WWDC authority, then cites local primitives for operational gates.
 
+Scenario input: this mode accepts `--scenario <id-or-path>` per `apollo/_shared/primitives/scenarios.md`; scenario fields replace inline workload/cohort/signpost/thread-scope prose when present.
+
 ## Signal classes
 
 | Class | What it looks like | Authoritative source | Apollo template |
@@ -194,6 +196,7 @@ Regression thresholds use `apollo/_shared/primitives/regression-detection.md`: C
 
 - `apollo/_shared/primitives/source-map.md` - Apple / WWDC source rows for CPU (`SRC-CPU-*`, `SRC-XCT-CPU-DOC`, `SRC-HANGS-WWDC22-10082`, `SRC-METRICKIT-WWDC20-10081`)
 - `apollo/_shared/primitives/evidence-gate.md` - strict-9 contract + refusal protocol
+- `apollo/_shared/primitives/scenarios.md` - reusable user-flow contract for repeatable captures
 - `apollo/_shared/primitives/instruments-index.md` - CPU Profiler / Time Profiler / CPU Counters / Processor Trace / System Trace details
 - `apollo/_shared/primitives/metrickit.md` - `MXCPUMetric`, `MXCPUExceptionDiagnostic`, `MXSignpostIntervalData` schemas
 - `apollo/_shared/primitives/signposts.md` - scenario anchors that make CPU traces re-runnable

--- a/apollo/modes/measure.md
+++ b/apollo/modes/measure.md
@@ -15,6 +15,7 @@ emits:
   - apollo_capture_deferred
 reads:
   - ~/.dev-studio/<project>/apollo/baselines/*.json
+  - ~/.dev-studio/<project>/apollo/scenarios/*.yaml
   - ~/.dev-studio/.runtime/host-capabilities.yaml
 writes:
   - ~/.dev-studio/<project>/apollo/captures/<id>/**
@@ -41,6 +42,7 @@ Not for: open-ended "what's slow?" investigation. Use the diagnostic mode packs 
 /apollo measure thermal --cohort iPhone-16-Pro-iOS-19 --workload export-1080p
 /apollo measure battery --capture-only       # explicit capture-only flag (alias)
 /apollo measure cpu --workload scroll-feed
+/apollo measure cpu --scenario feed-scroll-cpu
 /apollo memory --capture-only                # equivalent: enter memory mode, exit after capture
 ```
 
@@ -56,7 +58,7 @@ Not for: open-ended "what's slow?" investigation. Use the diagnostic mode packs 
 
 ### Step 1 — Resolve metric + cohort + workload
 
-Parse the invocation. Resolve metric to one of `memory | thermal | battery | cpu`. Resolve cohort either from `--cohort` or from `<project>/apollo/baselines/<baseline_ref>.json`. Resolve workload either from `--workload` or from the metric's mode-pack default.
+Parse the invocation. Resolve metric to one of `memory | thermal | battery | cpu`. If `--scenario <id-or-path>` is present, validate it with `scripts/validate-contract.sh apollo-scenario <scenario.yaml>` and resolve cohort, workload, signposts, duration, dwell, expected artifacts, and compare axes from `apollo/_shared/primitives/scenarios.md`. Otherwise resolve cohort from `--cohort` or `<project>/apollo/baselines/<baseline_ref>.json`, and workload from `--workload` or the metric's mode-pack default.
 
 If any of the three are unresolved, refuse with `missing-input` and list which fields are unset. Do not guess.
 
@@ -102,6 +104,11 @@ captured_with:
   host: claude-code
   session_id: "session-42"
 baseline_ref: null                            # populated when --baseline-for <ref> is set
+scenario:
+  path: null                                  # populated when --scenario is used
+  id: null
+  version: null
+  compare_axes: []
 ```
 
 The `measure` / `value` / `unit` triple is the canonical summary the brief's `evidence.artifacts` references. Apollo's diagnostic mode packs read these fields directly when computing baseline-vs-observed deltas.
@@ -142,6 +149,7 @@ All refusals emit `apollo_refused` with the reason code. Capture-mode refusals n
 
 - `apollo/_shared/primitives/evidence-gate.md` — the strict-9 contract this mode produces evidence for.
 - `apollo/_shared/primitives/execution-surface.md` — per-metric capture recipes.
+- `apollo/_shared/primitives/scenarios.md` — reusable scenario artifact and sidecar link.
 - `apollo/_shared/primitives/perf-merge-loop.md` — what consumes the captured artifact downstream.
 - `_shared/schemas/brief.md` — `evidence.artifacts[]` field this mode populates.
 - `apollo/modes/{memory,thermal,battery,cpu}.md` — diagnostic mode packs that capture-then-recommend.

--- a/apollo/modes/memory.md
+++ b/apollo/modes/memory.md
@@ -38,6 +38,8 @@ The mode treats four memory signal classes as distinct — diagnostic question, 
 
 Source-map rows: `apollo/_shared/primitives/source-map.md` §Mode row index → memory. This mode cites source-map row IDs for Apple / WWDC authority, then cites local primitives for operational gates.
 
+Scenario input: this mode accepts `--scenario <id-or-path>` per `apollo/_shared/primitives/scenarios.md`; scenario fields replace inline workload/cohort/signpost prose when present.
+
 ## Signal classes (heap taxonomy)
 
 | Class | What it looks like | Authoritative source | Apollo template |
@@ -253,6 +255,7 @@ The Metal/Imgly carve-out is Apollo's compositional hinge. Imgly knowledge lives
 - `apollo/_shared/primitives/source-map.md` — Apple / WWDC source rows for memory (`SRC-MEM-*`, `SRC-INST-*`, `SRC-METRICKIT-WWDC20-10081`, `SRC-ORG-WWDC21-10087`, `SRC-XCT-PERF`)
 - `apollo/_shared/primitives/mode-pack-scaffold.md` — five-phase pipeline framing, Phase 4 handoff contract, Phase 5 outcome state machine, procedure steps 5–8 boilerplate
 - `apollo/_shared/primitives/evidence-gate.md` — strict-9 contract + refusal protocol the phase gates feed into
+- `apollo/_shared/primitives/scenarios.md` — reusable user-flow contract for repeatable captures
 - `apollo/_shared/primitives/metrickit.md` — `MXMemoryMetric`, `MXAppExitMetric`, `MXCrashDiagnostic` schemas
 - `apollo/_shared/primitives/signposts.md` — `OSSignposter` shape + privacy default the signal table enforces
 - `apollo/_shared/primitives/instruments-index.md` — Allocations / VM Tracker / Leaks template details + capture commands

--- a/apollo/modes/thermal.md
+++ b/apollo/modes/thermal.md
@@ -39,6 +39,8 @@ The mode treats four thermal signal classes as distinct — diagnostic question,
 
 Source-map rows: `apollo/_shared/primitives/source-map.md` §Mode row index → thermal. This mode cites source-map row IDs for Apple / WWDC authority, then cites local primitives for operational gates.
 
+Scenario input: this mode accepts `--scenario <id-or-path>` per `apollo/_shared/primitives/scenarios.md`; scenario fields replace inline workload/cohort/signpost/dwell prose when present.
+
 ## Signal classes (thermal taxonomy)
 
 | Class | What it looks like | Authoritative source | Apollo template |
@@ -288,6 +290,7 @@ The Metal/Imgly carve-out is Apollo's compositional hinge. Imgly knowledge lives
 - `apollo/_shared/primitives/source-map.md` — Apple / WWDC source rows for thermal (`SRC-THERM-API`, `SRC-CPU-*`, `SRC-HANGS-WWDC22-10082`, `SRC-ORG-WWDC21-10087`, `SRC-METRICKIT-WWDC20-10081`). Historical `WWDC22 110340` is tracked there as stale and MUST NOT be cited for hangs.
 - `apollo/_shared/primitives/mode-pack-scaffold.md` — five-phase pipeline framing, Phase 4 handoff contract, Phase 5 outcome state machine, procedure steps 5–8 boilerplate
 - `apollo/_shared/primitives/evidence-gate.md` — strict-9 contract + refusal protocol the phase gates feed into
+- `apollo/_shared/primitives/scenarios.md` — reusable user-flow contract for repeatable captures
 - `apollo/_shared/primitives/metrickit.md` — `MXMetaData.thermalState`, `MXCPUMetric`, `MXCPUExceptionDiagnostic`, `MXHangDiagnostic`, `MXGPUMetric` schemas
 - `apollo/_shared/primitives/signposts.md` — `OSSignposter` shape + privacy default the signal table enforces
 - `apollo/_shared/primitives/instruments-index.md` — Time Profiler / CPU Counters / Processor Trace / Metal System Trace details + capture commands

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T22:33:17Z",
+  "generated_at": "2026-05-01T22:43:09Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/407-apollo-scenario-contract/test-apollo-scenario-schema.sh
+++ b/scripts/test-fixtures/407-apollo-scenario-contract/test-apollo-scenario-schema.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+VALID="$ROOT/tests/fixtures/apollo/scenarios/feed-scroll-cpu.yaml"
+INVALID="$ROOT/tests/fixtures/apollo/scenarios/invalid-missing-signpost.yaml"
+ERR="${TMPDIR:-/tmp}/apollo-scenario-invalid.$$"
+trap 'rm -f "$ERR"' EXIT
+
+"$ROOT/scripts/validate-contract.sh" apollo-scenario "$VALID"
+
+if "$ROOT/scripts/validate-contract.sh" apollo-scenario "$INVALID" >"$ERR" 2>&1; then
+  printf 'expected invalid scenario to fail validation\n' >&2
+  exit 1
+fi
+
+printf 'PASS: Apollo scenario schema validation\n'

--- a/scripts/validate-contract.sh
+++ b/scripts/validate-contract.sh
@@ -7,7 +7,7 @@
 # Usage:
 #   scripts/validate-contract.sh <schema-name> <file>
 #
-# <schema-name>: worker-report | debrief | review-verdict | handoff
+# <schema-name>: worker-report | debrief | review-verdict | handoff | apollo-scenario
 # <file>:        path to artifact (JSON or YAML — check-jsonschema handles both)
 #
 # Exit 0  — payload is valid against the named schema.
@@ -36,8 +36,9 @@ case "$SCHEMA_NAME" in
   debrief)         SCHEMA_FILE="$REPO_ROOT/_shared/contracts/debrief.schema.json" ;;
   review-verdict)  SCHEMA_FILE="$REPO_ROOT/_shared/contracts/review-verdict.schema.json" ;;
   handoff)         SCHEMA_FILE="$REPO_ROOT/_shared/contracts/handoff.schema.json" ;;
+  apollo-scenario) SCHEMA_FILE="$REPO_ROOT/_shared/contracts/apollo-scenario.schema.json" ;;
   *)
-    printf 'validate-contract: unknown schema %s (want worker-report|debrief|review-verdict|handoff)\n' \
+    printf 'validate-contract: unknown schema %s (want worker-report|debrief|review-verdict|handoff|apollo-scenario)\n' \
       "$SCHEMA_NAME" >&2
     exit 2
     ;;

--- a/tests/fixtures/apollo/scenarios/feed-scroll-cpu.yaml
+++ b/tests/fixtures/apollo/scenarios/feed-scroll-cpu.yaml
@@ -1,0 +1,66 @@
+schema_version:
+  name: apollo-scenario
+  version: 1.0.0
+  min_reader: 1.0.0
+  deprecated_at: null
+scenario_id: feed-scroll-cpu
+scenario_version: 1
+name: Feed scroll CPU pass
+intent: Measure CPU and frame-adjacent work while scrolling the home feed.
+app:
+  bundle_id: gg.turnip.app
+  scheme: Turnip
+  install_source: xcode
+  build_configuration: Release
+  build_identifier: null
+cohort:
+  device: iPhone 16 Pro
+  os: iOS 19.0
+  target_kind: real-device
+  udid: null
+preconditions:
+  login_state: test account signed in
+  network: wifi
+  charging_state: unplugged
+  thermal_state: nominal
+  screen_brightness_percent: 50
+  low_power_mode: false
+  notes: null
+flow:
+  - step: 1
+    action: Launch app from Xcode and wait for feed loaded.
+    expected_screen: Home feed
+    human_note: null
+  - step: 2
+    action: Scroll the feed for one minute at natural speed.
+    expected_screen: Home feed
+    human_note: Keep the device in hand; do not attach debugger-only gauges unless requested.
+signposts:
+  - name: FeedScroll
+    kind: interval
+    required: true
+    public_payload_keys:
+      - item_count
+metric_targets:
+  - cpu
+capture:
+  mode: human-run
+  duration_s: 60
+  dwell_s: 0
+  tools:
+    - xcode
+    - instruments
+  instructions: Start CPU Profiler, perform the flow, stop after the signpost interval ends.
+expected_artifacts:
+  - kind: trace
+    template: CPU Profiler
+    required: true
+compare_axes:
+  - scenario_id
+  - scenario_version
+  - cohort
+  - build_configuration
+  - signpost
+  - duration_s
+  - template
+created_at: 2026-05-02T00:00:00Z

--- a/tests/fixtures/apollo/scenarios/invalid-missing-signpost.yaml
+++ b/tests/fixtures/apollo/scenarios/invalid-missing-signpost.yaml
@@ -1,0 +1,38 @@
+schema_version:
+  name: apollo-scenario
+  version: 1.0.0
+  min_reader: 1.0.0
+  deprecated_at: null
+scenario_id: invalid-missing-signpost
+scenario_version: 1
+name: Invalid scenario
+intent: Missing signposts should fail validation.
+app:
+  bundle_id: gg.turnip.app
+  build_configuration: Release
+cohort:
+  device: iPhone 16 Pro
+  os: iOS 19.0
+  target_kind: real-device
+preconditions:
+  login_state: test account signed in
+  network: wifi
+  charging_state: unplugged
+  thermal_state: nominal
+  screen_brightness_percent: 50
+  low_power_mode: false
+flow:
+  - step: 1
+    action: Launch app.
+signposts: []
+metric_targets: [cpu]
+capture:
+  mode: human-run
+  duration_s: 60
+  dwell_s: 0
+  tools: [xcode]
+expected_artifacts:
+  - kind: trace
+    template: CPU Profiler
+    required: true
+compare_axes: [scenario_id, scenario_version, cohort]


### PR DESCRIPTION
## Summary
- add a portable Apollo scenario schema for repeatable performance captures
- document runtime scenario artifacts and capture sidecar links
- wire scenario references into Apollo mode packs and measure mode
- add valid/invalid scenario fixtures and schema validation coverage

Closes #407

## Verification
- scripts/lint-host-agnostic.sh --staged
- scripts/lint-architecture.sh --staged
- scripts/lint-comms-boundary.sh --staged
- scripts/lint-skill-prose.sh --staged
- scripts/lint-mode-pack.sh apollo/modes/memory.md apollo/modes/thermal.md apollo/modes/battery.md apollo/modes/cpu.md apollo/modes/measure.md
- scripts/test-fixtures/407-apollo-scenario-contract/test-apollo-scenario-schema.sh
- scripts/validate-schema.sh tests/fixtures/apollo/scenarios/feed-scroll-cpu.yaml
- git diff --cached --check

Portable: yes