### PR TITLE
Normalize sweep debrief ingest kinds

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,22 +19,22 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#384](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/384) Sweep ingestion should normalize enumerator debrief kinds | Small, direct sweep correctness bug; closes a known strand-with-success path before broader sweep work. |
-| 2 | [#335](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/335) Make test cases come from debrief YAML only | Removes a remaining split-brain artifact path while the YAML/debrief contract is already in focus. |
-| 3 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed as dashboard noise during the freeze. |
-| 4 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review timeouts, base-staleness consistency, and staged handoff payloads before merge-gate changes. |
-| 5 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
-| 6 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
-| 7 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
-| 8 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
-| 9 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
-| 10 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
+| 1 | [#335](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/335) Make test cases come from debrief YAML only | Removes a remaining split-brain artifact path while the YAML/debrief contract is already in focus. |
+| 2 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed as dashboard noise during the freeze. |
+| 3 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review timeouts, base-staleness consistency, and staged handoff payloads before merge-gate changes. |
+| 4 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
+| 5 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
+| 6 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
+| 7 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
+| 8 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
+| 9 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
+| 10 | [#203](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/203) Achilles debug mode + bug-fix flow rewrite | First capability-next item after the remaining safety-floor work; improves bug localization without starting a new feature arc. |
 
 ## Freeze Plan of Record
 
 Stay inside the Forge reliability freeze until this list clears or the user explicitly waives a named issue.
 
-1. Land low-ambiguity implementation fixes first: #384, #335, #240.
+1. Land low-ambiguity implementation fixes first: #335, #240.
 2. Slice the larger ready work instead of bundling it: #223 first, then #76.
 3. Run a short design pass before coding policy-sensitive or environment-sensitive work: #336, #313, #372, #224, #322.
 4. Keep new feature arcs parked. Phase 2.7, Host-agnostic Chanakya v2, Build-opt v2, Lu Ban, dashboard, and new mode packs remain blocked by the freeze.
@@ -84,7 +84,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#364](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/364) Analyze collection must be host-agnostic and `.dev-studio`-first | Closed | Reliability bug | Analysis can falsely report no usable surface when runtime artifacts exist under `.dev-studio` but host-specific memory is missing. |
 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass with non-canonical task IDs suppresses event emission and sweep hooks | Closed | Reliability bug | Direct artifact creation can bypass lib-ledger contracts and make downstream hooks silently no-op. |
 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows from sweeps | Closed | Reliability bug | Event-log loss makes sweeps and analytics falsely precise unless gaps are bounded and recoverable. |
-| [#384](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/384) Sweep ingestion should normalize enumerator debrief kinds | Open | Reliability bug | Sweep must not continue as successful when enumerator and ingester vocabularies diverge. |
+| [#384](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/384) Sweep ingestion should normalize enumerator debrief kinds | Closed | Reliability bug | Sweep must not continue as successful when enumerator and ingester vocabularies diverge. |
 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Open | Reliability bug | Host parity claims are false if Codex cannot resolve private commits or run canonical project tests. |
 | [#335](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/335) Make test cases come from debrief YAML only | Open | Safety-floor hardening | Test-case evidence should have one canonical source, not drift between YAML and legacy markdown. |
 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Open | Reliability bug | Alternate deployed layouts and alternate HOME roots must not resolve different briefs for the same task. |

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T09:36:59Z",
+  "generated_at": "2026-05-02T09:52:07Z",
   "agents": [
     {
       "name": "studio",

--- a/chanakya/modes/inbox-sweep.md
+++ b/chanakya/modes/inbox-sweep.md
@@ -32,7 +32,7 @@ First `/chanakya` invocation in a session (no `--auto-sweep`): proceed directly 
 
 ## Step 0 — Enumerate + ingest debriefs
 
-Run `scripts/sweep-enumerate-debriefs.sh`. Stdout is tab-separated `<kind>\t<path>\t<mode>` ingestable lines. For each stdout line, invoke `scripts/sweep-ingest.sh <kind> <path> [flags]`. Stderr may also contain diagnostic blind-spot lines (`mode=legacy`, `location=chanakya-inbox`, `stale_blocker=true`, or active Apollo deferred rows) plus a count summary; surface those to the user, but do not pass them to `sweep-ingest.sh`.
+Run `scripts/sweep-enumerate-debriefs.sh`. Stdout is tab-separated `<subcommand>\t<path>\t<mode>` ingestable lines, where `<subcommand>` is one of `debrief`, `build-check`, or `release`. For each stdout line, invoke `scripts/sweep-ingest.sh <subcommand> <path> [flags]`. Stop the sweep and surface stderr if any ingest exits non-zero; do not continue as though that item was handled. Stderr may also contain diagnostic blind-spot lines (`mode=legacy`, `location=chanakya-inbox`, `stale_blocker=true`, or active Apollo deferred rows) plus a count summary; surface those to the user, but do not pass them to `sweep-ingest.sh`.
 
 ### 0A — Uniform debrief ingest (task + direct-debrief)
 

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T09:36:58Z",
+  "generated_at": "2026-05-02T09:52:07Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -105,7 +105,7 @@ scripts/argus-emit-verdict.sh T001 approved '[]' --task-uuid <uuid> # YAML verdi
 scripts/emit-agent-session-completed.sh argus review T001 auto:T001 --verdict approved   # shared session-close (any agent); auto: resolves start-ts from emit-agent-boot stamp
 
 # Chanakya inbox sweep — mechanical extractions from modes/inbox-sweep.md (Phase 2.6.5):
-scripts/sweep-enumerate-debriefs.sh                     # stdout: ingestable debrief queue; stderr: blind-spot diagnostics
+scripts/sweep-enumerate-debriefs.sh                     # stdout: canonical ingest queue (debrief/build-check/release); stderr: blind-spot diagnostics
 scripts/sweep-ingest.sh debrief <path> [--argus-exempt] # Step 0A — task + direct-debrief ingest (follow-ups, back-refs, state flip)
 scripts/sweep-ingest.sh build-check <path>              # Step 0B — debt counter reset/hold, TBUILD auto-file on red
 scripts/sweep-ingest.sh release <path>                  # Step 0B2 — release artifact + per-task release back-ref

--- a/scripts/sweep-enumerate-debriefs.sh
+++ b/scripts/sweep-enumerate-debriefs.sh
@@ -2,14 +2,16 @@
 # sweep-enumerate-debriefs.sh — Step 0 of the inbox sweep.
 #
 # Enumerates unprocessed debrief artifacts under plans/debriefs/*.yaml with
-# state=emitted. Classifies each by kind and prints one tab-separated triple
-# per ingestable line on stdout:
+# state=emitted. Classifies each by ingest subcommand and prints one
+# tab-separated triple per ingestable line on stdout:
 #
-#   <kind>\t<path>\tyaml
+#   <subcommand>\t<path>\tyaml
 #
-#   kind ∈ {task-debrief, manual-build-check, release, direct-debrief}
+#   subcommand ∈ {debrief, build-check, release}
 #
-# (The trailing `yaml` column is retained for caller back-compat.)
+# (The trailing `yaml` column is retained for caller back-compat. Debrief
+# modes such as task vs direct-debrief stay in the YAML; the ingest command is
+# always the canonical sweep-ingest.sh subcommand.)
 #
 # Non-ingestable blind spots are diagnostics, not queue items. They print to
 # stderr so existing stdout consumers keep parsing only ingestable rows:
@@ -101,15 +103,15 @@ if [ -n "$DEBRIEFS_DIR" ] && [ -d "$DEBRIEFS_DIR" ] && command -v yq >/dev/null 
     case "$mode" in
       task)
         if [ -z "$task_id" ] || [ "$task_id" = "null" ]; then
-          printf 'direct-debrief\t%s\tyaml\n' "$yaml"
+          printf 'debrief\t%s\tyaml\n' "$yaml"
           yaml_count=$((yaml_count + 1))
         else
-          printf 'task-debrief\t%s\tyaml\n' "$yaml"
+          printf 'debrief\t%s\tyaml\n' "$yaml"
           yaml_count=$((yaml_count + 1))
         fi
         ;;
       manual-build-check)
-        printf 'manual-build-check\t%s\tyaml\n' "$yaml"
+        printf 'build-check\t%s\tyaml\n' "$yaml"
         yaml_count=$((yaml_count + 1))
         ;;
       release)
@@ -118,12 +120,12 @@ if [ -n "$DEBRIEFS_DIR" ] && [ -d "$DEBRIEFS_DIR" ] && command -v yq >/dev/null 
         ;;
       direct-debrief)
         # Pre-2.0.1 naming; treat as direct-debrief regardless of task_id.
-        printf 'direct-debrief\t%s\tyaml\n' "$yaml"
+        printf 'debrief\t%s\tyaml\n' "$yaml"
         yaml_count=$((yaml_count + 1))
         ;;
       *)
-        # Unknown mode — surface as task-debrief so it's at least visible.
-        printf 'task-debrief\t%s\tyaml\n' "$yaml"
+        # Unknown mode — surface as a normal debrief so it's at least visible.
+        printf 'debrief\t%s\tyaml\n' "$yaml"
         yaml_count=$((yaml_count + 1))
         ;;
     esac

--- a/scripts/sweep-ingest.sh
+++ b/scripts/sweep-ingest.sh
@@ -30,6 +30,8 @@ SRC="${2:-}"
 shift 2 2>/dev/null || true
 
 case "$SUBCMD" in
+  task-debrief|direct-debrief) SUBCMD=debrief ;;
+  manual-build-check) SUBCMD=build-check ;;
   debrief|build-check|release) ;;
   "") printf 'usage: sweep-ingest.sh <debrief|build-check|release> <source-path> [flags]\n' >&2; exit 2 ;;
   *) printf 'unknown subcommand: %s\n' "$SUBCMD" >&2; exit 2 ;;

--- a/scripts/test-fixtures/298-sweep-blind-spots/test-sweep-blind-spots.sh
+++ b/scripts/test-fixtures/298-sweep-blind-spots/test-sweep-blind-spots.sh
@@ -82,7 +82,7 @@ rc=$?
 
 assert "sweep exits zero" "[ $rc -eq 0 ]"
 assert "stdout keeps two ingestable YAML rows" "[ \$(wc -l < '$OUT' | tr -d ' ') -eq 2 ]"
-assert "stdout rows remain three-column queue items" "awk -F '\t' 'NF != 3 { exit 1 } \$1 !~ /^(task-debrief|direct-debrief|manual-build-check|release)\$/ { exit 1 }' '$OUT'"
+assert "stdout rows remain three-column queue items" "awk -F '\t' 'NF != 3 { exit 1 } \$1 !~ /^(debrief|build-check|release)\$/ { exit 1 }' '$OUT'"
 assert "legacy md blind spot is diagnosed with remediation" "grep -q 'TEST-debrief.md.*mode=legacy.*remediation=archive-or-migrate-to-plans-debriefs-yaml' '$ERR'"
 assert "misrouted inbox debrief is diagnosed with remediation" "grep -q 'TEST-debrief.yaml.*location=chanakya-inbox.*remediation=move-to-plans-debriefs-yaml' '$ERR'"
 assert "stale Apollo deferral is diagnosed" "grep -q 'TEST.yaml.*stale_blocker=true' '$ERR'"

--- a/scripts/test-fixtures/384-sweep-kind-contract/test-sweep-kind-contract.sh
+++ b/scripts/test-fixtures/384-sweep-kind-contract/test-sweep-kind-contract.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test-sweep-kind-contract.sh — regression fixture for sweep kind routing.
+#
+# The debrief enumerator must emit only canonical sweep-ingest subcommands.
+# Historical aliases remain accepted by sweep-ingest during mixed-version
+# rollout, but they must not appear in new queue rows.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t sweep-kind-contract.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export HOME="$TMPROOT/home"
+export ACHILLES_PROJECT=fixture
+PROJ="$HOME/.dev-studio/fixture"
+mkdir -p "$PROJ/plans/debriefs" "$PROJ/plans/tasks" "$PROJ/plans/releases" "$PROJ/events"
+
+pass=0
+fail=0
+
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+if ! command -v yq >/dev/null 2>&1; then
+  printf 'SKIP: yq required for sweep kind contract fixture\n'
+  exit 0
+fi
+
+cat > "$PROJ/plans/debriefs/001-task.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: task
+task_id: task-1
+legacy_task_id: T001
+YAML
+
+cat > "$PROJ/plans/debriefs/002-direct.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: direct-debrief
+task_id: null
+YAML
+
+cat > "$PROJ/plans/debriefs/003-build.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: manual-build-check
+result: inconclusive
+YAML
+
+cat > "$PROJ/plans/debriefs/004-release.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: release
+tag: TF-384
+channel: testflight
+version: 1.0.0
+build_number: 384
+tasks: []
+YAML
+
+OUT="$TMPROOT/stdout.txt"
+ERR="$TMPROOT/stderr.txt"
+bash "$ROOT/scripts/sweep-enumerate-debriefs.sh" >"$OUT" 2>"$ERR"
+rc=$?
+
+assert "enumerator exits zero" "[ $rc -eq 0 ]"
+assert "enumerator emits four queue rows" "[ \$(wc -l < '$OUT' | tr -d ' ') -eq 4 ]"
+assert "enumerator emits only canonical ingest subcommands" \
+  "awk -F '\t' 'NF != 3 { exit 1 } \$1 !~ /^(debrief|build-check|release)\$/ { exit 1 }' '$OUT'"
+assert "enumerator does not emit historical aliases" \
+  "! awk -F '\t' '\$1 ~ /^(task-debrief|direct-debrief|manual-build-check)\$/ { found=1 } END { exit found ? 0 : 1 }' '$OUT'"
+assert "task and direct debriefs both route through debrief" \
+  "[ \$(awk -F '\t' '\$1 == \"debrief\" { n++ } END { print n + 0 }' '$OUT') -eq 2 ]"
+assert "manual build check routes through build-check" \
+  "awk -F '\t' '\$1 == \"build-check\" && \$2 ~ /003-build.yaml\$/ { found=1 } END { exit found ? 0 : 1 }' '$OUT'"
+assert "release routes through release" \
+  "awk -F '\t' '\$1 == \"release\" && \$2 ~ /004-release.yaml\$/ { found=1 } END { exit found ? 0 : 1 }' '$OUT'"
+
+cat > "$PROJ/plans/debriefs/alias-task.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: task
+YAML
+
+cat > "$PROJ/plans/debriefs/alias-direct.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: direct-debrief
+YAML
+
+cat > "$PROJ/plans/debriefs/alias-build.yaml" <<'YAML'
+schema: debrief@2.0.2
+state: emitted
+mode: manual-build-check
+result: inconclusive
+YAML
+
+bash "$ROOT/scripts/sweep-ingest.sh" task-debrief "$PROJ/plans/debriefs/alias-task.yaml" >/dev/null 2>"$TMPROOT/alias-task.err"
+alias_task_rc=$?
+bash "$ROOT/scripts/sweep-ingest.sh" direct-debrief "$PROJ/plans/debriefs/alias-direct.yaml" >/dev/null 2>"$TMPROOT/alias-direct.err"
+alias_direct_rc=$?
+bash "$ROOT/scripts/sweep-ingest.sh" manual-build-check "$PROJ/plans/debriefs/alias-build.yaml" >/dev/null 2>"$TMPROOT/alias-build.err"
+alias_build_rc=$?
+
+assert "task-debrief alias still normalizes" "[ $alias_task_rc -eq 0 ]"
+assert "direct-debrief alias still normalizes" "[ $alias_direct_rc -eq 0 ]"
+assert "manual-build-check alias still normalizes" "[ $alias_build_rc -eq 0 ]"
+
+printf '%s assertions, %s failures\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary
- Emit canonical sweep-ingest subcommands from sweep enumeration: debrief, build-check, release.
- Normalize historical sweep kind aliases in sweep-ingest during mixed-version rollout.
- Add a regression fixture for the enumerator/ingester contract and refresh the Forge reliability tracker.

## Verification
- bash scripts/test-fixtures/384-sweep-kind-contract/test-sweep-kind-contract.sh
- bash scripts/test-fixtures/298-sweep-blind-spots/test-sweep-blind-spots.sh
- bash scripts/test-fixtures/316-sweep-lifecycle-reconcile/test-sweep-lifecycle-reconcile.sh
- bash scripts/test-fixtures/359-sweep-phase-timing/test-sweep-phase-timing.sh
- bash -n scripts/sweep-enumerate-debriefs.sh scripts/sweep-ingest.sh scripts/test-fixtures/384-sweep-kind-contract/test-sweep-kind-contract.sh scripts/test-fixtures/298-sweep-blind-spots/test-sweep-blind-spots.sh scripts/test-fixtures/316-sweep-lifecycle-reconcile/test-sweep-lifecycle-reconcile.sh scripts/test-fixtures/359-sweep-phase-timing/test-sweep-phase-timing.sh
- scripts/lint-architecture.sh --staged

Closes #384