### PR TITLE
Protect project-scoped host skill links

### DIFF
--- a/.codex/skills/studio
+++ b/.codex/skills/studio
@@ -1,0 +1,1 @@
+../../.claude/skills/studio

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ scripts/                # multi-worker fleet (BETA)
   achilles-cancel.sh    # remove pending dispatches
   fleet-cleanup.sh      # soft sweep (stale locks, old done/) or --all teardown
   lint-architecture.sh  # staged router/frontmatter checks; --full runs repository-wide audits
+  lint-project-skill-links.sh # blocks missing repo-local project skill discovery links
   test-mode-pack.sh     # skill-testing driver — runs fixtures against mode packs (on-demand, spawns claude -p)
   update-surface-manifest.sh  # regenerates docs-surface.json from command surface
   scaffold-agent.sh     # create new router-pattern-compliant agent skeleton

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T10:35:05Z",
+  "generated_at": "2026-05-02T12:31:01Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T10:35:04Z",
+  "generated_at": "2026-05-02T12:31:00Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -107,6 +107,32 @@ if [ -n "$audit_out" ]; then
   ctx="${ctx}${audit_out}"
 fi
 
+# Project-skill link repair: freshness checks only see canonical mtimes, so a
+# deleted repo-local discovery link needs its own invariant probe.
+project_skill_link_banner() {
+  [ "${STUDIO_SKIP_PROJECT_SKILL_REPAIR:-0}" = "1" ] && return 0
+  local lint_script="$REPO_ROOT/scripts/lint-project-skill-links.sh"
+  [ -x "$lint_script" ] || return 0
+
+  local lint_output
+  if lint_output=$("$lint_script" --host "$STUDIO_HOST" 2>&1); then
+    return 0
+  fi
+
+  if "$lint_script" --host "$STUDIO_HOST" --repair >/dev/null 2>&1 && \
+     "$lint_script" --host "$STUDIO_HOST" >/dev/null 2>&1; then
+    printf '\n\n*Project skill links repaired (%s): repo-local discovery links were missing or stale.*' "$STUDIO_HOST"
+  else
+    printf '\n\n*Project skill link repair failed (%s). Run `scripts/lint-project-skill-links.sh --host %s` and then `scripts/sync-host-skills.sh %s`.*' \
+      "$STUDIO_HOST" "$STUDIO_HOST" "$STUDIO_HOST"
+  fi
+}
+
+project_skill_out=$(project_skill_link_banner 2>/dev/null || true)
+if [ -n "$project_skill_out" ]; then
+  ctx="${ctx}${project_skill_out}"
+fi
+
 # Skill-distribution freshness — re-fan-out the symlink farm if any canonical
 # skill root has been touched since the last sync. Idempotent and silent in
 # the steady state. Background invocation; never blocks the session preamble.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -151,6 +151,7 @@ scripts/ingest-feedback.sh                              # idempotent; silent no-
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer host preflight
 scripts/pr-reviewer-eligibility.sh claude-reviewer      # same reviewer floor for Claude Code; uses CLAUDE_REVIEWER_CONFIG_DIR (default ~/.claude-reviewer)
 scripts/pre-commit-review.sh                            # manual reviewer gate for risky staged diffs; accepts approved/approved_with_fixes only
+scripts/lint-project-skill-links.sh [--host codex]      # repo-local project skill discovery link invariant + repair helper
 scripts/pr-headless-review.sh <pr>                      # run eligible reviewer, post gate, merge if non-blocked
 scripts/pr-autopilot.sh <pr> --verdict approved         # post reviewer gate, then merge if non-blocked
 scripts/pr-merge-finalize.sh <pr> --method auto         # <4 commits=rebase, larger main=merge commit, then fetch/prune

--- a/scripts/lint-architecture.sh
+++ b/scripts/lint-architecture.sh
@@ -588,6 +588,31 @@ main() {
     fi
   fi
 
+  # Project-skill link invariant. This always runs in staged mode because a
+  # plain deletion of .codex/skills/studio is the exact failure class it guards.
+  local psl_lint="$SCRIPT_DIR/lint-project-skill-links.sh"
+  if [ -x "$psl_lint" ]; then
+    local psl_args=()
+    [ "$STAGED" -eq 1 ] && psl_args=("--staged")
+    local psl_output psl_rc psl_errors_before
+    psl_errors_before="$ERRORS"
+    psl_output=$("$psl_lint" ${psl_args[@]+"${psl_args[@]}"} 2>&1)
+    psl_rc=$?
+    if [ -n "$psl_output" ]; then
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        case "$line" in
+          "lint-project-skill-links: "*) ;;
+          E_*) emit_error "$line" ;;
+          *) [ "$psl_rc" -ne 0 ] && emit_error "$line" || emit_warn "$line" ;;
+        esac
+      done <<< "$psl_output"
+    fi
+    if [ "$psl_rc" -ne 0 ] && [ "$ERRORS" -eq "$psl_errors_before" ]; then
+      emit_error "E_PROJECT_SKILL_LINK:lint-project-skill-links exited $psl_rc without a machine-readable error"
+    fi
+  fi
+
   print_findings
   [ "$ERRORS" -eq 0 ]
 }

--- a/scripts/lint-project-skill-links.sh
+++ b/scripts/lint-project-skill-links.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# lint-project-skill-links.sh - enforce repo-local project skill links.
+#
+# For every skill with portability.yaml scope: project, each declared host must
+# have a project_skill_dir entry in hosts/registry.yaml and a repo-local symlink
+# at <project_skill_dir>/<skill-name> pointing at the canonical skill dir.
+#
+# Usage:
+#   scripts/lint-project-skill-links.sh [--staged] [--host <host>] [--repair]
+#
+# Exit 0: all project links are present. Exit 1: invariant drift. Exit 2: bad
+# invocation or missing tooling.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REGISTRY="$REPO_ROOT/hosts/registry.yaml"
+
+STAGED=0
+HOST_FILTER=""
+REPAIR=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --staged) STAGED=1 ;;
+    --repair) REPAIR=1 ;;
+    --host)
+      shift
+      [ $# -gt 0 ] || { printf 'lint-project-skill-links: --host needs a value\n' >&2; exit 2; }
+      HOST_FILTER="$1"
+      ;;
+    -h|--help)
+      sed -n '2,13p' "$0"
+      exit 0
+      ;;
+    *)
+      printf 'lint-project-skill-links: unknown argument %s\n' "$1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if ! command -v yq >/dev/null 2>&1; then
+  printf 'lint-project-skill-links: yq is required\n' >&2
+  exit 2
+fi
+[ -f "$REGISTRY" ] || { printf 'lint-project-skill-links: %s missing\n' "$REGISTRY" >&2; exit 2; }
+
+ERRORS=0
+
+emit_error() {
+  printf '%s\n' "$1" >&2
+  ERRORS=$((ERRORS + 1))
+}
+
+candidate_roots() {
+  ( cd "$REPO_ROOT" && {
+      find . -maxdepth 2 -name 'SKILL.md' -type f \
+        -not -path './.git/*' \
+        -not -path './.claude/*' \
+        -not -path './skills/*' \
+        -not -path './_shared/*' \
+        -not -path './tests/*' \
+        -not -path './docs*' \
+        2>/dev/null
+      find .claude/skills skills/owned skills/vendored \
+        -maxdepth 4 -name 'SKILL.md' -type f 2>/dev/null
+    } \
+    | while IFS= read -r f; do dirname "$f"; done \
+    | sort -u )
+}
+
+resolve_symlink_target() {
+  # $1 = symlink path. Prints an absolute target path, resolving relative
+  # symlinks from the link's containing directory.
+  local link="$1" raw dir base
+  raw=$(readlink "$link") || return 1
+  case "$raw" in
+    /*) printf '%s\n' "$raw" ;;
+    *)
+      dir=$(dirname "$link")
+      base=$(basename "$raw")
+      ( cd "$dir" && cd "$(dirname "$raw")" && printf '%s/%s\n' "$(pwd -P)" "$base" )
+      ;;
+  esac
+}
+
+canonical_path() {
+  # $1 = existing absolute path. Prints the path with a physical parent, so
+  # macOS /var and /private/var spellings compare equal.
+  local path="$1" dir base
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  ( cd "$dir" && printf '%s/%s\n' "$(pwd -P)" "$base" )
+}
+
+symlink_points_to() {
+  # $1 = symlink path, $2 = expected absolute target path.
+  local actual expected
+  [ -L "$1" ] || return 1
+  actual=$(resolve_symlink_target "$1" 2>/dev/null || true)
+  [ -e "$actual" ] && actual=$(canonical_path "$actual" 2>/dev/null || printf '%s\n' "$actual")
+  expected=$(canonical_path "$2" 2>/dev/null || printf '%s\n' "$2")
+  [ "$actual" = "$expected" ]
+}
+
+link_target_for() {
+  # $1 = canonical absolute source, $2 = absolute destination. Project-scoped
+  # links inside this repo are relative so committed host links survive cloned
+  # checkouts and worktree cleanup.
+  local src="$1" dst="$2" src_rel dst_dir dst_rel ups n i
+  case "$src:$dst" in
+    "$REPO_ROOT"/*:"$REPO_ROOT"/*)
+      src_rel="${src#"$REPO_ROOT/"}"
+      dst_dir=$(dirname "$dst")
+      dst_rel="${dst_dir#"$REPO_ROOT/"}"
+      if [ "$dst_rel" = "$dst_dir" ] || [ -z "$dst_rel" ]; then
+        printf '%s\n' "$src_rel"
+        return
+      fi
+      n=$(printf '%s\n' "$dst_rel" | awk -F/ '{print NF}')
+      ups=""
+      i=0
+      while [ "$i" -lt "$n" ]; do
+        ups="../$ups"
+        i=$((i + 1))
+      done
+      printf '%s%s\n' "$ups" "$src_rel"
+      ;;
+    *)
+      printf '%s\n' "$src"
+      ;;
+  esac
+}
+
+repair_missing_link() {
+  # $1 = canonical absolute source, $2 = absolute destination.
+  local src="$1" dst="$2" link_target
+  [ "$REPAIR" -eq 1 ] || return 1
+  [ ! -e "$dst" ] && [ ! -L "$dst" ] || return 1
+  mkdir -p "$(dirname "$dst")" || return 1
+  link_target=$(link_target_for "$src" "$dst")
+  ln -s "$link_target" "$dst" || return 1
+  symlink_points_to "$dst" "$src"
+}
+
+registry_hosts() {
+  yq -r 'keys | .[]' "$REGISTRY" 2>/dev/null
+}
+
+skill_scope() {
+  local rel="$1"
+  local portability="$REPO_ROOT/$rel/portability.yaml"
+  local scope
+  [ -f "$portability" ] || { printf 'global\n'; return; }
+  scope=$(yq -r '.scope // "global"' "$portability" 2>/dev/null)
+  [ -z "$scope" ] || [ "$scope" = "null" ] && scope="global"
+  printf '%s\n' "$scope"
+}
+
+skill_declared_hosts() {
+  local rel="$1"
+  local portability="$REPO_ROOT/$rel/portability.yaml"
+  local host all_hosts
+  [ -f "$portability" ] || return 0
+  while IFS= read -r host; do
+    [ -z "$host" ] || [ "$host" = "null" ] && continue
+    if [ "$host" = "all" ]; then
+      all_hosts=$(registry_hosts)
+      printf '%s\n' "$all_hosts"
+    else
+      printf '%s\n' "$host"
+    fi
+  done < <(yq -r '.hosts[]?' "$portability" 2>/dev/null)
+}
+
+project_skill_dir_for_host() {
+  local host="$1" path
+  path=$(yq -r ".\"$host\".project_skill_dir // \"\"" "$REGISTRY" 2>/dev/null)
+  [ -z "$path" ] || [ "$path" = "null" ] && return 1
+  printf '%s\n' "$REPO_ROOT/$path"
+}
+
+host_exists() {
+  local host="$1"
+  registry_hosts | grep -Fxq "$host"
+}
+
+check_project_skill() {
+  local rel="$1" name host project_dir target
+  name=$(basename "$rel")
+  while IFS= read -r host; do
+    [ -z "$host" ] && continue
+    if [ -n "$HOST_FILTER" ] && [ "$host" != "$HOST_FILTER" ]; then continue; fi
+    if ! host_exists "$host"; then
+      emit_error "E_PROJECT_SKILL_HOST:$rel declares unknown host=$host | add host to hosts/registry.yaml or remove it from portability.yaml"
+      continue
+    fi
+    project_dir=$(project_skill_dir_for_host "$host" || true)
+    if [ -z "$project_dir" ]; then
+      emit_error "E_PROJECT_SKILL_HOST:$rel declares host=$host scope=project but hosts/registry.yaml has no project_skill_dir | add project_skill_dir or remove the host"
+      continue
+    fi
+    target="$project_dir/$name"
+    # Canonical skill already lives at this host's project discovery path.
+    [ "$REPO_ROOT/$rel" = "$target" ] && continue
+    if repair_missing_link "$REPO_ROOT/$rel" "$target"; then
+      continue
+    fi
+    if ! symlink_points_to "$target" "$REPO_ROOT/$rel"; then
+      emit_error "E_PROJECT_SKILL_LINK:$rel declares host=$host scope=project but $target is missing or wrong | repair: scripts/sync-host-skills.sh $host"
+    fi
+  done < <(skill_declared_hosts "$rel")
+}
+
+main() {
+  local rel
+  while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    [ "$(skill_scope "$rel")" = "project" ] || continue
+    check_project_skill "$rel"
+  done < <(candidate_roots)
+
+  if [ "$ERRORS" -gt 0 ]; then
+    printf 'lint-project-skill-links: %d error(s)%s\n' \
+      "$ERRORS" "$([ "$STAGED" -eq 1 ] && printf ' (staged)' || printf '')" >&2
+    return 1
+  fi
+  printf 'lint-project-skill-links: OK%s\n' \
+    "$([ "$STAGED" -eq 1 ] && printf ' (staged)' || printf '')" >&2
+}
+
+main

--- a/scripts/sync-host-skills.sh
+++ b/scripts/sync-host-skills.sh
@@ -189,10 +189,23 @@ resolve_symlink_target() {
   esac
 }
 
+canonical_path() {
+  # $1 = existing absolute path. Prints the path with a physical parent, so
+  # macOS /var and /private/var spellings compare equal.
+  local path="$1" dir base
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  ( cd "$dir" && printf '%s/%s\n' "$(pwd -P)" "$base" )
+}
+
 symlink_points_to() {
   # $1 = symlink path, $2 = expected absolute target path.
+  local actual expected
   [ -L "$1" ] || return 1
-  [ "$(resolve_symlink_target "$1" 2>/dev/null || true)" = "$2" ]
+  actual=$(resolve_symlink_target "$1" 2>/dev/null || true)
+  [ -e "$actual" ] && actual=$(canonical_path "$actual" 2>/dev/null || printf '%s\n' "$actual")
+  expected=$(canonical_path "$2" 2>/dev/null || printf '%s\n' "$2")
+  [ "$actual" = "$expected" ]
 }
 
 link_target_for() {

--- a/scripts/test-fixtures/430-project-skill-links/test-project-skill-links.sh
+++ b/scripts/test-fixtures/430-project-skill-links/test-project-skill-links.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t project-skill-links.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+REPO="$TMPROOT/repo"
+mkdir -p \
+  "$REPO/scripts" \
+  "$REPO/hosts" \
+  "$REPO/.claude/skills/studio" \
+  "$REPO/.codex/skills" \
+  "$REPO/_shared" \
+  "$TMPROOT/home"
+
+cp "$ROOT/scripts/lint-project-skill-links.sh" "$REPO/scripts/lint-project-skill-links.sh"
+cp "$ROOT/scripts/sync-host-skills.sh" "$REPO/scripts/sync-host-skills.sh"
+cp "$ROOT/scripts/lib-paths.sh" "$REPO/scripts/lib-paths.sh"
+chmod +x "$REPO/scripts/lint-project-skill-links.sh" "$REPO/scripts/sync-host-skills.sh"
+
+cat > "$REPO/hosts/registry.yaml" <<'YAML'
+codex:
+  display_name: "OpenAI Codex CLI"
+  detect_binary: codex
+  global_skill_dir: "~/.codex/skills"
+  project_skill_dir: ".codex/skills"
+  routing_file: "AGENTS.md"
+  routing_walks_parents: false
+  tool_dialect: openai
+  status: provisional
+YAML
+
+cat > "$REPO/.claude/skills/studio/SKILL.md" <<'MD'
+---
+name: studio
+description: Test project-scoped skill.
+type: agent-router
+---
+
+# Studio
+MD
+
+cat > "$REPO/.claude/skills/studio/portability.yaml" <<'YAML'
+schema_version: 1
+hosts:
+  - codex
+scope: project
+YAML
+
+missing_err="$TMPROOT/missing.err"
+if HOME="$TMPROOT/home" "$REPO/scripts/lint-project-skill-links.sh" --host codex >"$TMPROOT/missing.out" 2>"$missing_err"; then
+  echo "FAIL: lint accepted missing .codex/skills/studio" >&2
+  exit 1
+fi
+grep -q 'E_PROJECT_SKILL_LINK:.claude/skills/studio declares host=codex scope=project' "$missing_err" || {
+  echo "FAIL: missing-link error did not name the project skill invariant" >&2
+  cat "$missing_err" >&2
+  exit 1
+}
+grep -q 'repair: scripts/sync-host-skills.sh codex' "$missing_err" || {
+  echo "FAIL: missing-link error did not include repair command" >&2
+  cat "$missing_err" >&2
+  exit 1
+}
+
+HOME="$TMPROOT/home" "$REPO/scripts/lint-project-skill-links.sh" --host codex --repair >"$TMPROOT/repair.out" 2>"$TMPROOT/repair.err"
+HOME="$TMPROOT/home" "$REPO/scripts/lint-project-skill-links.sh" --host codex >"$TMPROOT/repaired.out" 2>"$TMPROOT/repaired.err"
+rm "$REPO/.codex/skills/studio"
+
+if ! HOME="$TMPROOT/home" "$REPO/scripts/sync-host-skills.sh" codex >"$TMPROOT/sync.out" 2>"$TMPROOT/sync.err"; then
+  echo "FAIL: sync-host-skills.sh codex failed" >&2
+  cat "$TMPROOT/sync.err" >&2
+  exit 1
+fi
+
+if [ ! -L "$REPO/.codex/skills/studio" ]; then
+  echo "FAIL: sync did not create .codex/skills/studio symlink" >&2
+  cat "$TMPROOT/sync.err" >&2
+  exit 1
+fi
+
+target=$(readlink "$REPO/.codex/skills/studio")
+if [ "$target" != "../../.claude/skills/studio" ]; then
+  echo "FAIL: expected relative project link, got $target" >&2
+  exit 1
+fi
+
+HOME="$TMPROOT/home" "$REPO/scripts/lint-project-skill-links.sh" --host codex >"$TMPROOT/fixed.out" 2>"$TMPROOT/fixed.err"
+
+echo "PASS: project-scoped skill links are linted and repairable"


### PR DESCRIPTION
## Summary
- restore the repo-local Codex studio skill link
- add a host-generic project skill link lint and run it from the architecture gate
- add SessionStart repo-local repair for missing project discovery links
- add a fixture covering missing-link failure, local repair, and sync repair

Closes #430

## Verification
- scripts/test-fixtures/430-project-skill-links/test-project-skill-links.sh
- scripts/lint-project-skill-links.sh --host codex
- scripts/lint-architecture.sh --staged
- .githooks/pre-commit

## Warnings
- pre-existing W_ARGUS_SECRET_SCOPE for .codex/capabilities.yaml
- pre-existing W_MISSING_SCHEMA_REF for chanakya/reopen in generated capability manifest