### PR TITLE
Refresh Forge reliability queue after #430

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,7 +19,7 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#430](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/430) Protect project-scoped host skill links from accidental deletion | Current-session routing regression; `$studio` can disappear on Codex even though the skill still declares host support. |
+| 1 | [#432](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/432) Make cross-host PR review real, observable, and smoke-gated | Live PR gate showed Claude reviewer can be eligible on paper while unauthenticated at runtime; review independence must be truthful. |
 | 2 | [#335](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/335) Make test cases come from debrief YAML only | Removes a remaining split-brain artifact path while the YAML/debrief contract is already in focus. |
 | 3 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed as dashboard noise during the freeze. |
 | 4 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review timeouts, base-staleness consistency, and staged handoff payloads before merge-gate changes. |
@@ -34,10 +34,10 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 Stay inside the Forge reliability freeze until this list clears or the user explicitly waives a named issue.
 
-1. Restore and mechanically protect the current session's project-scoped skill route: #430.
+1. Keep the PR review gate truthful after the live reviewer fallback: #432.
 2. Land low-ambiguity implementation fixes next: #335, #240.
 3. Slice the larger ready work instead of bundling it: #223 first, then #76.
-4. Run a short design pass before coding policy-sensitive or environment-sensitive work: #430, #336, #313, #372, #224, #322.
+4. Run a short design pass before coding policy-sensitive or environment-sensitive work: #432, #336, #313, #372, #224, #322.
 5. Keep new feature arcs parked. Phase 2.7, Host-agnostic Chanakya v2, Build-opt v2, Lu Ban, dashboard, and new mode packs remain blocked by the freeze.
 
 ### Multi-Session Tracking
@@ -52,7 +52,7 @@ Stay inside the Forge reliability freeze until this list clears or the user expl
 
 | Issue | Decision Needed Before Implementation |
 |---|---|
-| [#430](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/430) | Choose the enforcement structure: tracked symlink plus lint, generated manifest plus ignored links, or a combined invariant-audit path. |
+| [#432](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/432) | Define reviewer independence policy: smoke eligibility, fallback visibility, cross-host requirement boundaries, and bypass recording. |
 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) | Define the canonical runtime-root contract (`STUDIO_RUNTIME_ROOT` or equivalent) and alternate-`HOME` diagnostics. |
 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) | Choose missing-registry recovery behavior: hard fail, auto-file infra failure, structured waive prompt, or a combined path. |
 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) | Define how Codex sessions prove GitHub credential parity and choose the canonical test invocation root/wrapper. |
@@ -87,7 +87,8 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#315](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/315) Ledger bypass with non-canonical task IDs suppresses event emission and sweep hooks | Closed | Reliability bug | Direct artifact creation can bypass lib-ledger contracts and make downstream hooks silently no-op. |
 | [#314](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/314) Canonical event log reconstruction can hide lifecycle windows from sweeps | Closed | Reliability bug | Event-log loss makes sweeps and analytics falsely precise unless gaps are bounded and recoverable. |
 | [#384](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/384) Sweep ingestion should normalize enumerator debrief kinds | Closed | Reliability bug | Sweep must not continue as successful when enumerator and ingester vocabularies diverge. |
-| [#430](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/430) Protect project-scoped host skill links from accidental deletion | Open | Reliability bug | Project-scoped routers must not silently disappear from a supported host when a local discovery link is deleted. |
+| [#430](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/430) Protect project-scoped host skill links from accidental deletion | Closed | Reliability bug | Project-scoped routers must not silently disappear from a supported host when a local discovery link is deleted. |
+| [#432](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/432) Make cross-host PR review real, observable, and smoke-gated | Open | Reliability bug | Review gates must not claim cross-host or independent coverage when eligible reviewer hosts cannot actually run. |
 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Open | Reliability bug | Host parity claims are false if Codex cannot resolve private commits or run canonical project tests. |
 | [#335](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/335) Make test cases come from debrief YAML only | Open | Safety-floor hardening | Test-case evidence should have one canonical source, not drift between YAML and legacy markdown. |
 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Open | Reliability bug | Alternate deployed layouts and alternate HOME roots must not resolve different briefs for the same task. |

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T12:31:01Z",
+  "generated_at": "2026-05-02T12:37:23Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T12:31:00Z",
+  "generated_at": "2026-05-02T12:37:22Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- mark #430 closed in the Forge reliability lookup
- promote #432 as the next safety-floor item after the live reviewer fallback
- keep Up Next at exactly 10 open tasks

## Verification
- .githooks/pre-commit

## Warnings
- pre-existing W_MISSING_SCHEMA_REF for chanakya/reopen in the generated capability manifest