### PR TITLE
Fix Apollo chain launcher backgrounding

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T02:12:02Z",
+  "generated_at": "2026-05-03T02:44:59Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T02:12:00Z",
+  "generated_at": "2026-05-03T02:44:57Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/run-apollo-network-reviewed-chain.sh
+++ b/scripts/run-apollo-network-reviewed-chain.sh
@@ -53,6 +53,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 log_file="$log_dir/apollo-network-efficiency-$suffix-$stamp.log"
 latest_log="$log_dir/apollo-network-efficiency-$suffix.latest.log"
+run_script="$log_dir/apollo-network-efficiency-$suffix-$stamp.run.sh"
 
 cmd=("$SCRIPT_DIR/studio-chain-reviewed.sh" apollo-network-efficiency --host codex --review-host claude-reviewer)
 if [ "$DRY_RUN" -eq 1 ]; then
@@ -75,12 +76,25 @@ if [ "$FOREGROUND" -eq 1 ]; then
   exit "$rc"
 fi
 
-nohup bash -lc 'cd "$1" && shift && exec env HOME="$1" "${@:2}"' \
-  bash "$REPO_ROOT" "$LOGIN_HOME" "${cmd[@]}" \
-  > "$log_file" 2>&1 &
-pid=$!
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -euo pipefail\n'
+  printf 'cd %q\n' "$REPO_ROOT"
+  printf 'exec env HOME=%q' "$LOGIN_HOME"
+  printf ' %q' "${cmd[@]}"
+  printf ' >> %q 2>&1\n' "$log_file"
+} > "$run_script"
+chmod +x "$run_script"
 
-printf 'APOLLO_NETWORK_CHAIN_PID=%s\n' "$pid"
+session_name="apollo-network-${suffix}-${stamp}"
+if command -v screen >/dev/null 2>&1; then
+  screen -dmS "$session_name" bash "$run_script"
+  printf 'APOLLO_NETWORK_CHAIN_SESSION=%s\n' "$session_name"
+  printf 'screen -r %q\n' "$session_name"
+else
+  nohup bash "$run_script" >/dev/null 2>&1 &
+  printf 'APOLLO_NETWORK_CHAIN_PID=%s\n' "$!"
+fi
 printf 'APOLLO_NETWORK_CHAIN_LOG=%s\n' "$log_file"
 printf 'APOLLO_NETWORK_CHAIN_LATEST_LOG=%s\n' "$latest_log"
 printf 'tail -f %q\n' "$latest_log"


### PR DESCRIPTION
## Summary

- replace the reaped nohup bash -lc launcher with a generated run script
- use detached screen when available so this Codex session can launch and return safely
- retain nohup fallback for normal shells without screen

## Verification

- bash -n scripts/run-apollo-network-reviewed-chain.sh
- HOME=/Users/vishalsingh scripts/run-apollo-network-reviewed-chain.sh --dry-run starts a detached screen session and writes the latest dry-run log
- screen -ls confirms detached dry-run session exists
- dry-run log begins with studio-chain-reviewed plan review
- git diff --check
- REVIEW.md manual pass for script changes