### PR TITLE
Surface parallel chain opportunities at pickup

### DIFF
--- a/.claude/skills/studio/modes/work.md
+++ b/.claude/skills/studio/modes/work.md
@@ -40,6 +40,25 @@ Run:
 scripts/studio-chain-runner.sh <manifest-or-name> [--only <chain>] [--host codex|claude-code] [--dry-run]
 ```
 
+## Manual parallel shell guidance
+
+When a manifest contains independent chains, tell the user they can open one
+shell session per chain and run `--only <chain>` in each. Start with dry-runs
+so branch/worktree/PR/review shape is visible before execution:
+
+```bash
+# Shell 1
+scripts/studio-chain-runner.sh <manifest-or-name> --only <chain-a> --dry-run
+
+# Shell 2
+scripts/studio-chain-runner.sh <manifest-or-name> --only <chain-b> --dry-run
+```
+
+After the user accepts the dry-run shape, provide the matching non-dry-run
+commands. Only suggest this when the chains are dependency-independent and do
+not share an integration branch or phase gate. Each chain runner creates its
+own worktrees and final reviewed PR; keep dependent chains sequential.
+
 Manifest:
 
 ```yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,22 @@ When the user proposes or asks for work:
 
 Keep this pragmatic. Do not turn tiny edits into ceremony, do not block urgent fixes on speculative polish, and do not expand scope silently. If an improvement is obvious and low-risk, fold it in; if it changes behavior, cost, priority, or runtime risk, surface it before implementation.
 
+## Parallel chain surfacing
+
+When studio work contains independent chains, tracks, batches, or issue groups,
+surface the parallelization option explicitly. The default assistant shape is:
+one short "parallel opportunities" line, followed by one command per manual
+shell/session when the user is expected to launch work themselves. Name the
+independence boundary (different chain names, disjoint issues, separate
+worktrees/branches) and keep dependency-ordered work sequential.
+
+Do not auto-spawn user shell sessions. Do not suggest parallelizing across:
+unclean phase-gate reviews, dependent phases, shared branch/index mutations,
+or work that has not been shaped enough to know its write boundaries. For
+studio chains, suggest `scripts/studio-chain-runner.sh <manifest> --only
+<chain> --dry-run` per shell first, then the non-dry-run command after the user
+accepts the shape.
+
 ## Auto-apply tiers (reduce user touchpoints)
 
 The studio's own rules and conventions are auto-improvable. Some changes apply silently; some require a quick OK. Default to action; ask only when there's real ambiguity.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-02T20:06:41Z",
+  "generated_at": "2026-05-02T20:14:21Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-02T20:06:40Z",
+  "generated_at": "2026-05-02T20:14:20Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,6 +65,7 @@ scripts/forge-latency-report.sh --project turnip-ios --days 14   # stage-level t
 scripts/field-workflow-report.sh --project turnip-ios --days 14   # Field loop timing, tokens, gates, review coverage, improvement candidates
 scripts/studio-chain-runner.sh workflow-measurement-improvements --dry-run  # plan chain branches, capacity-scaled fresh sessions, PR review/merge
 scripts/studio-chain-runner.sh workflow-measurement-improvements --host codex # execute chains with node/RAM-sized session pool + private report
+scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution
 scripts/host-preflight.sh codex /repo                 # gh auth + git ls-remote credential-helper proof before host task work
 
 # Chain runner pool sizing:


### PR DESCRIPTION
## Summary

- Add bootstrap pickup guidance for a concise "Parallel opportunities" line and one command per manual shell/session when work is independent.
- Teach studio work chain mode to suggest `--only <chain> --dry-run` per shell for dependency-independent chains.
- Add a scripts README example for manual per-chain dry-runs.

## Verification

- `git diff --check`
- `scripts/lint-mode-pack.sh .claude/skills/studio/modes/work.md` (existing grandfathered token-budget warning only)
- Pre-commit hook: architecture lint 0 errors; comms-boundary existing chanakya/reopen warning; mode-pack grandfathered warning.

Closes #460