### PR TITLE
Formalize label taxonomy

### DIFF
--- a/THEMES.md
+++ b/THEMES.md
@@ -60,11 +60,28 @@ Informed by observing how the studio is actually used today — not aspirational
 
 ---
 
+## Retained active theme labels
+
+These labels predate the current six-theme taxonomy and still appear on active issues. Retain them until their open issues are intentionally reclassified; do not add them to new issues by default. The GitHub issue templates offer the six canonical themes above plus `needs-triage` for this reason.
+
+| Label | Status | Use on existing issues |
+|---|---|---|
+| `theme/input` | Retained | PRD, Figma, conversation, and requirements intake work from the older input-pipeline taxonomy. |
+| `theme/implement` | Retained | Modularization, flags, and implementation-structure work from the older delivery taxonomy. |
+| `theme/observe` | Retained | Crash, telemetry, review, and post-release signal work from the older observability taxonomy. |
+| `theme/ship` | Retained | Release-health and rollout-manifest work from the older shipping taxonomy. |
+| `theme/meta` | Retained | Process, checklist, and changelog-convention work from the older process taxonomy. |
+
+---
+
 ## How themes interact with issues
 
-- Every issue gets one `theme/*` label.
-- One issue can address multiple themes (rare); pick the dominant theme.
-- Theme labels persist; issue labels (`phase-2`, `enhancement`, `bug`) describe the work type.
+- Every open issue gets one dominant `theme/*` label.
+- One issue can address multiple themes, but that is rare; keep the first label in issue prose and comments as the dominant theme when humans need to disambiguate.
+- Theme labels describe long-running investment areas. Work-type labels such as `enhancement`, `bug`, `documentation`, `polish`, `roadmap`, and `phase-2` describe the shape or timing of the work.
+- Track labels (`track:*`) identify parallel work lanes or active arcs. They are documented in `TRACKS.md`.
+- Chain labels (`chain/*`) identify automated runner chains and are operational, not thematic.
+- Status labels such as `urgent`, `blocked`, `parking-lot`, `pilot`, `duplicate`, `question`, and `wontfix` describe workflow state or handling.
 
 ## How themes evolve
 

--- a/TRACKS.md
+++ b/TRACKS.md
@@ -2,6 +2,23 @@
 
 Independent work tracks. Each session works on one track only.
 
+## Track label registry
+
+`track:*` labels identify active or historical work lanes. A track label is not a theme; every issue still needs one dominant `theme/*` label from `THEMES.md`.
+
+| Label | Status | Planning surface |
+|---|---|---|
+| `track:apollo` | Active | Apollo performance-agent research and build arc. Detailed work lives in the Apollo issues and skill docs. |
+| `track:build-opt` | Active | Documented below as Track B. |
+| `track:forge-safety` | Retained / no open issues | Documented below as Track C and in `FORGE-RELIABILITY.md`; keep for historical filtering until a new forge-safety issue reopens the lane. |
+| `track:host-agnostic` | Historical / mostly shipped | Documented below as Track A for context. |
+| `track:pm-surface` | Active | GitHub-as-PM-surface arc, including labels, projects, milestones, and issue graph hygiene. |
+| `track:skill-distribution` | Active backlog | Skill distribution and recipe-system follow-ups from the skill distribution arc. |
+| `track:v2` | Active | Studio v2 substrate rebuild and transition issues; sequence context lives in `ROADMAP.md`. |
+| `track:workflow` | Active | Chain-runner and workflow-control-plane enhancements. |
+
+Legacy follow-up labels such as `phase-2-5-followup`, `phase-2-6-followup`, and `phase-2.7-epic` are retained for existing issue filtering, but they are not `track:*` labels. Prefer a `track:*` label for new parallel work lanes.
+
 ## How to use
 
 1. **Pick a track** — open a session, check out the track branch.


### PR DESCRIPTION
## Summary
- document canonical and retained theme labels in THEMES.md
- add active/historical track label registry to TRACKS.md
- backfill theme labels for open issues and record B3 evidence on #443

## Verification
- HOME=/Users/vishalsingh gh issue list --state open --limit 300 --json number,title,labels -> missing_theme=0 across 91 open issues
- phase plan review: /Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-03-b3-label-taxonomy-plan-review.md, nothing fatal
- phase outcome review: /Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-03-b3-label-taxonomy-outcome-review.md, nothing fatal
- git diff --check

Closes #465