### PR TITLE
Expand v2 transition executable manifest

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T11:59:53Z",
+  "generated_at": "2026-05-03T12:53:30Z",
   "agents": [
     {
       "name": "studio",

--- a/chains/v2-transition.yaml
+++ b/chains/v2-transition.yaml
@@ -12,16 +12,46 @@
 # after the reviewed PR merges.
 #
 # Phase schedule:
-# - B5 native sub-issue migration starts the chain by linking #495 as the
-#   first GitHub-native leaf under the #443 PM-surface umbrella.
-# - Keep this B5 chain scoped to #495. Add future B/A/C/D runnable leaves only
-#   after their native leaf issues exist and their phase plan review is clean.
+# - B2-B5 are already closed leaf evidence: #464, #465, #466, #495.
+# - B10 is intentionally excluded because #443 marks it as a placeholder
+#   dependent on the closed #446 D5 work and not part of B acceptance.
+# - A10 is intentionally excluded from unattended execution because #444
+#   requires a >=2 week stability window plus user sign-off after A9.
+# - #445 children are intentionally excluded until post-A7 contract timing.
 
 schema_version: 1
 chains:
-  - name: v2-b5-native-subissues
+  - name: v2-pm-surface-prereq
     base: main
-    branch: feature/v2-b5-native-subissues
+    branch: feature/v2-pm-surface-prereq
     host: auto
     phase_review: required
-    issues: [495]
+    issues: [498]
+
+  - name: v2-pm-surface-followups
+    base: main
+    branch: feature/v2-pm-surface-followups
+    host: auto
+    phase_review: required
+    issues: [499, 500, 501, 502, 503, 504, 505, 506]
+
+  - name: v2-substrate-spec
+    base: main
+    branch: feature/v2-substrate-spec
+    host: auto
+    phase_review: required
+    issues: [507, 508, 509, 510, 511, 512, 513, 514]
+
+  - name: v2-substrate-core
+    base: main
+    branch: feature/v2-substrate-core
+    host: auto
+    phase_review: required
+    issues: [515, 516, 517, 518, 519, 520, 523, 521, 522, 524, 528]
+
+  - name: v2-agent-migration-pre-cutover
+    base: main
+    branch: feature/v2-agent-migration-pre-cutover
+    host: auto
+    phase_review: required
+    issues: [525, 526, 527]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T11:59:52Z",
+  "generated_at": "2026-05-03T12:53:29Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary

- creates the executable manifest shape for the full automatable v2 transition
- points `v2-transition` at open native leaf issues #498-#528 instead of completed #495
- keeps umbrellas, #445 post-A7 children, B10, and A10 out of unattended execution

## Verification

- sibling plan review: clean
- sibling outcome review: clean
- `yq '.' chains/v2-transition.yaml >/dev/null`
- `scripts/studio-chain-runner.sh --explain-next chains/v2-transition.yaml` reports `Action: start`

Private artifacts:
- `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-03-v2-end-to-end-bootstrap-plan.md`
- `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-03-v2-end-to-end-bootstrap-outcome.md`