### PR TITLE
Add Apollo signpost assistant contract

### DIFF
--- a/_shared/contracts/apollo-signpost-plan.schema.json
+++ b/_shared/contracts/apollo-signpost-plan.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "apollo-signpost-plan.schema.json",
+  "schema": 1,
+  "title": "Apollo Signpost Plan",
+  "description": "Patch-ready signpost plan derived from an Apollo scenario before capture.",
+  "type": "object",
+  "required": ["schema_version", "plan_id", "scenario", "mode_targets", "signposts", "brief_seed", "missing_signpost_policy"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "$ref": "debrief.schema.json#/$defs/schemaVersion" },
+    "plan_id": { "type": "string", "pattern": "^signpost-plan-[a-z0-9-]{6,80}$" },
+    "scenario": {
+      "type": "object",
+      "required": ["id", "version"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "version": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "mode_targets": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["memory", "cpu", "thermal", "battery"] }
+    },
+    "signposts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "kind", "placement", "privacy", "required_for_recommendation"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kind": { "enum": ["interval", "event"] },
+          "placement": { "type": "string", "minLength": 1 },
+          "privacy": { "enum": ["public-metadata", "private-metadata", "no-metadata"] },
+          "public_payload_keys": { "type": "array", "items": { "type": "string" } },
+          "required_for_recommendation": { "type": "boolean" }
+        }
+      }
+    },
+    "brief_seed": {
+      "type": "object",
+      "required": ["owner", "summary", "acceptance"],
+      "additionalProperties": false,
+      "properties": {
+        "owner": { "enum": ["achilles", "human"] },
+        "summary": { "type": "string", "minLength": 1 },
+        "acceptance": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+      }
+    },
+    "missing_signpost_policy": { "enum": ["block-before-capture", "retry-once", "advisory-only"] }
+  }
+}

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T22:54:16Z",
+  "generated_at": "2026-05-01T23:02:17Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/reader-versions.json
+++ b/_shared/schemas/reader-versions.json
@@ -13,5 +13,6 @@
   "events-index":      {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
   "capability-manifest": {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
   "apollo-scenario":  {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
-  "apollo-code-area": {"max_known": "1.0.0", "min_acceptable": "1.0.0"}
+  "apollo-code-area": {"max_known": "1.0.0", "min_acceptable": "1.0.0"},
+  "apollo-signpost-plan": {"max_known": "1.0.0", "min_acceptable": "1.0.0"}
 }

--- a/apollo/_shared/primitives/scenarios.md
+++ b/apollo/_shared/primitives/scenarios.md
@@ -68,6 +68,7 @@ Human-run scenarios are first-class. Apollo may guide the user through Xcode and
 
 - `_shared/contracts/apollo-scenario.schema.json`
 - `apollo/_shared/primitives/signposts.md`
+- `apollo/_shared/primitives/signpost-assistant.md`
 - `apollo/_shared/primitives/regression-detection.md`
 - `apollo/_shared/primitives/evidence-gate.md`
 - `apollo/modes/measure.md`

--- a/apollo/_shared/primitives/signpost-assistant.md
+++ b/apollo/_shared/primitives/signpost-assistant.md
@@ -1,0 +1,75 @@
+---
+name: Apollo signpost assistant
+description: Scenario-driven signpost planning for Apollo. Produces OSSignposter interval/event plans, privacy guidance, patch-ready brief seeds, and missing-signpost refusal policy.
+type: reference
+schema_version: 1
+---
+
+# Apollo signpost assistant
+
+The signpost assistant runs before capture when a scenario has weak or missing points of interest. It reads `apollo/_shared/primitives/scenarios.md`, writes a signpost plan, and lets Apollo block before producing an unusable trace.
+
+Validate plans with:
+
+```bash
+scripts/validate-contract.sh apollo-signpost-plan <plan.yaml>
+```
+
+## Mode patterns
+
+| Mode | Preferred interval | Useful events | Metadata guidance |
+|---|---|---|---|
+| memory | The allocation-heavy user flow, e.g. `PhotoExport` or `FeedOpen` | Cache flush, image decode start/end, memory warning | Public numeric sizes only: bytes, item counts, dimensions. No filenames or user text. |
+| cpu | The hot interaction or compute window, e.g. `FeedScroll`, `ExportEncode` | QoS/task entry, algorithm phase, retry boundary | Public counters: item count, frame index, batch size. No content labels. |
+| thermal | Sustained workload dwell, e.g. `CanvasRenderDwell` | `thermalState` transition, shed action | Thermal state and FPS cap are public; user/session identifiers stay private. |
+| battery | Foreground or background energy window, e.g. `BackgroundSync` | Lifecycle transition, radio wake, background task start/end | Public counts and durations only; URLs, channels, and account ids stay private. |
+
+## Patch-ready brief seed
+
+When a required signpost is absent, Apollo emits a brief seed instead of recommending a performance fix:
+
+```yaml
+dispatch_agent: achilles
+kind: impl
+title: Add Apollo signposts for <scenario-id>
+body:
+  goal: Add OSSignposter points of interest required by Apollo scenario <scenario-id>.
+  acceptance:
+    - Required intervals from the signpost plan are emitted in Release builds.
+    - Public metadata keys match the plan and contain no user data.
+    - A trace for the scenario shows the expected interval/event names.
+evidence:
+  artifacts:
+    - ~/.dev-studio/<project>/apollo/scenarios/<scenario-id>.yaml
+    - ~/.dev-studio/<project>/apollo/signpost-plans/<plan-id>.yaml
+```
+
+## Missing-signpost policy
+
+| Situation | Apollo behavior |
+|---|---|
+| Scenario declares required signposts that are absent before capture | `block-before-capture`; emit the brief seed above |
+| Capture finishes but a required signpost is missing | `retry-once` with corrected scenario/instrumentation; second miss emits `apollo_refused` with `reason: signpost_missing` |
+| Signpost would expose private data | Replace payload with public count/category, or mark metadata private and do not use it for MetricKit aggregation |
+| User cannot add instrumentation | Downgrade to `advisory-only`; no strict-9 recommendation can cite the missing interval |
+
+## Procedure
+
+1. **READ** the Apollo scenario.
+   Before: scenario is validated by `_shared/contracts/apollo-scenario.schema.json`.
+   After: flow steps, metric targets, and expected artifacts are known.
+
+2. **WRITE** a signpost plan.
+   Before: scenario metric targets are known.
+   After: each required interval/event has placement, privacy, and acceptance text.
+
+3. **CHECK** captured artifacts for expected signposts.
+   Before: trace, MetricKit payload, or `.xcresult` exists.
+   After: Apollo proceeds, retries once, or refuses with `reason: signpost_missing`.
+
+## See also
+
+- `_shared/contracts/apollo-signpost-plan.schema.json`
+- `apollo/_shared/primitives/signposts.md`
+- `apollo/_shared/primitives/scenarios.md`
+- `apollo/_shared/primitives/evidence-gate.md`

--- a/apollo/_shared/primitives/signposts.md
+++ b/apollo/_shared/primitives/signposts.md
@@ -122,6 +122,10 @@ Mode packs cite signposts in two evidence shapes:
 
 Apollo refuses citations that name a signpost without naming the trace file or payload window — see the "vague citation" failure mode in `apollo/_shared/primitives/evidence-gate.md`.
 
+## Assistant plans
+
+Before capture, Apollo can produce a signpost plan from a scenario using `apollo/_shared/primitives/signpost-assistant.md`. Plans are patch-ready instrumentation briefs: they name interval/event placement, public metadata keys, and missing-signpost policy. The schema is `_shared/contracts/apollo-signpost-plan.schema.json`.
+
 ## Why
 
 Signposts are the only mechanism that produces evidence equally usable in development (Instruments traces) and production (MetricKit aggregates). XCTest baselines cover the dev-loop regression bar; MetricKit covers fleet drift; signposts are the named-workload anchor that links them. Without them, dev-loop and fleet measure different things at different layers and Apollo's regression-detection math (`apollo/_shared/primitives/regression-detection.md`, Stage 1b) cannot compare across sources.
@@ -131,6 +135,7 @@ The privacy default (`.private`) is what makes the "tag measurement-grade numeri
 ## See also
 
 - `apollo/_shared/primitives/evidence-gate.md`
+- `apollo/_shared/primitives/signpost-assistant.md` — scenario-driven signpost plans
 - `apollo/_shared/primitives/metrickit.md` — `MXSignpostMetric` consumer side
 - `apollo/_shared/primitives/xctest-baselines.md` (Stage 1b) — `XCTOSSignpostMetric`
 - WWDC18 405 — Measuring Performance Using Logging

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T22:54:15Z",
+  "generated_at": "2026-05-01T23:02:17Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/411-apollo-signpost-assistant/test-apollo-signpost-plan-schema.sh
+++ b/scripts/test-fixtures/411-apollo-signpost-assistant/test-apollo-signpost-plan-schema.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+DIR="$ROOT/tests/fixtures/apollo/signpost-plans"
+
+"$ROOT/scripts/validate-contract.sh" apollo-signpost-plan "$DIR/feed-scroll-cpu.yaml"
+"$ROOT/scripts/validate-contract.sh" apollo-signpost-plan "$DIR/multi-mode.yaml"
+
+if "$ROOT/scripts/validate-contract.sh" apollo-signpost-plan "$DIR/invalid-private-required.yaml" >/dev/null 2>&1; then
+  printf 'expected invalid signpost plan to fail validation\n' >&2
+  exit 1
+fi
+
+printf 'PASS: Apollo signpost plan schema validation\n'

--- a/scripts/validate-contract.sh
+++ b/scripts/validate-contract.sh
@@ -7,7 +7,7 @@
 # Usage:
 #   scripts/validate-contract.sh <schema-name> <file>
 #
-# <schema-name>: worker-report | debrief | review-verdict | handoff | apollo-scenario | apollo-code-area
+# <schema-name>: worker-report | debrief | review-verdict | handoff | apollo-scenario | apollo-code-area | apollo-signpost-plan
 # <file>:        path to artifact (JSON or YAML — check-jsonschema handles both)
 #
 # Exit 0  — payload is valid against the named schema.
@@ -38,8 +38,9 @@ case "$SCHEMA_NAME" in
   handoff)         SCHEMA_FILE="$REPO_ROOT/_shared/contracts/handoff.schema.json" ;;
   apollo-scenario) SCHEMA_FILE="$REPO_ROOT/_shared/contracts/apollo-scenario.schema.json" ;;
   apollo-code-area) SCHEMA_FILE="$REPO_ROOT/_shared/contracts/apollo-code-area.schema.json" ;;
+  apollo-signpost-plan) SCHEMA_FILE="$REPO_ROOT/_shared/contracts/apollo-signpost-plan.schema.json" ;;
   *)
-    printf 'validate-contract: unknown schema %s (want worker-report|debrief|review-verdict|handoff|apollo-scenario|apollo-code-area)\n' \
+    printf 'validate-contract: unknown schema %s (want worker-report|debrief|review-verdict|handoff|apollo-scenario|apollo-code-area|apollo-signpost-plan)\n' \
       "$SCHEMA_NAME" >&2
     exit 2
     ;;

--- a/tests/fixtures/apollo/signpost-plans/feed-scroll-cpu.yaml
+++ b/tests/fixtures/apollo/signpost-plans/feed-scroll-cpu.yaml
@@ -1,0 +1,30 @@
+schema_version:
+  name: apollo-signpost-plan
+  version: 1.0.0
+  min_reader: 1.0.0
+  deprecated_at: null
+plan_id: signpost-plan-feed-scroll-cpu
+scenario:
+  id: feed-scroll-cpu
+  version: 1
+mode_targets: [cpu]
+signposts:
+  - name: FeedScroll
+    kind: interval
+    placement: Wrap the visible feed scroll interaction from first drag event through deceleration end.
+    privacy: public-metadata
+    public_payload_keys: [item_count, visible_count]
+    required_for_recommendation: true
+  - name: FeedPageLoaded
+    kind: event
+    placement: Emit when the next feed page finishes decoding and diffing.
+    privacy: public-metadata
+    public_payload_keys: [item_count]
+    required_for_recommendation: false
+brief_seed:
+  owner: achilles
+  summary: Add OSSignposter points of interest for feed-scroll-cpu.
+  acceptance:
+    - FeedScroll interval appears in a CPU Profiler trace.
+    - Public payload keys include only counts.
+missing_signpost_policy: block-before-capture

--- a/tests/fixtures/apollo/signpost-plans/invalid-private-required.yaml
+++ b/tests/fixtures/apollo/signpost-plans/invalid-private-required.yaml
@@ -1,0 +1,23 @@
+schema_version:
+  name: apollo-signpost-plan
+  version: 1.0.0
+  min_reader: 1.0.0
+  deprecated_at: null
+plan_id: signpost-plan-invalid-private
+scenario:
+  id: feed-scroll-cpu
+  version: 1
+mode_targets: [cpu]
+signposts:
+  - name: FeedScroll
+    kind: interval
+    placement: Wrap the scroll.
+    privacy: raw-user-data
+    public_payload_keys: [message_text]
+    required_for_recommendation: true
+brief_seed:
+  owner: achilles
+  summary: Invalid signpost plan.
+  acceptance:
+    - This should fail.
+missing_signpost_policy: block-before-capture

--- a/tests/fixtures/apollo/signpost-plans/multi-mode.yaml
+++ b/tests/fixtures/apollo/signpost-plans/multi-mode.yaml
@@ -1,0 +1,30 @@
+schema_version:
+  name: apollo-signpost-plan
+  version: 1.0.0
+  min_reader: 1.0.0
+  deprecated_at: null
+plan_id: signpost-plan-export-multi
+scenario:
+  id: export-1080p
+  version: 2
+mode_targets: [memory, cpu, thermal, battery]
+signposts:
+  - name: Export1080p
+    kind: interval
+    placement: Wrap export start through file write completion.
+    privacy: public-metadata
+    public_payload_keys: [pixel_width, pixel_height, frame_count]
+    required_for_recommendation: true
+  - name: ThermalShed
+    kind: event
+    placement: Emit when the app reduces work because thermal state changed.
+    privacy: public-metadata
+    public_payload_keys: [thermal_state, fps_cap]
+    required_for_recommendation: true
+brief_seed:
+  owner: achilles
+  summary: Add Apollo signposts for export-1080p.
+  acceptance:
+    - Export1080p brackets the full export flow.
+    - ThermalShed event is emitted when load shedding runs.
+missing_signpost_policy: retry-once


### PR DESCRIPTION
## Summary
- add a portable Apollo signpost plan schema and assistant primitive
- document memory, CPU, thermal, and battery signpost patterns plus privacy guidance
- add patch-ready brief seed shape and missing-signpost policy
- add valid/invalid signpost plan fixtures and validation coverage

Closes #411

## Verification
- scripts/lint-host-agnostic.sh --staged
- scripts/lint-architecture.sh --staged
- scripts/lint-comms-boundary.sh --staged
- scripts/lint-skill-prose.sh --staged
- scripts/test-fixtures/411-apollo-signpost-assistant/test-apollo-signpost-plan-schema.sh
- scripts/validate-schema.sh tests/fixtures/apollo/signpost-plans/feed-scroll-cpu.yaml
- git diff --cached --check

Portable: yes