### PR TITLE
Add Apollo guided profile mode

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-01T23:02:17Z",
+  "generated_at": "2026-05-01T23:14:22Z",
   "agents": [
     {
       "name": "studio",
@@ -304,8 +304,8 @@
       "name": "apollo",
       "router": "apollo/SKILL.md",
       "description": "iOS performance agent. Per-metric mode packs (memory/thermal/battery/cpu) under a strict-9 evidence gate. Refuses recommendations without hard evidence; auto-captures via the execution surface.",
-      "reads": ["apollo/_shared/integrations/imgly-and-metal.md", "apollo/_shared/primitives/evidence-gate.md", "apollo/_shared/primitives/instruments-index.md", "apollo/_shared/primitives/metrickit.md", "apollo/_shared/primitives/signposts.md", "apollo/_shared/primitives/source-map.md", "apollo/_shared/primitives/xctest-baselines.md", "~/.dev-studio/.runtime/host-capabilities.yaml", "~/.dev-studio/<project>/apollo/baselines/*.json", "~/.dev-studio/<project>/apollo/captures/**", "~/.dev-studio/<project>/apollo/deferred/*.yaml", "~/.dev-studio/<project>/apollo/scenarios/*.yaml", "~/.dev-studio/<project>/events/**.jsonl"],
-      "writes": ["~/.dev-studio/.runtime/locks/apollo/*", "~/.dev-studio/<project>/apollo/captures/<id>/**", "~/.dev-studio/<project>/apollo/deferred/<id>.yaml", "~/.dev-studio/<project>/apollo/recommendations/<id>.md", "~/.dev-studio/<project>/events/<today>.jsonl"],
+      "reads": ["apollo/_shared/integrations/imgly-and-metal.md", "apollo/_shared/primitives/code-attribution.md", "apollo/_shared/primitives/evidence-gate.md", "apollo/_shared/primitives/execution-surface.md", "apollo/_shared/primitives/instruments-index.md", "apollo/_shared/primitives/metrickit.md", "apollo/_shared/primitives/scenarios.md", "apollo/_shared/primitives/signpost-assistant.md", "apollo/_shared/primitives/signposts.md", "apollo/_shared/primitives/source-map.md", "apollo/_shared/primitives/xctest-baselines.md", "~/.dev-studio/.runtime/host-capabilities.yaml", "~/.dev-studio/<project>/apollo/baselines/*.json", "~/.dev-studio/<project>/apollo/captures/**", "~/.dev-studio/<project>/apollo/deferred/*.yaml", "~/.dev-studio/<project>/apollo/scenarios/*.yaml", "~/.dev-studio/<project>/events/**.jsonl"],
+      "writes": ["~/.dev-studio/.runtime/locks/apollo/*", "~/.dev-studio/<project>/apollo/captures/<id>/**", "~/.dev-studio/<project>/apollo/deferred/<id>.yaml", "~/.dev-studio/<project>/apollo/recommendations/<id>.md", "~/.dev-studio/<project>/apollo/scenarios/<scenario-id>.yaml", "~/.dev-studio/<project>/apollo/signpost-plans/<plan-id>.yaml", "~/.dev-studio/<project>/events/<today>.jsonl"],
       "modes": [
         {
           "name": "battery",
@@ -350,6 +350,17 @@
           "snapshots": [],
           "dry_run": false,
           "budget_tokens": 6000
+        },
+        {
+          "name": "profile",
+          "path": "apollo/modes/profile.md",
+          "type": "mode-pack",
+          "description": "Guided on-device profiling conductor. Turns intake, scenario, signpost plan, capture, artifact export, attribution, recommendation, and post-fix verification into a strict-9 session workflow.",
+          "reads": ["apollo/_shared/primitives/source-map.md", "apollo/_shared/primitives/scenarios.md", "apollo/_shared/primitives/signpost-assistant.md", "apollo/_shared/primitives/code-attribution.md", "apollo/_shared/primitives/evidence-gate.md", "apollo/_shared/primitives/execution-surface.md", "~/.dev-studio/.runtime/host-capabilities.yaml", "~/.dev-studio/<project>/apollo/scenarios/*.yaml"],
+          "writes": ["~/.dev-studio/<project>/apollo/scenarios/<scenario-id>.yaml", "~/.dev-studio/<project>/apollo/signpost-plans/<plan-id>.yaml", "~/.dev-studio/<project>/apollo/captures/<id>/**", "~/.dev-studio/<project>/apollo/deferred/<id>.yaml", "~/.dev-studio/<project>/events/<today>.jsonl"],
+          "snapshots": [],
+          "dry_run": false,
+          "budget_tokens": 5000
         },
         {
           "name": "thermal",

--- a/apollo/README.md
+++ b/apollo/README.md
@@ -27,6 +27,7 @@ Performance work is orthogonal to feature work. Bolting it onto Argus would bloa
 | `thermal` | thermal throttling, sustained CPU, GPU heat | `MXMetaData.thermalState` distribution, CPU Counters / Time Profiler `.trace`, Metal System Trace, Energy Log |
 | `battery` | foreground energy, cumulative CPU per hour, drain regressions | `MXAppRunTimeMetric`, ASC Performance Metrics power row, Energy Log, `MXCPUMetric` |
 | `cpu` | foreground CPU spikes, hot paths, main-thread saturation, CPU diagnostics | CPU Profiler / Time Profiler `.trace`, CPU Counters, Processor Trace, System Trace, `MXCPUMetric`, `MXCPUExceptionDiagnostic`, `XCTCPUMetric` |
+| `profile` | guided real-device profiling session; orchestrates scenario, signposts, capture, attribution, and verification | Delegates evidence to memory / CPU / thermal / battery modes |
 
 Phase 2 modes (launch-time, scroll-perf, binary-size, network-efficiency) are deferred. Each mode is a single mode pack at `apollo/modes/<name>.md`; the dispatch table in `apollo/SKILL.md` is the single source of truth for triggers.
 
@@ -134,6 +135,7 @@ apollo/
     thermal.md               # #231
     battery.md               # #232
     cpu.md                   # #406
+    profile.md               # #410
   _shared/primitives/        # cross-cutting primitives
     evidence-gate.md         # strict-9 contract
     execution-surface.md     # capability matrix

--- a/apollo/SKILL.md
+++ b/apollo/SKILL.md
@@ -56,6 +56,7 @@ The gate is the load-bearing invariant. Every mode pack's entry conditions cite 
 | `battery` / "battery drain" / "energy regression" | `modes/battery.md` | Stage 2c — #232, shipped |
 | `cpu` / "CPU spike" / "high CPU" / "main-thread CPU" | `modes/cpu.md` | Apollo expansion — #406, shipped |
 | `measure <metric>` / `--capture-only` | `modes/measure.md` | Stage 5 — #235, shipped |
+| `profile` / "guided profiling session" / "run this flow on device" | `modes/profile.md` | Apollo expansion — #410, shipped |
 | *(no args or free-text)* | infer metric from cited artifact / prompt for one of {memory, thermal, battery, cpu} | router-only until Stage 2 |
 
 Phase 2 modes (launch-time, scroll-perf, binary-size, network-efficiency) are deferred. Adding a mode = one file under `modes/`, one dispatch row, one fixture at `tests/mode-packs/apollo/<mode>.yaml`. Same rule as every other router in this repo.

--- a/apollo/docs.html
+++ b/apollo/docs.html
@@ -358,6 +358,11 @@ Resume with `apollo &lt;mode&gt; --evidence &lt;path&gt;`.</code></pre>
         <div class="status shipping-soon">Stage 5 · #235</div>
         <div class="what">Capture-only path. Produces one hard-evidence artifact for a named metric on a named cohort, then exits — no fix, no patch dispatch. Pre-flight tool for Chanakya brief authoring (populates <code>evidence.artifacts[]</code>) and for cohort re-capture after a perf-merge refusal. <code>--capture-only</code> alias on the diagnostic mode packs has the same effect.</div>
       </div>
+      <div class="mode-card">
+        <code>/apollo profile</code>
+        <div class="status shipping-soon">Apollo expansion · #410</div>
+        <div class="what">Guided real-device profiling conductor. Creates or validates a scenario, checks signposts, guides Xcode/Instruments or on-device Performance Trace capture, then hands analysis to the selected metric mode.</div>
+      </div>
     </div>
     <h3>Perf-mode dispatch from Chanakya</h3>
     <p>Briefs declared with <code>dispatch_agent: apollo</code> route to Apollo instead of Achilles, with <code>perf_mode</code> selecting the diagnostic mode pack and <code>evidence</code> pre-flighting the strict-9 gate at brief-write time. Argus skips these merges entirely (<code>argus/SKILL.md</code> §Skip threshold) — Apollo's re-measure delta on the brief's cohort is the merge gate. Loop spec: <code>apollo/_shared/primitives/perf-merge-loop.md</code>.</p>

--- a/apollo/modes/profile.md
+++ b/apollo/modes/profile.md
@@ -1,0 +1,123 @@
+---
+name: Apollo profile mode
+description: Guided on-device profiling conductor. Turns intake, scenario, signpost plan, capture, artifact export, attribution, recommendation, and post-fix verification into a strict-9 session workflow.
+type: mode-pack
+schema_version: 1
+snapshots: []
+budget_tokens: 5000
+session_budget: 1800s
+locks:
+  - real-device-{udid}
+  - xctrace-{device}
+emits:
+  - apollo_capture_started
+  - apollo_capture_completed
+  - apollo_capture_deferred
+  - apollo_refused
+reads:
+  - apollo/_shared/primitives/source-map.md
+  - apollo/_shared/primitives/scenarios.md
+  - apollo/_shared/primitives/signpost-assistant.md
+  - apollo/_shared/primitives/code-attribution.md
+  - apollo/_shared/primitives/evidence-gate.md
+  - apollo/_shared/primitives/execution-surface.md
+  - ~/.dev-studio/.runtime/host-capabilities.yaml
+  - ~/.dev-studio/<project>/apollo/scenarios/*.yaml
+writes:
+  - ~/.dev-studio/<project>/apollo/scenarios/<scenario-id>.yaml
+  - ~/.dev-studio/<project>/apollo/signpost-plans/<plan-id>.yaml
+  - ~/.dev-studio/<project>/apollo/captures/<id>/**
+  - ~/.dev-studio/<project>/apollo/deferred/<id>.yaml
+  - ~/.dev-studio/<project>/events/<today>.jsonl
+---
+
+# Mode: Profile (`/apollo profile`)
+
+`/apollo profile` is the guided session conductor. It does not diagnose a metric by itself and it does not recommend from conversation. It turns a human-run or automated device workflow into the artifacts required by the metric modes (`memory`, `cpu`, `thermal`, `battery`), then hands analysis to the selected mode.
+
+## Session phases
+
+| Phase | Human-run responsibility | Automated / Apollo responsibility | Output |
+|---|---|---|---|
+| Intake | Name device, OS, build, app install source, suspected metric, and user flow | Normalize metric target; create or load scenario | Valid `apollo-scenario` artifact |
+| Preflight | Pair/unlock real device; confirm Xcode/Instruments access; provide dSYM status | Check `host-capabilities.yaml`, source-map rows, and symbolication readiness | Preflight pass or blocker |
+| Signpost plan | Approve instrumentation points or existing signposts | Generate `apollo-signpost-plan`; block if required signposts are absent | Patch-ready brief seed or capture-ready plan |
+| Capture plan | Follow Xcode/Instruments/on-device Performance Trace steps | Select templates: CPU Profiler, Time Profiler, Power Profiler, Allocations, System Trace, MetricKit/Organizer | Ordered capture checklist |
+| Guided run | Start capture, perform scenario steps, stop/export artifacts | Record expected artifact paths and sidecars | `apollo/captures/<id>/` |
+| Analysis handoff | Provide exported `.trace`, `.xcresult`, MetricKit, Organizer, or Performance Trace bundle | Dispatch to metric mode; validate strict-9 evidence; run code-area attribution | Recommendation, refusal, or advisory |
+| Post-fix | Re-run matched scenario on same cohort | Compare axes from scenario + mode; refuse weak completion claims | Verification verdict |
+
+## Capture sources
+
+| Source | Use | Gate |
+|---|---|---|
+| Local Xcode-connected Instruments | Preferred for reproducible CPU, memory, thermal, and battery scenarios | Requires real-device pairing for power/thermal and target-cohort CPU |
+| `xctrace` automated run | Preferred when AXe/XCTest can drive the flow | Requires scenario + signpost interval |
+| On-device Performance Trace | Human-run fallback when the issue occurs away from the Mac | Requires exported trace bundle, build, cohort, and dSYM/symbolication path |
+| MetricKit / Organizer / ASC | Field-only or post-release confirmation | Requires payload window, cohort, build, and dSYM status |
+
+## Blocker states
+
+| Blocker | Response |
+|---|---|
+| Missing metric target | Ask once for one of `memory`, `cpu`, `thermal`, `battery`; do not guess |
+| Missing scenario details | Write scenario draft and stop before capture |
+| Required signpost absent | Emit signpost brief seed; block before capture or retry once after instrumentation |
+| Host capability unavailable | Emit strict-9 refusal with `capability_unavailable`; allow `--evidence <path>` resume |
+| dSYM / symbolication missing | Capture may be retained, but code-area attribution is blocked |
+| Cohort mismatch | Re-capture or re-baseline; do not compare across device/OS/build axes |
+| Artifact exported but strict-9 fields missing | Refuse with exact missing fields and unblock recipe |
+
+## Procedure
+
+1. **READ** intake and resolve metric target.
+   Before: user invokes `/apollo profile` with free text or flags.
+   After: one or more metric targets are selected, or Apollo asks once and stops.
+
+2. **WRITE** or validate the scenario.
+   Before: user flow and cohort are known.
+   After: `apollo/_shared/primitives/scenarios.md` contract is satisfied.
+
+3. **CHECK** signposts.
+   Before: scenario exists.
+   After: required points of interest are present, or `apollo/_shared/primitives/signpost-assistant.md` emits a patch-ready brief seed.
+
+4. **RUN** capture or guide the human-run capture.
+   Before: host/device/capability preflight passes.
+   After: artifact sidecar links scenario id/version, template, cohort, and compare axes.
+
+5. **PROCEED** to the metric mode.
+   Before: artifacts exist.
+   After: selected mode evaluates strict-9 evidence and code-area attribution.
+
+6. **CHECK** post-fix verification.
+   Before: patch lands or user asks whether it is fixed.
+   After: matched rerun verifies, partially verifies, regresses, or refuses the claim.
+
+## Failure modes
+
+| Failure | Classification | Response |
+|---|---|---|
+| Metric target missing after intake | permanent | Ask once for one of `memory`, `cpu`, `thermal`, `battery`; stop without capture |
+| Scenario cannot be made valid | permanent | Write the invalid fields and required scenario schema; stop before capture |
+| Required signpost absent | ambiguous | Emit a signpost assistant brief seed; retry once after instrumentation, then refuse with `reason: signpost_missing` |
+| Host cannot capture and no evidence path was supplied | permanent | Emit strict-9 refusal with `reason: capability_unavailable` and `--evidence <path>` resume recipe |
+| Real device unavailable for real-device-only metric | permanent | Refuse the capture; simulator is not a substitute for battery, thermal, or target-cohort CPU evidence |
+| dSYM or symbolication missing | ambiguous | Keep the artifact but block code-area attribution until symbols resolve |
+| Capture exceeds session budget | transient | Write `apollo/deferred/<id>.yaml` and report the deferred capture recipe |
+| Post-fix rerun does not match scenario/cohort/template axes | permanent | Refuse the completion claim and require matched rerun |
+
+## Non-goals
+
+- Do not replace `memory`, `cpu`, `thermal`, or `battery`; profile orchestrates them.
+- Do not recommend fixes without artifacts.
+- Do not require every scenario to be automatable.
+- Do not embed SwiftUI, Imgly, or Metal domain internals; use code-area ownership routing.
+
+## See also
+
+- `apollo/_shared/primitives/scenarios.md`
+- `apollo/_shared/primitives/signpost-assistant.md`
+- `apollo/_shared/primitives/code-attribution.md`
+- `apollo/_shared/primitives/evidence-gate.md`
+- `apollo/modes/{memory,cpu,thermal,battery}.md`

--- a/apollo/routing.yaml
+++ b/apollo/routing.yaml
@@ -8,6 +8,7 @@ invocation:
     - "/apollo thermal"
     - "/apollo battery"
     - "/apollo cpu"
+    - "/apollo profile"
     - "/apollo measure <metric>"
     - "/apollo memory --capture-only"
     - "/apollo thermal --capture-only"
@@ -21,6 +22,8 @@ invocation:
     - "device heat"
     - "energy regression"
     - "high CPU"
+    - "guided profiling session"
+    - "run this flow on device"
     - "where were we on perf"
 domains:
   - turnip-ios

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T23:02:17Z",
+  "generated_at": "2026-05-01T23:14:22Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},
@@ -28,6 +28,7 @@
     {"name": "apollo.cpu", "source": "apollo/modes/cpu.md", "agent": "apollo", "mode": "cpu", "description": "Diagnose -> measure -> attribute -> recommend -> verify protocol for CPU regressions under strict-9 evidence gating. Covers hot paths, main-thread saturation, off-CPU waits, and field CPU diagnostics."},
     {"name": "apollo.measure", "source": "apollo/modes/measure.md", "agent": "apollo", "mode": "measure", "description": "Capture-only mode for hard-evidence artifacts without recommending a fix. Pre-flight tool for Apollo perf briefs with empty evidence artifacts."},
     {"name": "apollo.memory", "source": "apollo/modes/memory.md", "agent": "apollo", "mode": "memory", "description": "Diagnose → measure → propose → patch → re-measure protocol for memory regressions under strict-9 evidence gating. Covers transient peaks, persistent growth, leaks, and OOM kills."},
+    {"name": "apollo.profile", "source": "apollo/modes/profile.md", "agent": "apollo", "mode": "profile", "description": "Guided on-device profiling conductor. Turns intake, scenario, signpost plan, capture, artifact export, attribution, recommendation, and post-fix verification into a strict-9 session workflow."},
     {"name": "apollo.thermal", "source": "apollo/modes/thermal.md", "agent": "apollo", "mode": "thermal", "description": "Diagnose → measure → propose → patch → re-measure protocol for thermal regressions under strict-9 evidence gating. Covers sustained-load throttle, hang-under-thermal, CPU hot loops, and GPU-rooted heat."},
     {"name": "argus.code-quality", "source": "argus/modes/code-quality.md", "agent": "argus", "mode": "code-quality", "description": "Stage 2 of two-stage Argus review. Cross-file regressions, edge cases, diff anomalies, secrets, base-branch staleness, M/L test run, TDD red→green. Runs iff Stage 1 returned approved or flagged. Previously the sole Argus pass; split 2026-04-23."},
     {"name": "argus.spec-compliance", "source": "argus/modes/spec-compliance.md", "agent": "argus", "mode": "spec-compliance", "description": "Stage 1 of the two-stage Argus review. Narrow check — does the diff match the brief? Nothing extra, nothing missed. Runs before code-quality. Drawn from obra/superpowers/subagent-driven-development."},

--- a/tests/mode-packs/apollo/profile.yaml
+++ b/tests/mode-packs/apollo/profile.yaml
@@ -1,0 +1,24 @@
+# Skill-testing fixture for apollo/modes/profile.md
+schema: 1
+pack: apollo/modes/profile.md
+scenario: |
+  User says: "/apollo profile" and wants to run a feed scroll flow on a real
+  device using Xcode. They know CPU is suspected, but the scenario has no
+  signposts yet and no trace artifact exists.
+
+  Explain what Apollo does next, which parts are human-run versus automated,
+  which blocker state fires, and why Apollo does not recommend a fix yet.
+failure_signals:
+  - "(?i)recommend.*fix.*without.*(trace|artifact|evidence)"
+  - "(?i)profile.*replaces.*cpu"
+  - "(?i)ignore.*signpost"
+success_signals:
+  - "(?i)scenario"
+  - "(?i)signpost.*brief|patch-ready"
+  - "(?i)block.*before.*capture|signpost_missing"
+  - "(?i)human-run"
+  - "(?i)cpu mode|selected metric mode"
+  - "(?i)strict-9"
+notes: |
+  The fixture catches the main regression: treating /apollo profile as a generic
+  advisor instead of a conductor that prepares evidence for metric modes.


### PR DESCRIPTION
## Summary
- add /apollo profile guided profiling mode-pack proposal
- separate human-run setup/capture steps from automated Apollo checks and metric-mode handoff
- document blocker states for missing metrics, scenarios, signposts, host capabilities, symbolication, cohort mismatch, and weak artifacts
- update Apollo router/docs/readme plus fixture coverage

Closes #410

## Verification
- scripts/lint-host-agnostic.sh --staged
- scripts/lint-architecture.sh --staged
- scripts/lint-comms-boundary.sh --staged
- scripts/lint-skill-prose.sh --staged
- scripts/lint-mode-pack.sh apollo/modes/profile.md
- scripts/test-mode-pack.sh validate apollo/modes/profile.md
- git diff --cached --check

Portable: yes