### PR TITLE
Document field-agent review wrapper rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,19 @@ Pick the sibling reviewer explicitly (`claude-reviewer` when primary is Codex,
 `scripts/pr-reviewer-eligibility.sh` first and stops before the phase if the
 reviewer is not smoke-eligible.
 
+**Field-agent review setup rule:** this same primitive applies when v2 field
+agents add cross-host **review** to worker, planner/architect, qa-engineer,
+flow-tester, release-manager, or perf workflows. Do not embed raw review-host
+CLI spawns (`claude -p`, `codex exec`, etc.) in worker/architect mode packs,
+briefs, manifests, or issue acceptance criteria. Route review through the
+smoke-gated reviewer profile wrapper (`scripts/phase-review.sh` today) or a v2
+successor that preserves the same contract: auth-home selection, no-secret env
+scrubbing, MCP isolation, sandbox-readable payload handoff, and failure-detail
+surfacing stay centralized. User-controlled override for emergency/debug-only
+cases: `STUDIO_BYPASS_FIELD_REVIEW_WRAPPER=1`; the bypass must be mentioned in
+the plan/outcome artifact and must not be used silently by an assistant. See
+`hosts/ADAPTER-SPEC.md` §PR reviewer profiles for the adapter-side contract.
+
 **Required content of phase-plan.md:**
 
 - Goal of the phase

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T19:47:08Z",
+  "generated_at": "2026-05-02T20:06:41Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T19:47:06Z",
+  "generated_at": "2026-05-02T20:06:40Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/hosts/ADAPTER-SPEC.md
+++ b/hosts/ADAPTER-SPEC.md
@@ -91,6 +91,17 @@ keep using scratch `HOME` plus `CODEX_HOME`.
 Do not make a normal worker profile eligible by relaxing the gate. Add a
 dedicated `<host>-reviewer` adapter with its own manifest and enforcement.
 
+The reviewer-profile primitive is not PR-only. Any cross-host review used by
+field agents (worker, planner/architect, qa-engineer, flow-tester,
+release-manager, perf) must route through this same smoke-gated profile layer
+or a v2 successor with the same contract, not through hand-written raw host
+commands. The contract is: host auth roots, no-secret env scrubbing, MCP
+isolation, sandbox-readable payload handoff, and startup-failure diagnostics
+are centralized. Emergency/debug-only override is
+`STUDIO_BYPASS_FIELD_REVIEW_WRAPPER=1`; use must be user-controlled and
+recorded in the review artifact. See `CLAUDE.md` §Cross-host phase review for
+the workflow rule that consumes this adapter contract.
+
 ### Env-scrub at Argus dispatch
 
 `scripts/dispatch-review.sh` enforces the Argus floor at spawn time by env-scrubbing the subprocess. Only PATH/HOME/LANG/USER, the host plugin-root, and explicit task-context vars cross the boundary; `ANTHROPIC_API_KEY`, `GH_TOKEN`/`GITHUB_TOKEN`, and arbitrary inherited env are dropped. The host CLI re-authenticates from its own keychain inside the spawned session.

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -5,6 +5,11 @@
 #   scripts/phase-review.sh --review-host claude-reviewer --input plan.md --output review.md
 #   scripts/phase-review.sh --kind outcome --input outcome.md --output outcome-review.md
 #
+# Emergency/debug-only bypass for field-agent wrapper enforcement:
+#   STUDIO_BYPASS_FIELD_REVIEW_WRAPPER=1
+# The bypass is user-controlled and must be recorded in the plan/outcome
+# artifact; assistants must not use it silently.
+#
 # This is deliberately a thin wrapper over pr-reviewer-eligibility.sh. Phase
 # gates must not hand-compose raw `claude -p` / `codex exec` calls; those bypass
 # the smoke/auth/config checks that keep reviewer sessions reliable.


### PR DESCRIPTION
## Summary

- Extend the cross-host review rule so future worker/planner/architect/qa/flow/release/perf review setup uses smoke-gated reviewer profiles, not raw host CLI snippets.
- Record the adapter-side contract in hosts/ADAPTER-SPEC and add the emergency/debug-only override note to phase-review.sh.
- File #458 for mechanical linting so this becomes enforceable beyond prose.

## Verification

- `git diff --check`
- `bash -n scripts/phase-review.sh`
- `bash scripts/test-fixtures/454-phase-review/test-phase-review.sh`
- Claude rule-shape review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-03-field-agent-review-rule-review-round2.md` -> clean, nothing fatal.

Related: #458