### PR TITLE
Add Forge reliability closure chain

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T18:09:50Z",
+  "generated_at": "2026-05-02T18:20:39Z",
   "agents": [
     {
       "name": "studio",

--- a/chains/forge-reliability-closure.yaml
+++ b/chains/forge-reliability-closure.yaml
@@ -1,0 +1,58 @@
+# Forge reliability closure chain.
+#
+# Dry-run first:
+#   scripts/studio-chain-runner.sh chains/forge-reliability-closure.yaml --dry-run
+#
+# Execute the full ordered sequence:
+#   scripts/studio-chain-runner.sh chains/forge-reliability-closure.yaml --host codex
+#
+# Or via the studio router:
+#   /studio work chain forge-reliability-closure
+#
+# The chains are intentionally one issue each. These are safety-floor and
+# policy-sensitive fixes; landing one reviewed PR per issue keeps rollback,
+# tracker updates, and design-gate decisions explicit.
+
+schema_version: 1
+chains:
+  - name: forge-reliability-336-brief-resolution
+    base: main
+    branch: feature/forge-reliability-336-brief-resolution
+    host: auto
+    issues: [336]
+
+  - name: forge-reliability-313-argus-registry
+    base: main
+    branch: feature/forge-reliability-313-argus-registry
+    host: auto
+    issues: [313]
+
+  - name: forge-reliability-372-codex-parity
+    base: main
+    branch: feature/forge-reliability-372-codex-parity
+    host: auto
+    issues: [372]
+
+  - name: forge-reliability-224-merge-gate
+    base: main
+    branch: feature/forge-reliability-224-merge-gate
+    host: auto
+    issues: [224]
+
+  - name: forge-reliability-322-model-policy
+    base: main
+    branch: feature/forge-reliability-322-model-policy
+    host: auto
+    issues: [322]
+
+  - name: forge-reliability-434-build-diagnostics
+    base: main
+    branch: feature/forge-reliability-434-build-diagnostics
+    host: auto
+    issues: [434]
+
+  - name: forge-reliability-435-testflight-version
+    base: main
+    branch: feature/forge-reliability-435-testflight-version
+    host: auto
+    issues: [435]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T18:09:49Z",
+  "generated_at": "2026-05-02T18:20:38Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- adds a sequential studio chain manifest for the current Forge reliability closure queue
- keeps each design-gated issue in its own reviewed PR chain

## Verification
- scripts/studio-chain-runner.sh chains/forge-reliability-closure.yaml --dry-run
- .githooks/pre-commit

## Notes
- pre-commit still reports the existing chanakya/reopen schema warning