### PR TITLE
Close dual-write audit drift

### DIFF
--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,23 +19,23 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
-| 2 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
-| 3 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
-| 4 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
-| 5 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
-| 6 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
-| 7 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Restores actionable diagnostics for full-green build-gate failures before more Achilles work depends on it. |
-| 8 | [#435](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/435) TestFlight push can preserve a rejected marketing version | Prevents release tooling from contradicting explicit version intent and uploading a rejected build. |
-| 9 | [#418](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/418) Host-agnostic Chanakya v2 implementation | Makes orchestrator dispatch and status paths portable without Claude-Code-only load-bearing primitives. |
-| 10 | [#203](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/203) Achilles modes/debug.md + bug-fix flow rewrite | Sets up the bug-fix workflow and localization loop that will make future repair work faster and less brittle. |
+| 1 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
+| 2 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
+| 3 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
+| 4 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
+| 5 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
+| 6 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Restores actionable diagnostics for full-green build-gate failures before more Achilles work depends on it. |
+| 7 | [#435](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/435) TestFlight push can preserve a rejected marketing version | Prevents release tooling from contradicting explicit version intent and uploading a rejected build. |
+| 8 | [#418](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/418) Host-agnostic Chanakya v2 implementation | Makes orchestrator dispatch and status paths portable without Claude-Code-only load-bearing primitives. |
+| 9 | [#203](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/203) Achilles modes/debug.md + bug-fix flow rewrite | Sets up the bug-fix workflow and localization loop that will make future repair work faster and less brittle. |
+| 10 | [#213](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/213) Achilles SourceKit-LSP symbol localization | Improves bug localization from file-level grep to symbol-level Swift resolution once the safety-floor queue has room for capability work. |
 
 ## Freeze Plan of Record
 
 Stay inside the Forge reliability freeze until this list clears or the user explicitly waives a named issue.
 
 1. Keep the PR review gate truthful after the live reviewer fallback: #432 closed in PR #438.
-2. Land the next low-ambiguity implementation fixes: #76, then #336.
+2. Land the next low-ambiguity implementation fixes: #336, then #313.
 3. Slice the larger ready work instead of bundling it: #313, #372, #224, #322, #418, #203.
 4. Run a short design pass before coding policy-sensitive or environment-sensitive work: #336, #313, #372, #224, #322.
 5. Keep new feature arcs parked. Phase 2.7, Host-agnostic Chanakya v2, Build-opt v2, Lu Ban, dashboard, and new mode packs remain blocked by the freeze.
@@ -106,7 +106,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#362](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/362) `push-tf` must preflight GitHub auth before mutating build number | Closed | Reliability bug | Release workflows must prove required auth before creating partial external state. |
 | [#391](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/391) Claude reviewer runner lacks a dedicated auth/config root | Closed | Reliability bug | Headless PR review can look eligible but still fail at runtime when `claude-reviewer` inherits an empty session home. |
 | [#97](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/97) App Store live version lookup must use app-scoped endpoint | Closed | Reliability bug | Release/status logic must not depend on a forbidden top-level endpoint. |
-| [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Open | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
+| [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Closed | Reliability bug | Ensures no active prose or writer still mutates retired legacy surfaces. |
 | [#318](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/318) PR merge autopilot with headless reviewer gate | Closed | Safety-floor hardening | Makes PR review and merge flow explicit: headless reviewer first, critical blockers stop only that PR, and integration advances only through GitHub PR merge. |
 | [#325](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/325) Harden PR autopilot merge method and local cleanup | Closed | Reliability bug | Prevents a successful remote merge from being reported as failed because local cleanup ran from a detached or stale worktree. |
 

--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,24 +19,24 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed as dashboard noise during the freeze. |
-| 2 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review timeouts, base-staleness consistency, and staged handoff payloads before merge-gate changes. |
-| 3 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
-| 4 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
-| 5 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
-| 6 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
-| 7 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
-| 8 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
-| 9 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Restores actionable diagnostics for full-green build-gate failures before more Achilles work depends on it. |
-| 10 | [#435](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/435) TestFlight push can preserve a rejected marketing version | Prevents release tooling from contradicting explicit version intent and uploading a rejected build. |
+| 1 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
+| 2 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
+| 3 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
+| 4 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
+| 5 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
+| 6 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
+| 7 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Restores actionable diagnostics for full-green build-gate failures before more Achilles work depends on it. |
+| 8 | [#435](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/435) TestFlight push can preserve a rejected marketing version | Prevents release tooling from contradicting explicit version intent and uploading a rejected build. |
+| 9 | [#418](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/418) Host-agnostic Chanakya v2 implementation | Makes orchestrator dispatch and status paths portable without Claude-Code-only load-bearing primitives. |
+| 10 | [#203](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/203) Achilles modes/debug.md + bug-fix flow rewrite | Sets up the bug-fix workflow and localization loop that will make future repair work faster and less brittle. |
 
 ## Freeze Plan of Record
 
 Stay inside the Forge reliability freeze until this list clears or the user explicitly waives a named issue.
 
 1. Keep the PR review gate truthful after the live reviewer fallback: #432 closed in PR #438.
-2. Land low-ambiguity implementation fixes next: #240.
-3. Slice the larger ready work instead of bundling it: #223 first, then #76.
+2. Land the next low-ambiguity implementation fixes: #76, then #336.
+3. Slice the larger ready work instead of bundling it: #313, #372, #224, #322, #418, #203.
 4. Run a short design pass before coding policy-sensitive or environment-sensitive work: #336, #313, #372, #224, #322.
 5. Keep new feature arcs parked. Phase 2.7, Host-agnostic Chanakya v2, Build-opt v2, Lu Ban, dashboard, and new mode packs remain blocked by the freeze.
 
@@ -97,9 +97,9 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Open | Reliability bug | Alternate deployed layouts and alternate HOME roots must not resolve different briefs for the same task. |
 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Open | Safety-floor hardening | Reviewer independence and model freshness should be policy-backed instead of hardcoded in scripts or prose. |
 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing from deployed skills layout | Open | Reliability bug | Review gate availability depends on host registry deployment and deterministic infra-failure handling. |
-| [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Open | Safety-floor hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
+| [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Closed | Safety-floor hardening | Tightens review handoff timeouts, base-staleness consistency, and stage payloads. |
 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Open | Safety-floor hardening | Closes paths where flagged reviews or sibling merges can pass the merge boundary unsafely. |
-| [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Open | Safety-floor hardening | Prevents `done_with_concerns` and structured follow-ups from being absorbed without tasks. |
+| [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Closed | Safety-floor hardening | Prevents `done_with_concerns` and structured follow-ups from being absorbed without tasks. |
 | [#226](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/226) Inbox sweep observability | Closed | Observability | Handoff anomalies and missing debriefs should emit visible signals before they become stale status drift. |
 | [#241](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/241) Review-coverage metric in `/chanakya status` | Closed | Observability | Makes review dark periods visible as a metric, not a post-hoc investigation. |
 | [#195](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/195) Merged task shown as briefed / missing debrief | Closed | Reliability bug | Status can show completed work as pending when debrief emission is missing. |

--- a/FORGE-RELIABILITY.md
+++ b/FORGE-RELIABILITY.md
@@ -19,23 +19,23 @@ Curated next 10 for Forge reliability work. This list is the quick lookup; GitHu
 
 | Rank | Issue | Why Now |
 |---:|---|---|
-| 1 | [#433](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/433) Normalize sweep enumerator kinds before ingest | Prevents debriefs from staying emitted when the enumerator and ingester use different kind names. |
-| 2 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed as dashboard noise during the freeze. |
-| 3 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review timeouts, base-staleness consistency, and staged handoff payloads before merge-gate changes. |
-| 4 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
-| 5 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
-| 6 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
-| 7 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
-| 8 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
-| 9 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
-| 10 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Restores actionable diagnostics for full-green build-gate failures before more Achilles work depends on it. |
+| 1 | [#240](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/240) Concern→task auto-mint from debrief follow-ups and debt flags | Prevents structured concerns from being absorbed as dashboard noise during the freeze. |
+| 2 | [#223](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/223) Achilles ↔ Argus contract hardening | Tightens review timeouts, base-staleness consistency, and staged handoff payloads before merge-gate changes. |
+| 3 | [#76](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/76) Audit mode-pack dual-write during Phase 2.6 transition | Confirms no remaining writer mutates legacy artifacts without YAML while freeze work depends on the ledger. |
+| 4 | [#336](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/336) Brief resolution must be identical across deployed skills layouts | Needs a short design pass on canonical runtime-root behavior, then closes alternate-HOME brief drift. |
+| 5 | [#313](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/313) Argus dispatch fails when host registry is missing | Needs recovery-policy shaping, then restores deterministic review-gate availability in deployed layouts. |
+| 6 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Needs credential/test-root contract shaping before code; important for host parity but easy to overfit. |
+| 7 | [#224](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/224) Argus → merge gate policy + sibling-merge race | Needs explicit policy choice for flagged-review merge friction before changing autonomous merge behavior. |
+| 8 | [#322](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/322) Add provider model catalog and reviewer model policy | Needs sparse-refresh policy and official model verification; supports reviewer independence without blocking earlier fixes. |
+| 9 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Restores actionable diagnostics for full-green build-gate failures before more Achilles work depends on it. |
+| 10 | [#435](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/435) TestFlight push can preserve a rejected marketing version | Prevents release tooling from contradicting explicit version intent and uploading a rejected build. |
 
 ## Freeze Plan of Record
 
 Stay inside the Forge reliability freeze until this list clears or the user explicitly waives a named issue.
 
 1. Keep the PR review gate truthful after the live reviewer fallback: #432 closed in PR #438.
-2. Land low-ambiguity implementation fixes next: #433, #240.
+2. Land low-ambiguity implementation fixes next: #240.
 3. Slice the larger ready work instead of bundling it: #223 first, then #76.
 4. Run a short design pass before coding policy-sensitive or environment-sensitive work: #336, #313, #372, #224, #322.
 5. Keep new feature arcs parked. Phase 2.7, Host-agnostic Chanakya v2, Build-opt v2, Lu Ban, dashboard, and new mode packs remain blocked by the freeze.
@@ -89,7 +89,7 @@ These remain eligible during the Forge reliability freeze because they prevent s
 | [#430](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/430) Protect project-scoped host skill links from accidental deletion | Closed | Reliability bug | Project-scoped routers must not silently disappear from a supported host when a local discovery link is deleted. |
 | [#432](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/432) Make cross-host PR review real, observable, and smoke-gated | Closed | Reliability bug | Review gates must not claim cross-host or independent coverage when eligible reviewer hosts cannot actually run. |
 | [#440](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/440) Claude reviewer auth must use an explicit reviewer HOME | Closed | Reliability bug | Cross-host review must not fall back to same-family review when a configured Claude reviewer exists but temp `HOME` breaks auth. |
-| [#433](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/433) Sweep ingest does not accept enumerator debrief kinds | Open | Reliability bug | Enumerator/ingester vocabulary drift can strand emitted debriefs without lifecycle events or visible status. |
+| [#433](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/433) Sweep ingest does not accept enumerator debrief kinds | Closed | Reliability bug | Enumerator/ingester vocabulary drift can strand emitted debriefs without lifecycle events or visible status. |
 | [#434](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/434) Build gate success marker can be absent without diagnostics | Open | Reliability bug | Full-green tasks can be blocked by opaque harness failure with no actionable build diagnostic. |
 | [#435](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/435) TestFlight push can preserve a rejected marketing version | Open | Reliability bug | Release tooling can contradict explicit version intent and upload a rejected version without a preflight halt. |
 | [#372](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/372) Codex host must match Claude auth and test-context parity | Open | Reliability bug | Host parity claims are false if Codex cannot resolve private commits or run canonical project tests. |

--- a/_shared/contracts/events.md
+++ b/_shared/contracts/events.md
@@ -111,6 +111,7 @@ Use `printf '%s\n'` (not `echo`) — portable and avoids trailing-space issues.
 | `review_approved` | All checks pass | `checks_run`, `stage` |
 | `review_flagged` | Non-blocking findings | `findings` (array of strings), `stage` |
 | `review_blocked` | Hard block — cannot merge | `block_reason`, `check`, `stage` |
+| `review_timeout` | `dispatch-review.sh` waited past its timeout without a verdict. The spawned review process is killed, and Achilles must surface the review as blocked rather than silently continue. | `stage`, `idem_key`, `timeout_s`, `elapsed_s`, `requested_at` (when available), `host`, `attempt` |
 | `brief_review_flagged` | Chanakya brief-review (#104) found one or more checklist defects in an authored brief. Warn-tier; dispatch is not blocked. Empty `findings` is not emitted (clean runs don't emit). | `brief_uuid`, `finding_count`, `findings` (comma-joined C-item IDs, e.g. `"C1,C4,C7"`), `size`, `type` |
 | `test_run_started` | Test phase begins. Argus M/L emits via `argus-run-tests.sh` (machine-local, test-slot semaphore). Achilles test-suite mode emits via `task-test-gate.sh` (node-dispatched, per-node xcodebuild lock — #215). | `slot` (argus) \| `node` (achilles), `suite` (argus) \| `scheme`+`test_target`+`worktree` (achilles), `attempt` (achilles) |
 | `test_run_passed` | Tests green | `duration_s`, `test_count`; achilles path additionally carries `node`, `scheme`, `test_target`, `attempt` |

--- a/_shared/primitives/base-staleness.md
+++ b/_shared/primitives/base-staleness.md
@@ -1,0 +1,17 @@
+---
+name: Base Staleness Threshold
+description: Canonical drift floor used by Achilles pre-refresh and Argus base-staleness checks.
+type: primitive
+---
+
+# Base Staleness Threshold
+
+Threshold: 2
+
+Rationale: refreshing one or two commits is cheap enough to avoid Argus staleness; beyond that, the branch should be refreshed explicitly before review.
+
+Consumers:
+
+- `scripts/achilles-refresh-base.sh` reads `Threshold:` as the default pre-review refresh floor.
+- `argus/rules/base-staleness.md` points at this file so the review rule and the refresh script share one source of truth.
+- `ACHILLES_BASE_REFRESH_THRESHOLD` remains a per-run override for exceptional cases.

--- a/_shared/rules/cleanup-policy.md
+++ b/_shared/rules/cleanup-policy.md
@@ -86,14 +86,7 @@ rm -f "$MARKER"
 trap - EXIT INT TERM
 ```
 
-**Achilles respects this marker:** refuse worktree cleanup (`git worktree remove`) while `.argus-running` exists. Check before Step 9:
-
-```bash
-if [ -f "$WORKTREE/.argus-running" ]; then
-  echo "Argus is still reviewing — waiting before cleanup..." >&2
-  # poll every 30s, up to 10 min
-fi
-```
+**Achilles respects this marker:** `.argus-running` remains Argus-owned cleanup state, but it is no longer a polling gate. `dispatch-review.sh` owns the wait window, emits `review_timeout` if the verdict never arrives, and kills the spawned review on timeout. Achilles should not busy-wait on the marker before merge cleanup.
 
 ---
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T17:20:17Z",
+  "generated_at": "2026-05-02T17:52:55Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T16:53:48Z",
+  "generated_at": "2026-05-02T17:20:17Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T17:52:55Z",
+  "generated_at": "2026-05-02T18:09:50Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/state-machines/review-lifecycle.md
+++ b/_shared/state-machines/review-lifecycle.md
@@ -16,7 +16,7 @@ Argus reviews have their own short-cycle state machine, separate from task and b
 | `in-progress` | Argus is actively reading diff + running checks. `.argus-running` marker exists. |
 | `approved` | All checks passed. Safe to merge. |
 | `flagged` | Non-blocking findings. Safe to merge; Chanakya files follow-ups. |
-| `blocked` | Hard block (secrets, base staleness Achilles can't fix, etc.). Do not merge. |
+| `blocked` | Hard block (secrets, base staleness Achilles can't fix, dispatch timeout, etc.). Do not merge. |
 | `acknowledged` | Terminal. Achilles or Chanakya consumed the verdict and acted. |
 
 ## Transitions
@@ -25,7 +25,7 @@ Argus reviews have their own short-cycle state machine, separate from task and b
 pending      → in-progress  : Argus writes `.argus-running` marker.
 in-progress  → approved     : all checks green.
 in-progress  → flagged      : findings but not blocking.
-in-progress  → blocked      : hard block.
+in-progress  → blocked      : hard block, including dispatch timeout (`review_timeout`).
 approved     → acknowledged : Achilles proceeds to merge.
 flagged      → acknowledged : Achilles proceeds; Chanakya files follow-up.
 blocked      → acknowledged : Achilles fixes and re-invokes, or surfaces to user.

--- a/achilles/modes/task.md
+++ b/achilles/modes/task.md
@@ -313,7 +313,8 @@ eval "$(scripts/task-invoke-argus.sh "$TASK_ID" "$WORKTREE" "$ORIG_BRANCH" "$SIZ
 
 Emits `review_requested` and exports `ACHILLES_REVIEW_REQUESTED_AT` (carried into the debrief for verdict-timing correlation).
 
-Argus runs in **two sequential stages**, both dispatched via `scripts/dispatch-review.sh`. The script handles host adapter selection (Claude Code / Codex / future), env-scrubs the spawn (no API keys, no GH tokens), validates the handoff payload against `_shared/contracts/handoff.schema.json`, and tails the event log for the verdict — the contract is shell-reachable on every supported host.
+Argus runs in **two sequential stages**, both dispatched via `scripts/dispatch-review.sh`. The script handles host adapter selection (Claude Code / Codex / future), env-scrubs the spawn (no API keys, no GH tokens), validates the handoff payload against `_shared/contracts/handoff.schema.json`, and tails the event log for the verdict — the contract is shell-reachable on every supported host. If the tail times out, `dispatch-review.sh` emits `review_timeout`, kills the spawned review, and exits non-zero; treat that as a hard block, not a silent skip.
+Stage 2 carries a compact `prior_findings_summary` from Stage 1 in the routed handoff payload, so code-quality sees the earlier spec verdict once without re-reading the entire review artifact.
 
 #### Stage 1 — spec-compliance
 
@@ -329,7 +330,7 @@ Narrow question: does the diff match the brief?
 - **`approved`** or **`flagged`:** proceed to Stage 2. Carry Stage 1 findings forward into the debrief.
 - **`blocked`:** do NOT run Stage 2 — the spec is wrong at the structural level, re-reviewing code doesn't help. Surface block reason; attempt to fix (see below) or debrief with `report_state: blocked`.
 
-Retry policy: validator rejection never auto-retries (per `_shared/contracts/idempotency.md`). Transient failures (timeout, spawn fork) may retry once with `--attempt 2` and a fresh idempotency-key suffix.
+Retry policy: validator rejection never auto-retries (per `_shared/contracts/idempotency.md`). Transient failures (spawn fork, infra launch) may retry once with `--attempt 2` and a fresh idempotency-key suffix. A `review_timeout` is a hard block: do not merge, surface the stall, and write the debrief with `report_state: blocked`.
 
 #### Stage 2 — code-quality
 
@@ -375,7 +376,7 @@ Mints a UUIDv7, writes `plans/debriefs/<debrief-id>.yaml` (schema: `_shared/sche
 
 ### Step 10 — Commit, merge back, clean up
 
-**Respect `.argus-running` marker.** Before invoking the merge script, if `$WORKTREE/.argus-running` exists a standalone Argus is still reviewing — poll every 30s up to 10 min, then surface to user. Normal Step 8.5 flow clears the marker automatically.
+**No `.argus-running` polling.** The review dispatch now owns the timeout window and emits `review_timeout` when it expires. If the marker is still present at Step 10, treat the review session as unresolved and surface the block; do not sleep in a retry loop.
 
 ```bash
 scripts/task-merge.sh "$TASK_ID" "$WORKTREE" "$ORIG_BRANCH" "Merge <task-id> into $ORIG_BRANCH"

--- a/argus/modes/code-quality.md
+++ b/argus/modes/code-quality.md
@@ -30,6 +30,8 @@ At first write of a review session, invoke `scripts/emit-agent-boot.sh argus <ta
 
 In week 1, only these checks produce **blocks**: compile failure, test failure (M/L only), secrets in diff, base-branch staleness.
 
+Base-branch staleness uses the shared threshold in `_shared/primitives/base-staleness.md`, so Achilles' pre-review refresh and Argus' block decision read the same floor.
+
 Everything else (diff anomalies, edge-case gaps, test adequacy, regression risk) produces a **flag** in week 1. Merge proceeds; Chanakya auto-files follow-ups from flagged findings. To promote a check to block, edit the `Block?` column in `_shared/rules/review-rules.md`.
 
 ## Scope Caps

--- a/argus/rules/base-staleness.md
+++ b/argus/rules/base-staleness.md
@@ -8,3 +8,4 @@ applies_when:
 Always load. Base-branch staleness is independent of diff content.
 
 Source rule: `_shared/rules/review-rules.md` Check 5.
+Shared threshold source: `_shared/primitives/base-staleness.md`.

--- a/audits/76-dual-write-audit.md
+++ b/audits/76-dual-write-audit.md
@@ -1,0 +1,81 @@
+# Issue #76 Dual-Write Audit
+
+Date: 2026-05-02
+Scope: mode packs named in issue #76 plus active ledger writer scripts.
+
+## Current Rule
+
+The Phase 2.6 dual-write window is closed. Post-#245 A.4/A.5, Phase 2.6 artifacts write only canonical YAML through `scripts/lib-ledger.sh` writers and transition helpers. Retired `legacy_*` helpers fail loud with exit 9.
+
+`_shared/patterns/dual-write-transition.md` remains as a reusable pattern for future migrations, not as an active write contract.
+
+## Mode-Pack Classification
+
+| Surface | Classification | Evidence |
+|---|---|---|
+| `chanakya/modes/intake.md` | yaml-only writer | Calls `write_task_artifact`; no legacy write target. |
+| `chanakya/modes/brief.md` | yaml-only writer | Calls `write_brief_artifact`, `set_task_link`, and `transition_task_state`; explicitly forbids hand-edited YAML. |
+| `chanakya/modes/feedback.md` | no Phase 2.6 legacy-only writer | Mutates task/feedback YAML; feedback markdown paths are the separate F-id feedback surface. |
+| `chanakya/modes/sweep-debt.md` | no artifact write | `writes: []`. |
+| `chanakya/modes/inbox-sweep.md` | yaml-only delegated writer | Delegates to `sweep-enumerate-debriefs.sh` and `sweep-ingest.sh`; legacy markdown is diagnostic-only. |
+| `chanakya/modes/ship.md` | no Phase 2.6 artifact write | Writes only the worker queue. |
+| `chanakya/modes/status.md` | no Phase 2.6 artifact write | Reads canonical YAML and writes only push-queue display state. |
+| `chanakya/modes/verify.md` | no direct artifact write | Orchestrates tests/feedback/intake sub-modes. |
+| `chanakya/modes/sync-slack.md` | no Phase 2.6 artifact write | Reads YAML, writes Slack list plus feedback reminder markdown. |
+| `chanakya/modes/tests.md` | yaml-only writer | Round writes go through `scripts/tests-write-round.sh` -> `write_round_artifact`; historical test sidecars are read-only fallback. |
+| `chanakya/modes/update.md` | yaml-only writer | Task state transitions via `lib-ledger`. |
+| `chanakya/modes/compact.md` | yaml-only for Phase 2.6 artifacts | Task/feedback/round state transitions via YAML; archive/changelog markdown are retained editorial surfaces. |
+| `chanakya/modes/review.md` | yaml-only writer | Mutates and mints tasks/briefs via lib-ledger-shaped steps. |
+| `achilles/modes/task.md` | yaml-only writer | Debrief/task/brief mutations flow through task scripts backed by `lib-ledger`. |
+| `achilles/modes/group.md` | no direct artifact write | Delegates to task mode. |
+| `achilles/modes/app-store.md` | yaml-only writer | Writes release/debrief YAML and task release back-refs. |
+| `achilles/modes/build.md` | yaml-only writer | Writes build-check debrief YAML; build debt markdown is rendered projection. |
+| `achilles/modes/next.md` | no direct artifact write | Delegates to task mode. |
+| `achilles/modes/push-tf.md` | yaml-only writer | Writes release/debrief YAML and task release back-refs. |
+| `achilles/modes/test-suite.md` | yaml-only writer | Writes test-suite debrief YAML. |
+| `argus/SKILL.md` | router, no artifact write | Actual review artifact writer is `scripts/argus-emit-verdict.sh`. |
+
+## Script Audit
+
+Active artifact producers route through these YAML writers:
+
+- `write_task_artifact`
+- `write_brief_artifact`
+- `write_debrief_artifact`
+- `write_review_artifact`
+- `write_round_artifact`
+- `write_release_artifact`
+- `transition_task_state`
+- `transition_brief_state`
+- `transition_release_state`
+- `transition_review_state`
+- `transition_round_state`
+
+The following stale dual-write references were removed in this audit because `lib-ledger.sh` no longer emits dual-write partial exit code 3:
+
+- `scripts/argus-emit-verdict.sh`
+- `scripts/task-claim.sh`
+- `scripts/task-emit-debrief.sh`
+- `scripts/task-finalize-merge.sh`
+- `scripts/tests-write-round.sh`
+- `scripts/sweep-ingest.sh`
+
+## Grep Checks
+
+Run from repo root:
+
+```sh
+rg -n 'legacy_(master_plan|inbox|brief|review|round|release).*\(' \
+  scripts chanakya/modes achilles/modes argus \
+  -g '*.sh' -g '*.md'
+
+rg -n 'chanakya-inbox.*-debrief\.(md|yaml)|plans/chanakya-tasks|plans/chanakya-master\.md' \
+  chanakya/modes achilles/modes argus scripts \
+  -g '*.md' -g '*.sh'
+```
+
+Expected result: no active legacy-only Phase 2.6 writer. Allowed hits are migration/archive/diagnostic readers, rendered-projection readers, or retired helper definitions in `lib-ledger.sh`.
+
+## Conclusion
+
+No listed mode pack is a legacy-only Phase 2.6 writer. The remaining legacy reads are explicitly diagnostic, migration, or rendered-projection paths. The stale rc=3 dual-write prose in active scripts was the only live drift found.

--- a/chanakya/modes/inbox-sweep.md
+++ b/chanakya/modes/inbox-sweep.md
@@ -121,6 +121,7 @@ Read the stuck state by `grep '"stuck": true'` on the marker — don't re-invoke
 | `debrief_concerns` | Push-queue append kind=`debrief_concerns` for `report_state: done_with_concerns`. |
 | `debrief_needs_context` | Push-queue append kind=`debrief_needs_context` for `report_state: needs_context`. |
 | `follow_up_mint_failed` | Push-queue append kind=`follow_up_mint_failed`; structured follow-ups never disappear silently. |
+| `review_timeout` | Push-queue append kind=`review_timeout`; dispatch timed out before Argus returned a verdict. |
 | `argus_gate_skipped` | When `reason ∈ {unknown_host, missing_manifest, missing_spawn_command, secret_scope_floor_unmet}`: idempotently file `bug` + `theme/internal` GitHub issue titled "Argus infra-failure: `<reason>` on `<host>`"; if an open issue with that title already exists, append a comment with the timestamp and `idem_key` instead. Operational reasons (`verdict_timeout_*`, `no_verdict_at_merge`) are no-ops. See `scripts/sweep-process-events.sh`. |
 | `test_run_failed` / `build_debt_incremented` | No direct action; surfaced in status. |
 

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T17:52:54Z",
+  "generated_at": "2026-05-02T18:09:49Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T16:53:47Z",
+  "generated_at": "2026-05-02T17:20:15Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T17:20:15Z",
+  "generated_at": "2026-05-02T17:52:54Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/achilles-refresh-base.sh
+++ b/scripts/achilles-refresh-base.sh
@@ -17,8 +17,12 @@
 #   6. Conflict → abort the merge (leave worktree clean), emit
 #      `base_refresh_conflict`, exit 2. Caller surfaces to user; no auto-resolve.
 #
-# Threshold:
-#   $ACHILLES_BASE_REFRESH_THRESHOLD (env), else 2.
+# Threshold source:
+#   `_shared/primitives/base-staleness.md` (default `Threshold: 2`).
+# Per-run override:
+#   `$ACHILLES_BASE_REFRESH_THRESHOLD` (env) still wins when set.
+# Test seam:
+#   `$ACHILLES_BASE_STALENESS_DOC` can point at an alternate primitive file.
 #
 # Usage:
 #   scripts/achilles-refresh-base.sh <task-id> <worktree> <base-branch>
@@ -41,12 +45,27 @@ TASK_ID="${1:?usage: achilles-refresh-base.sh <task-id> <worktree> <base-branch>
 WORKTREE="${2:?worktree required}"
 BASE_BRANCH="${3:?base-branch required}"
 
-THRESHOLD="${ACHILLES_BASE_REFRESH_THRESHOLD:-2}"
+BASE_STALENESS_DOC="${ACHILLES_BASE_STALENESS_DOC:-$SCRIPT_DIR/../_shared/primitives/base-staleness.md}"
+read_base_staleness_threshold() {
+  local doc="${1:?read_base_staleness_threshold <doc>}"
+  [ -f "$doc" ] || { printf 'error: base staleness primitive not found: %s\n' "$doc" >&2; return 2; }
+  awk -F': *' '/^Threshold:[[:space:]]*/ {print $2; exit}' "$doc"
+}
+
+THRESHOLD_DEFAULT=$(read_base_staleness_threshold "$BASE_STALENESS_DOC") || exit $?
+case "$THRESHOLD_DEFAULT" in
+  ''|*[!0-9]*)
+    printf 'error: invalid base staleness threshold in %s\n' "$BASE_STALENESS_DOC" >&2
+    exit 2
+    ;;
+esac
+
+THRESHOLD="${ACHILLES_BASE_REFRESH_THRESHOLD:-$THRESHOLD_DEFAULT}"
 case "$THRESHOLD" in
   ''|*[!0-9]*)
-    printf 'warn: ACHILLES_BASE_REFRESH_THRESHOLD=%s not a non-negative integer; using 2\n' \
-      "$THRESHOLD" >&2
-    THRESHOLD=2
+    printf 'warn: ACHILLES_BASE_REFRESH_THRESHOLD=%s not a non-negative integer; using %s\n' \
+      "$THRESHOLD" "$THRESHOLD_DEFAULT" >&2
+    THRESHOLD="$THRESHOLD_DEFAULT"
     ;;
 esac
 

--- a/scripts/argus-emit-verdict.sh
+++ b/scripts/argus-emit-verdict.sh
@@ -2,13 +2,12 @@
 # argus-emit-verdict.sh — Step 7 of the Argus pipeline (+ Step 8 stdout line).
 #
 # Writes the YAML review artifact via `write_review_artifact`, also writes a
-# free-form review markdown under the project's Claude memory dir (separate
-# carve-out from plans/, see file-locations.md "Review files (legacy archive)"
-# row — unaffected by #245 A.4), appends the review to the parent task's
-# `links.reviews` via `append_task_link`, emits the verdict event (handled
-# inside write_review_artifact), appends to the push queue on block, manages
-# result-bundle retention on flag, and prints the Step-8 machine-parseable
-# verdict line on stdout.
+# free-form review markdown under the project's Claude memory dir (a separate
+# review-notes carve-out from plans/, see file-locations.md), appends the
+# review to the parent task's `links.reviews` via `append_task_link`, emits
+# the verdict event (handled inside write_review_artifact), appends to the
+# push queue on block, manages result-bundle retention on flag, and prints
+# the Step-8 machine-parseable verdict line on stdout.
 #
 # Usage:
 #   scripts/argus-emit-verdict.sh <task-id> <verdict> <findings-json> \
@@ -17,7 +16,6 @@
 # Exit codes:
 #   0  verdict recorded
 #   2  missing args, task-uuid resolution failed, or unknown verdict
-#   3  dual-write partial failure (propagated from lib-ledger)
 
 set -u
 umask 022
@@ -76,17 +74,15 @@ fi
 
 REVIEW_ID=$(mint_uuidv7)
 
-# Primary write: YAML artifact + verdict event. lib-ledger attempts the
+# Primary write: YAML artifact + verdict event.
 write_review_artifact "$REVIEW_ID" task "$TASK_UUID" "$VERDICT" "$FINDINGS_JSON" "$STAGE"
 rc=$?
-if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
-  # rc=3 is retained for older dual-write-aware callers. Any other nonzero is
-  # a real failure.
+if [ "$rc" -ne 0 ]; then
   printf 'error: write_review_artifact failed rc=%s\n' "$rc" >&2
   exit "$rc"
 fi
 
-# Write the legacy review markdown directly. Path: project-memory carve-out
+# Write the review markdown directly. Path: project-memory carve-out
 # (~/.claude/projects/<slug>/memory/reviews/), not under ~/.dev-studio/plans/
 # — separate surface, unaffected by the #245 archive of plans/.legacy-archive.
 if [ -n "$LEGACY_PATH_OVERRIDE" ]; then

--- a/scripts/dispatch-review.sh
+++ b/scripts/dispatch-review.sh
@@ -25,7 +25,8 @@
 #      arbitrary env. The host CLI re-authenticates from its own keychain.
 #   6. Block by tailing the event log for a review_* event whose envelope
 #      carries the same idempotency_key. Timeout: $DISPATCH_REVIEW_TIMEOUT
-#      seconds (default 600). Per capabilities.block_for_event_strategy=tail.
+#      seconds (default 900). A timeout emits `review_timeout`, kills the
+#      spawned review, and exits non-zero. Per capabilities.block_for_event_strategy=tail.
 #   7. Print `ARGUS_VERDICT=<approved|flagged|blocked>` on stdout. Exit 0
 #      on verdict, non-zero on unrecoverable error.
 #
@@ -72,10 +73,12 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 # shellcheck source=lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh"
 
-TIMEOUT="${DISPATCH_REVIEW_TIMEOUT:-600}"
+TIMEOUT="${DISPATCH_REVIEW_TIMEOUT:-900}"
 WORKTREE="${ACHILLES_WORKTREE:-}"
 BASE_BRANCH="${ACHILLES_BASE_BRANCH:-}"
 SIZE="${TASK_SIZE:-}"
+REQUESTED_AT="${ACHILLES_REVIEW_REQUESTED_AT:-}"
+CAPTURE_HANDOFF="${DISPATCH_REVIEW_CAPTURE_HANDOFF:-}"
 
 event_log=$(resolve_event_log) || {
   printf 'dispatch-review: cannot resolve event log path\n' >&2
@@ -126,6 +129,56 @@ try:
 except Exception:
     pass
 '
+}
+prior_findings_summary_json() {
+  python3 - "$event_log" "$TASK_ID" <<'PY'
+import json
+import sys
+
+path, task_id = sys.argv[1:]
+latest = None
+
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except Exception:
+                continue
+            if event.get("task") != task_id:
+                continue
+            if event.get("event") not in {"review_approved", "review_flagged", "review_blocked"}:
+                continue
+            data = event.get("data") or {}
+            if data.get("stage") != "spec":
+                continue
+            latest = event
+except FileNotFoundError:
+    pass
+
+if latest is None:
+    sys.exit(1)
+
+data = latest.get("data") or {}
+verdict = (latest.get("event") or "").split("_", 1)[1]
+summary = {
+    "stage": "spec",
+    "verdict": verdict,
+}
+if verdict == "approved":
+    summary["finding_count"] = 0
+elif verdict == "flagged" and data.get("finding_count") is not None:
+    summary["finding_count"] = data.get("finding_count")
+elif verdict == "blocked" and data.get("block_reason"):
+    summary["block_reason"] = data.get("block_reason")
+if data.get("review_file"):
+    summary["review_file"] = data.get("review_file")
+
+print(json.dumps(summary, separators=(",", ":")))
+PY
 }
 find_prior_verdict() {
   [ -f "$event_log" ] || return 1
@@ -191,7 +244,10 @@ if [ "$HOST" != "claude-code" ] && [ "$SECRET_SCOPE" != "none" ]; then
   exit 1
 fi
 
-# ---- Step 4: build + validate handoff payload ------------------------------
+# ---- Step 4: build + validate routed handoff payload -----------------------
+# The envelope stays hub-and-spoke (`chanakya` -> `argus`) and Stage 2 may
+# carry a compact Stage 1 summary so code-quality sees the earlier verdict
+# without re-parsing the full review artifact.
 handoff_path=$(mktemp -t dispatch-review.XXXXXX) || { SKIP_REASON="mktemp_failed"; exit 1; }
 handoff_path="${handoff_path}.json"
 # Compose with _emit_skip_if_open — earlier-installed trap must keep firing.
@@ -202,10 +258,23 @@ if [ -n "$TASK_UUID" ]; then
   task_id_field="\"$TASK_UUID\""
 fi
 
+prior_findings_field=""
+if [ "$STAGE" = "quality" ]; then
+  # Stage 2 inherits a compact Stage 1 summary instead of the whole review.
+  if prior_json=$(prior_findings_summary_json 2>/dev/null); then
+    prior_findings_field=$(printf ',\n    "prior_findings_summary": %s' "$prior_json")
+  fi
+fi
+
 cat > "$handoff_path" <<EOF
 {
-  "schema_version": 1,
-  "from": "achilles",
+  "schema_version": {
+    "name": "handoff",
+    "version": "1.0.0",
+    "min_reader": "1.0.0",
+    "deprecated_at": null
+  },
+  "from": "chanakya",
   "to": "argus",
   "task_id": $task_id_field,
   "reason": "review:$STAGE for $TASK_ID (attempt $ATTEMPT)",
@@ -214,7 +283,7 @@ cat > "$handoff_path" <<EOF
     "stage": "$STAGE",
     "worktree": "$WORKTREE",
     "base_branch": "$BASE_BRANCH",
-    "size": "$SIZE"
+    "size": "$SIZE"$prior_findings_field
   },
   "idempotency_key": "$IDEM_KEY"
 }
@@ -223,7 +292,9 @@ EOF
 validator_err=$(mktemp -t dispatch-review-validate.XXXXXX) || { SKIP_REASON="mktemp_failed"; exit 1; }
 # Replace prior tmpfile-only trap, but keep _emit_skip_if_open running on EXIT.
 trap '_emit_skip_if_open; rm -f "$handoff_path" "$handoff_path.tmp" "$validator_err"' EXIT
-if ! "$SCRIPT_DIR/validate-contract.sh" handoff "$handoff_path" 2>"$validator_err"; then
+if "$SCRIPT_DIR/validate-contract.sh" handoff "$handoff_path" 2>"$validator_err"; then
+  :
+else
   rc=$?
   if [ "$rc" -eq 2 ]; then
     SKIP_REASON="validator_unavailable"
@@ -234,6 +305,11 @@ if ! "$SCRIPT_DIR/validate-contract.sh" handoff "$handoff_path" 2>"$validator_er
   fi
   cat "$validator_err" >&2 2>/dev/null || true
   exit 1
+fi
+
+if [ -n "$CAPTURE_HANDOFF" ]; then
+  mkdir -p "$(dirname "$CAPTURE_HANDOFF")" 2>/dev/null || true
+  cp "$handoff_path" "$CAPTURE_HANDOFF"
 fi
 
 # ---- Step 5: env-scrubbed spawn -------------------------------------------
@@ -294,15 +370,33 @@ EOF
   elapsed=$((elapsed + 1))
 done
 
-# Reap spawn (best-effort; the spawn may have exited cleanly already).
-wait "$spawn_pid" 2>/dev/null || true
-
 if [ -z "$verdict" ]; then
   SKIP_REASON="verdict_timeout_${TIMEOUT}s"
+  timeout_data=$(printf '{"stage":"%s","idem_key":"%s","timeout_s":%s,"elapsed_s":%s,"host":"%s","attempt":%s' \
+    "$STAGE" "$IDEM_KEY" "$TIMEOUT" "$elapsed" "$(_json_escape "$HOST")" "$ATTEMPT")
+  if [ -n "$REQUESTED_AT" ]; then
+    timeout_data="$timeout_data,\"requested_at\":\"$(_json_escape "$REQUESTED_AT")\""
+  fi
+  timeout_data="$timeout_data}"
+  kill "$spawn_pid" >/dev/null 2>&1 || true
+  grace=0
+  while [ "$grace" -lt 5 ]; do
+    if ! kill -0 "$spawn_pid" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+    grace=$((grace + 1))
+  done
+  kill -KILL "$spawn_pid" >/dev/null 2>&1 || true
+  wait "$spawn_pid" 2>/dev/null || true
+  emit_event_keyed argus review review_timeout "$TASK_ID" "$timeout_data" --idem-key "timeout:$IDEM_KEY" >/dev/null 2>&1 || true
   printf 'dispatch-review: timeout (%ds) waiting for review_* event with idempotency_key=%s\n' \
     "$TIMEOUT" "$IDEM_KEY" >&2
   exit 1
 fi
+
+# Reap spawn (best-effort; the spawn may have exited cleanly already).
+wait "$spawn_pid" 2>/dev/null || true
 
 # ---- Step 7: print verdict -------------------------------------------------
 # Spawned argus already emitted review_<verdict> via argus-emit-verdict.sh;

--- a/scripts/sweep-ingest.sh
+++ b/scripts/sweep-ingest.sh
@@ -14,7 +14,6 @@
 # Exit codes:
 #   0  ingest ok (or idempotent no-op)
 #   2  parse / resolution error
-#   3  dual-write partial failure propagated from lib-ledger
 
 set -u
 umask 022

--- a/scripts/sweep-process-events.sh
+++ b/scripts/sweep-process-events.sh
@@ -215,6 +215,13 @@ printf '%s\n' "$new_events" | while IFS= read -r line; do
     follow_up_mint_failed)
       push_append follow_up_mint_failed "$task" "structured follow-up could not be minted"
       ;;
+    review_timeout)
+      timeout_s=""
+      if command -v jq >/dev/null 2>&1; then
+        timeout_s=$(printf '%s' "$line" | jq -r '.data.timeout_s // ""' 2>/dev/null)
+      fi
+      push_append review_timeout "$task" "Argus review timed out${timeout_s:+ after ${timeout_s}s}"
+      ;;
     argus_gate_skipped)
       # Auto-file a GitHub issue for infra-broken skip reasons (#244).
       # Operational reasons (verdict_timeout, no_verdict_at_merge) are no-ops here.

--- a/scripts/task-claim.sh
+++ b/scripts/task-claim.sh
@@ -2,10 +2,8 @@
 # task-claim.sh — Step 2 of the Achilles task mode.
 #
 # Flips the paired task + brief artifacts to the in-flight states and emits
-# `brief_started`. lib-ledger's transition helpers handle the dual-write to
-# legacy master-plan (task side) so the mode-pack no longer carries that
-# prose. Brief state has no legacy counterpart today (Phase 2.6 defers brief
-# Status rows), so the brief transition is YAML-only.
+# `brief_started`. lib-ledger's transition helpers are YAML-only post-#245
+# A.4/A.5; any straggler legacy helper call fails loud inside lib-ledger.
 #
 # Usage:
 #   scripts/task-claim.sh [--steal] <task-uuid> <brief-uuid> <size>
@@ -13,7 +11,6 @@
 # Exit codes:
 #   0  both transitions applied + event emitted
 #   2  missing args / artifact not found
-#   3  dual-write partial (propagated from lib-ledger)
 #   4  duplicate claim refused — a live worktree already holds this brief
 #      (override: --steal flag or ACHILLES_RECLAIM_OK=1)
 
@@ -86,12 +83,11 @@ if [ -n "$BRIEF_UUID" ]; then
   fi
 fi
 
-# Task flip first — the task's legacy dual-write (master-plan Status) lives
-# here, so a crash between the two transitions leaves the post-migration
-# shape biased consistent (dual-write-transition.md rule 2).
+# Task flip first so a crash between the two transitions leaves task state
+# ahead of brief state; the sweep can recover from a claimed task more safely
+# than from a dispatched brief with no task-side evidence.
 transition_task_state "$TASK_UUID" in-progress achilles "Step 2 claim" || {
   rc=$?
-  [ "$rc" -eq 3 ] && exit 3
   printf 'error: transition_task_state failed rc=%s\n' "$rc" >&2
   exit 2
 }
@@ -100,7 +96,6 @@ transition_task_state "$TASK_UUID" in-progress achilles "Step 2 claim" || {
 if [ -n "$BRIEF_UUID" ]; then
   transition_brief_state "$BRIEF_UUID" dispatched achilles "task-started" || {
     rc=$?
-    [ "$rc" -eq 3 ] && exit 3
     printf 'error: transition_brief_state failed rc=%s\n' "$rc" >&2
     exit 2
   }

--- a/scripts/task-emit-debrief.sh
+++ b/scripts/task-emit-debrief.sh
@@ -21,15 +21,14 @@
 # Pre-merge mode (#249 Phase 2): pass `argus-reviewed` to *stage* the
 # debrief before task-merge.sh runs. The brief→debriefed transition and
 # the `brief_completed` event are deferred to task-finalize-merge.sh on
-# successful merge. Any other state runs the legacy single-shot path
-# (direct-mode and pre-#249 callers).
+# successful merge. Any other state runs the direct single-shot path used by
+# direct-mode and pre-#249 callers.
 #
 # Stdout: the minted debrief UUID.
 #
 # Exit codes:
 #   0  debrief written + state flips applied
 #   2  missing args or artifact not found
-#   3  reserved for retired dual-write partials
 
 set -u
 umask 022
@@ -100,10 +99,8 @@ export WITHHOLD_INDEX=1
 
 write_debrief_artifact "$DEBRIEF_UUID" "$TASK_UUID" "$BRIEF_ARG" task emitted ${KV_ARGS[@]+"${KV_ARGS[@]}"} || {
   rc=$?
-  [ "$rc" -ne 3 ] && { printf 'error: write_debrief_artifact failed rc=%s\n' "$rc" >&2; exit "$rc"; }
-  # rc=3 is retained for older callers that still understand the retired
-  # dual-write partial code. YAML is the only active debrief artifact.
-  DUAL_WRITE_PARTIAL=1
+  printf 'error: write_debrief_artifact failed rc=%s\n' "$rc" >&2
+  exit "$rc"
 }
 
 # Task back-ref — point at the new debrief. Idempotent if the caller retries.
@@ -115,7 +112,8 @@ set_task_link "$TASK_UUID" debrief "$DEBRIEF_UUID" || {
 # pre-Argus debriefs; `blocked` / `cancelled` are the escape hatches.
 transition_task_state "$TASK_UUID" "$TARGET_STATE" achilles "debrief emitted" || {
   rc=$?
-  [ "$rc" -eq 3 ] && DUAL_WRITE_PARTIAL=1 || { printf 'error: transition_task_state failed rc=%s\n' "$rc" >&2; exit "$rc"; }
+  printf 'error: transition_task_state failed rc=%s\n' "$rc" >&2
+  exit "$rc"
 }
 
 # Brief → debriefed only when we have a brief. Direct-mode skips. The
@@ -125,7 +123,8 @@ transition_task_state "$TASK_UUID" "$TARGET_STATE" achilles "debrief emitted" ||
 if [ -n "$BRIEF_UUID" ] && [ "$TARGET_STATE" != "argus-reviewed" ]; then
   transition_brief_state "$BRIEF_UUID" debriefed achilles "task complete" || {
     rc=$?
-    [ "$rc" -eq 3 ] && DUAL_WRITE_PARTIAL=1 || { printf 'error: transition_brief_state failed rc=%s\n' "$rc" >&2; exit "$rc"; }
+    printf 'error: transition_brief_state failed rc=%s\n' "$rc" >&2
+    exit "$rc"
   }
 fi
 
@@ -199,5 +198,4 @@ flush_index 2>/dev/null || true
 
 printf '%s\n' "$DEBRIEF_UUID"
 
-[ "${DUAL_WRITE_PARTIAL:-0}" -eq 1 ] && exit 3
 exit 0

--- a/scripts/task-finalize-merge.sh
+++ b/scripts/task-finalize-merge.sh
@@ -26,7 +26,6 @@
 # Exit codes:
 #   0  finalized
 #   2  missing args / artifact not found
-#   3  reserved for retired dual-write partials
 
 set -u
 umask 022
@@ -49,7 +48,6 @@ fi
 
 command -v jq >/dev/null 2>&1 || { printf 'error: jq required for fields-json parsing\n' >&2; exit 2; }
 
-DUAL_WRITE_PARTIAL=0
 saved_withhold="${WITHHOLD_INDEX:-0}"
 export WITHHOLD_INDEX=1
 
@@ -68,23 +66,15 @@ fi
 
 transition_task_state "$TASK_UUID" merged achilles "post-merge finalize" || {
   rc=$?
-  if [ "$rc" -eq 3 ]; then
-    DUAL_WRITE_PARTIAL=1
-  else
-    printf 'error: transition_task_state failed rc=%s\n' "$rc" >&2
-    exit "$rc"
-  fi
+  printf 'error: transition_task_state failed rc=%s\n' "$rc" >&2
+  exit "$rc"
 }
 
 if [ -n "$BRIEF_UUID" ]; then
   transition_brief_state "$BRIEF_UUID" debriefed achilles "task complete" || {
     rc=$?
-    if [ "$rc" -eq 3 ]; then
-      DUAL_WRITE_PARTIAL=1
-    else
-      printf 'error: transition_brief_state failed rc=%s\n' "$rc" >&2
-      exit "$rc"
-    fi
+    printf 'error: transition_brief_state failed rc=%s\n' "$rc" >&2
+    exit "$rc"
   }
 fi
 
@@ -131,5 +121,4 @@ emit_event_keyed achilles task brief_completed "$TASK_UUID" "$data" >/dev/null 2
 export WITHHOLD_INDEX="$saved_withhold"
 flush_index 2>/dev/null || true
 
-[ "$DUAL_WRITE_PARTIAL" -eq 1 ] && exit 3
 exit 0

--- a/scripts/task-invoke-argus.sh
+++ b/scripts/task-invoke-argus.sh
@@ -2,11 +2,12 @@
 # task-invoke-argus.sh — Step 8.5 of the Achilles task mode.
 #
 # Emits the `review_requested` event that marks the pre-Argus handoff and
-# prints `ACHILLES_REVIEW_REQUESTED_AT=<iso-ts>` so the debrief can correlate
-# the verdict timing. The actual Argus invocation happens in the mode-pack
-# prose via Claude's Agent tool (not reachable from a shell), and the
-# verdict-event emit (`review_approved` / `review_flagged` / `review_blocked`)
-# happens inside `scripts/argus-emit-verdict.sh`, which Argus calls directly.
+# prints `ACHILLES_REVIEW_REQUESTED_AT=<iso-ts>` so the debrief and
+# `dispatch-review.sh` timeout path can correlate verdict timing. The actual
+# Argus invocation happens in the mode-pack prose via Claude's Agent tool (not
+# reachable from a shell), and the verdict-event emit (`review_approved` /
+# `review_flagged` / `review_blocked`) happens inside
+# `scripts/argus-emit-verdict.sh`, which Argus calls directly.
 #
 # Usage:
 #   scripts/task-invoke-argus.sh <task-id> <worktree> <base-branch> <size>

--- a/scripts/test-fixtures/223-argus-contract-hardening/test-argus-contract-hardening.sh
+++ b/scripts/test-fixtures/223-argus-contract-hardening/test-argus-contract-hardening.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Verifies the Argus dispatch timeout path and the shared base-staleness
+# threshold source.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t argus-contract-223.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export HOME="$TMPROOT/home"
+export ACHILLES_PROJECT="argus-contract-223"
+
+REPO="$TMPROOT/repo"
+mkdir -p "$REPO/hosts" "$REPO/.slow-reviewer" "$REPO/bin" "$TMPROOT/worktree"
+ln -s "$ROOT/scripts" "$REPO/scripts"
+ln -s "$ROOT/_shared" "$REPO/_shared"
+
+cat > "$REPO/hosts/registry.yaml" <<'YAML'
+slow-reviewer:
+  capabilities_path: ".slow-reviewer/capabilities.yaml"
+YAML
+
+cat > "$REPO/.slow-reviewer/capabilities.yaml" <<EOF
+supports_hooks: false
+spawn_command: "$REPO/bin/slow-review.sh"
+block_for_event_strategy: tail
+tool_dialect: openai
+sandbox_profile: full
+secret_scope: none
+EOF
+
+cat > "$REPO/bin/slow-review.sh" <<'SH'
+#!/usr/bin/env bash
+sleep 5
+SH
+chmod +x "$REPO/bin/slow-review.sh"
+
+# shellcheck source=../../../scripts/lib-paths.sh
+. "$ROOT/scripts/lib-paths.sh"
+# shellcheck source=../../../scripts/lib-ledger.sh
+. "$ROOT/scripts/lib-ledger.sh"
+
+TASK_ID="T223"
+IDEM_KEY="$TASK_ID:quality:1"
+REQUESTED_AT="2026-05-02T00:00:00Z"
+HANDOFF_CAPTURE="$TMPROOT/handoff.json"
+export STUDIO_HOST="slow-reviewer"
+export TASK_SIZE="S"
+export ACHILLES_REVIEW_REQUESTED_AT="$REQUESTED_AT"
+export DISPATCH_REVIEW_CAPTURE_HANDOFF="$HANDOFF_CAPTURE"
+
+emit_event_keyed argus review review_flagged "$TASK_ID" \
+  '{"stage":"spec","review_file":"reviews/review_T223_spec.md","finding_count":2}' \
+  --idem-key "$TASK_ID:spec:1" >/dev/null
+
+set +e
+DISPATCH_REVIEW_TIMEOUT=2 "$REPO/scripts/dispatch-review.sh" "$TASK_ID" quality \
+  --idempotency-key "$IDEM_KEY" >/dev/null 2>"$TMPROOT/dispatch-stderr"
+dispatch_rc=$?
+set -e
+
+if [ "$dispatch_rc" -eq 0 ]; then
+  printf 'FAIL: dispatch-review unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+LOG=$(resolve_event_log)
+jq -e --arg req "$REQUESTED_AT" \
+  'select(.event == "review_timeout" and .data.requested_at == $req and .data.timeout_s == 2 and .data.stage == "quality")' \
+  "$LOG" >/dev/null
+jq -e 'select(.event == "argus_gate_skipped" and .data.reason == "verdict_timeout_2s")' \
+  "$LOG" >/dev/null
+jq -e '.from == "chanakya" and .to == "argus" and .payload_ref.prior_findings_summary.verdict == "flagged" and .payload_ref.prior_findings_summary.finding_count == 2' \
+  "$HANDOFF_CAPTURE" >/dev/null
+
+offset_file="$TMPROOT/events_offset.fixture"
+mkdir -p "$(dirname "$offset_file")"
+printf '%s.jsonl:0\n' "$(basename "$LOG" .jsonl)" > "$offset_file"
+"$REPO/scripts/sweep-process-events.sh" --offset-file "$offset_file" >/dev/null
+QUEUE=$(resolve_push_queue)
+jq -e 'select(.kind == "review_timeout" and (.text | test("timed out"))) ' "$QUEUE" >/dev/null
+
+BASE_DOC="$TMPROOT/base-staleness.md"
+cat > "$BASE_DOC" <<'MD'
+Threshold: 7
+MD
+
+set +e
+DRY_RUN=1 ACHILLES_BASE_STALENESS_DOC="$BASE_DOC" "$REPO/scripts/achilles-refresh-base.sh" \
+  "$TASK_ID" "$TMPROOT/worktree" main >/dev/null 2>"$TMPROOT/refresh-stderr"
+refresh_rc=$?
+set -e
+
+if [ "$refresh_rc" -ne 0 ]; then
+  printf 'FAIL: dry-run refresh-base exited %s\n' "$refresh_rc" >&2
+  cat "$TMPROOT/refresh-stderr" >&2
+  exit 1
+fi
+
+grep -q 'threshold=7' "$TMPROOT/refresh-stderr" || {
+  printf 'FAIL: refresh-base did not read threshold from shared primitive\n' >&2
+  cat "$TMPROOT/refresh-stderr" >&2
+  exit 1
+}
+
+printf 'PASS: argus contract hardening\n'

--- a/scripts/tests-write-round.sh
+++ b/scripts/tests-write-round.sh
@@ -2,9 +2,9 @@
 # tests-write-round.sh — Step 7 round artifact write for /chanakya test-flow.
 #
 # Thin wrapper that mints a UUIDv7 and delegates to lib-ledger's
-# write_round_artifact, which handles the YAML write, legacy markdown
-# dual-write at plans/user-testing-rounds/user-testing-round<N>.md, the
-# round_state_changed event, and index rebuild.
+# write_round_artifact, which handles the YAML write, round_state_changed
+# event, and index rebuild. Legacy round markdown is read-only historical
+# input post-#245 A.4/A.5.
 #
 # Usage:
 #   scripts/tests-write-round.sh <round-number> <scope> <tasks-csv> <body-file>
@@ -15,7 +15,6 @@
 # Exit codes:
 #   0  round written
 #   2  missing args or body-file
-#   3  dual-write partial failure propagated from lib-ledger
 
 set -u
 umask 022
@@ -46,7 +45,7 @@ body=$(cat "$BODY_FILE")
 
 write_round_artifact "$uuid" "$ROUND_NUM" "$SCOPE" "$TASKS_CSV" "$body"
 rc=$?
-if [ "$rc" -ne 0 ] && [ "$rc" -ne 3 ]; then
+if [ "$rc" -ne 0 ]; then
   printf 'error: write_round_artifact failed rc=%s\n' "$rc" >&2
   exit "$rc"
 fi


### PR DESCRIPTION
## Summary
- adds an explicit #76 audit record for the named mode packs and active ledger writers
- removes stale retired dual-write rc=3 handling/prose from active scripts
- refreshes FORGE-RELIABILITY.md now that #76 is closing

Closes #76

## Verification
- .githooks/pre-commit
- bash scripts/lint-debrief-writers.sh
- bash scripts/lint-comms-boundary.sh
- bash -n scripts/argus-emit-verdict.sh scripts/task-claim.sh scripts/task-emit-debrief.sh scripts/task-finalize-merge.sh scripts/tests-write-round.sh scripts/sweep-ingest.sh
- bash scripts/test-fixtures/311-debrief-writer-lint/test-debrief-writer-lint.sh
- bash scripts/test-fixtures/migrate-ledger/migrate-roundtrip.sh
- bash scripts/test-fixtures/rebuild-index/index-roundtrip.sh

## Notes
- lint-comms-boundary still reports the pre-existing chanakya/reopen schema warning
- lint-host-agnostic still reports the pre-existing Argus secret-scope adapter warning