### PR TITLE
Add Apollo network chain launcher

### DIFF
--- a/.claude/skills/studio/docs.html
+++ b/.claude/skills/studio/docs.html
@@ -330,6 +330,7 @@
 /studio work &lt;track&gt;      # run a parallel track, then final reviewed PR + cleanup + summary
 /studio work chain workflow-measurement-improvements  # run issue chains with fresh sessions, UUID telemetry, reviewed PRs, cleanup
 scripts/studio-chain-reviewed.sh apollo-network-efficiency --host codex --review-host claude-reviewer  # phase-review the plan, then run reviewed chain PRs
+scripts/run-apollo-network-reviewed-chain.sh  # background Apollo network chain; prints PID + latest-log tail command
 /studio janitor [--yes]   # cross-project sweep of stale artifacts (dry-run by default)
 /studio nodes             # day-2 fleet management — status, add, sync, health, diagnose, schedule, recheck
 /studio tf-push [--dry-run] [--version X.Y.Z] [--background]  # TestFlight push; explicit version + optional background handle

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ scripts/field-workflow-report.sh --days 14                  # Field loop timing,
 scripts/studio-pr-baseline-report.sh 366                    # PR-level timing, churn, gate, and generated-file baselines
 scripts/host-preflight.sh codex /repo                       # prove gh + git credential access before host task work
 scripts/studio-chain-reviewed.sh apollo-network-efficiency --host codex --review-host claude-reviewer  # pre-run plan review + reviewed chain PR merges
+scripts/run-apollo-network-reviewed-chain.sh                # fire-and-sleep Apollo network chain launcher; prints PID + log path
 scripts/pre-commit-review.sh                                # manual no-secret reviewer gate for risky staged diffs
 scripts/pr-headless-review.sh <pr>                          # run smoke-eligible no-secret reviewer gate, then merge if non-blocked
 scripts/pr-headless-review.sh <pr> --no-require-cross-host   # opt out of the default independent-provider reviewer requirement

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T02:00:34Z",
+  "generated_at": "2026-05-03T02:12:02Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T02:00:33Z",
+  "generated_at": "2026-05-03T02:12:00Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,6 +67,7 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements --dry-run  # pl
 scripts/studio-chain-runner.sh workflow-measurement-improvements --host codex # execute chains with node/RAM-sized session pool + private report
 scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution
 scripts/studio-chain-reviewed.sh apollo-network-efficiency --host codex --review-host claude-reviewer  # pre-run phase review, then chain PRs reviewed by the selected reviewer
+scripts/run-apollo-network-reviewed-chain.sh             # background Apollo network chain; prints PID + latest-log tail command
 scripts/host-preflight.sh codex /repo                 # gh auth + git ls-remote credential-helper proof before host task work
 
 # Chain runner pool sizing:

--- a/scripts/run-apollo-network-reviewed-chain.sh
+++ b/scripts/run-apollo-network-reviewed-chain.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# run-apollo-network-reviewed-chain.sh — one-command Apollo network chain launch.
+#
+# Usage:
+#   scripts/run-apollo-network-reviewed-chain.sh [--dry-run] [--foreground]
+#
+# Default mode starts the reviewed Apollo network-efficiency chain in the
+# background, keeps the machine awake through studio-chain-reviewed.sh, and
+# writes a timestamped log plus a stable latest-log symlink.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+
+usage() {
+  sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+DRY_RUN=0
+FOREGROUND=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --foreground) FOREGROUND=1; shift ;;
+    -h|--help) usage ;;
+    *)
+      printf 'run-apollo-network-reviewed-chain: unknown flag %s\n' "$1" >&2
+      usage
+      ;;
+  esac
+done
+
+LOGIN_HOME=$(resolve_user_login_home 2>/dev/null || true)
+[ -n "$LOGIN_HOME" ] && [ -d "$LOGIN_HOME" ] || {
+  printf 'run-apollo-network-reviewed-chain: could not resolve login home\n' >&2
+  exit 1
+}
+
+log_dir="$(resolve_project_root_for generic-dev-studio)/chain-runs/manual-logs"
+mkdir -p "$log_dir"
+
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+suffix="reviewed"
+if [ "$DRY_RUN" -eq 1 ]; then
+  suffix="reviewed-dry-run"
+fi
+log_file="$log_dir/apollo-network-efficiency-$suffix-$stamp.log"
+latest_log="$log_dir/apollo-network-efficiency-$suffix.latest.log"
+
+cmd=("$SCRIPT_DIR/studio-chain-reviewed.sh" apollo-network-efficiency --host codex --review-host claude-reviewer)
+if [ "$DRY_RUN" -eq 1 ]; then
+  cmd+=(--dry-run --no-caffeinate)
+fi
+
+ln -sfn "$log_file" "$latest_log"
+
+if [ "$FOREGROUND" -eq 1 ]; then
+  printf 'run-apollo-network-reviewed-chain: running in foreground\n' | tee "$log_file"
+  printf 'run-apollo-network-reviewed-chain: log: %s\n' "$log_file" | tee -a "$log_file"
+  set +e
+  (
+    cd "$REPO_ROOT"
+    HOME="$LOGIN_HOME" "${cmd[@]}"
+  ) 2>&1 | tee -a "$log_file"
+  rc=${PIPESTATUS[0]}
+  set -e
+  printf 'run-apollo-network-reviewed-chain: exit_code=%s\n' "$rc" | tee -a "$log_file"
+  exit "$rc"
+fi
+
+nohup bash -lc 'cd "$1" && shift && exec env HOME="$1" "${@:2}"' \
+  bash "$REPO_ROOT" "$LOGIN_HOME" "${cmd[@]}" \
+  > "$log_file" 2>&1 &
+pid=$!
+
+printf 'APOLLO_NETWORK_CHAIN_PID=%s\n' "$pid"
+printf 'APOLLO_NETWORK_CHAIN_LOG=%s\n' "$log_file"
+printf 'APOLLO_NETWORK_CHAIN_LATEST_LOG=%s\n' "$latest_log"
+printf 'tail -f %q\n' "$latest_log"


### PR DESCRIPTION
## Summary

- add scripts/run-apollo-network-reviewed-chain.sh as a fire-and-sleep Apollo network launcher
- background mode prints PID, timestamped log, and latest-log tail command
- add dry-run/foreground mode for verification and document the entry point

## Verification

- bash -n scripts/run-apollo-network-reviewed-chain.sh
- HOME=/Users/vishalsingh scripts/run-apollo-network-reviewed-chain.sh --dry-run --foreground
- git diff --check
- zsh -c 'source scripts/lib-paths.sh && resolve_project_root_for generic-dev-studio >/dev/null'
- opened .claude/skills/studio/docs.html in Safari
- REVIEW.md manual pass for script changes