### PR TITLE
Fix phase-review feedback extraction

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T08:25:37Z",
+  "generated_at": "2026-05-03T09:27:50Z",
   "agents": [
     {
       "name": "studio",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T08:25:36Z",
+  "generated_at": "2026-05-03T09:27:48Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -569,23 +569,40 @@ phase_review_record() {
 compact_phase_review_feedback_json() {
   local review_file="$1"
   awk '
+    function review_section(line, lower) {
+      lower=tolower(line)
+      sub(/^[[:space:]]*#+[[:space:]]*/, "", lower)
+      sub(/^[[:space:]]*/, "", lower)
+      if (lower ~ /^accepted plan adjustments?([[:space:]:]|$)/) return "accepted plan adjustments"
+      if (lower ~ /^plan adjustments?([[:space:]:]|$)/) return "plan adjustments"
+      if (lower ~ /^recommendations?([[:space:]:]|$)/) return "recommendations"
+      if (lower ~ /^warnings?([[:space:]:]|$)/) return "warnings"
+      if (lower ~ /^(fatal blockers?|blockers?)([[:space:]:]|$)/) return "__stop__"
+      return ""
+    }
     BEGIN { section="" }
     /^[[:space:]]*PHASE_REVIEW_VERDICT[[:space:]]*[:=]/ { next }
-    /^[[:space:]]*(Warnings?|Recommendations?|Plan adjustments?|Accepted plan adjustments?)[[:space:]]*:?/ {
-      section=tolower($0)
-      sub(/:.*/, "", section)
-      next
+    {
+      next_section=review_section($0)
+      if (next_section == "__stop__") {
+        section=""
+        next
+      }
+      if (next_section != "") {
+        section=next_section
+        next
+      }
     }
-    /^[[:space:]]*(Fatal blockers?|Blockers?)[[:space:]]*:?/ { section=""; next }
-    section != "" && /^[[:space:]]*([-*]|\d+[.)])[[:space:]]+/ {
+    section != "" && /^[[:space:]]*([-*]|[0-9]+[.)])[[:space:]]+/ {
       line=$0
-      sub(/^[[:space:]]*([-*]|\d+[.)])[[:space:]]+/, "", line)
-      gsub(/"/, "\\\"", line)
+      sub(/^[[:space:]]*([-*]|[0-9]+[.)])[[:space:]]+/, "", line)
       if (line != "") print section "\t" line
+      next
     }
   ' "$review_file" | jq -R -s -c '
     split("\n")[:-1]
-    | map(split("\t") | {kind:.[0], text:.[1]})
+    | map(capture("^(?<kind>[^\t]+)\t(?<text>.*)$")?)
+    | map(select(. != null))
     | map(select(.text != null and .text != ""))
     | .[:8]
   '

--- a/scripts/test-fixtures/492-phase-review-feedback/test-phase-review-feedback.sh
+++ b/scripts/test-fixtures/492-phase-review-feedback/test-phase-review-feedback.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t phase-review-feedback.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# Source only the extractor function; the full runner executes on load.
+extractor="$TMPROOT/extractor.sh"
+sed -n '/^compact_phase_review_feedback_json()/,/^}/p' "$ROOT/scripts/studio-chain-runner.sh" > "$extractor"
+# shellcheck source=/dev/null
+. "$extractor"
+
+review="$TMPROOT/review.md"
+cat > "$review" <<'MD'
+PHASE_REVIEW_VERDICT=clean
+
+## Warnings
+
+- dash bullet
+* star bullet with "quoted text"
+1. numbered dot with "quoted text"
+2) numbered paren
+
+## Recommendations
+
+1. recommendation with "quoted text"
+
+## Fatal blockers
+
+- must not be forwarded
+
+## Accepted plan adjustments
+
+- accepted adjustment with "quoted text"
+MD
+
+json=$(compact_phase_review_feedback_json "$review")
+
+printf '%s\n' "$json" | jq -e '
+  length == 6
+  and any(.[]; .kind == "warnings" and .text == "dash bullet")
+  and any(.[]; .kind == "warnings" and .text == "star bullet with \"quoted text\"")
+  and any(.[]; .kind == "warnings" and .text == "numbered dot with \"quoted text\"")
+  and any(.[]; .kind == "warnings" and .text == "numbered paren")
+  and any(.[]; .kind == "recommendations" and .text == "recommendation with \"quoted text\"")
+  and any(.[]; .kind == "accepted plan adjustments" and .text == "accepted adjustment with \"quoted text\"")
+  and all(.[]; (.text | contains("\\\"") | not))
+  and all(.[]; .text != "must not be forwarded")
+' >/dev/null
+
+printf 'PASS: phase-review feedback extraction preserves bullets and quotes\n'


### PR DESCRIPTION
## Summary
- fix compact phase-review feedback extraction for numbered bullets on macOS/BSD awk
- stop manually escaping quotes before jq -R so forwarded private context keeps normal quoted text
- add fixture coverage for dash, star, numbered bullets, quoted text, and blocker-section exclusion

Fixes #492.

## Verification
- bash -n scripts/studio-chain-runner.sh scripts/test-fixtures/492-phase-review-feedback/test-phase-review-feedback.sh
- bash scripts/test-fixtures/492-phase-review-feedback/test-phase-review-feedback.sh
- bash scripts/test-fixtures/395-chain-control-plane/test-plan-state-and-validation.sh
- bash scripts/test-fixtures/454-phase-review/test-phase-review.sh
- bash scripts/test-fixtures/478-chain-task-envelope/test-chain-task-envelope.sh
- bash scripts/test-fixtures/479-chain-halt-escrow/test-chain-halt-escrow.sh
- bash scripts/test-fixtures/481-chain-supervisor/test-chain-supervisor.sh
- staged lint gates passed; existing comms-boundary warning only