### PR TITLE
Add v2 role registry resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ scripts/studio-chain-reviewed.sh v2-transition --host codex --review-host claude
 # Chain manifests may set phase_review: required|auto|off; required/auto gates issue phases through scripts/phase-review.sh and forwards compact clean outcome feedback privately.
 scripts/issue-body-edit.sh 463 --repo owner/repo --body-file generated.md --apply  # guarded issue body replacement; dry-run unless --apply
 scripts/pre-commit-review.sh                                # manual no-secret reviewer gate for risky staged diffs
+scripts/v2-role-resolve.sh chanakya                         # resolve Studio v2 compatibility aliases to canonical role names
 scripts/lint-v2-enforcement.sh --staged                     # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/pr-headless-review.sh <pr>                          # run smoke-eligible no-secret reviewer gate, then merge if non-blocked
 scripts/pr-headless-review.sh <pr> --no-require-cross-host   # opt out of the default independent-provider reviewer requirement
@@ -246,6 +247,7 @@ scripts/                # multi-worker fleet (BETA)
   fleet-cleanup.sh      # soft sweep (stale locks, old done/) or --all teardown
   lint-architecture.sh  # staged router/frontmatter checks; --full runs repository-wide audits
   lint-project-skill-links.sh # blocks missing repo-local project skill discovery links
+  v2-role-resolve.sh    # Studio v2 canonical role + compatibility alias resolver
   lint-v2-enforcement.sh # A0.6 Studio v2 SPEC-derived substrate/profile gates
   test-mode-pack.sh     # skill-testing driver — runs fixtures against mode packs (on-demand, spawns claude -p)
   lint-field-review-surfaces.sh # blocks raw cross-host review snippets outside phase-review wrappers

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T16:01:36Z",
+  "generated_at": "2026-05-03T16:22:19Z",
   "agents": [
     {
       "name": "studio",

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -13,6 +13,8 @@ Current bootstrap artifacts:
 - `schemas/bootstrap.schema.json` defines the bootstrap manifest shape.
 - `hooks/pre-commit` is the v2-local hook entry point; the repo hook delegates
   to `scripts/lint-v2-bootstrap.sh`.
+- `registry/roles.json` is the A1 canonical role registry. Resolve canonical
+  names and compatibility aliases with `scripts/v2-role-resolve.sh`.
 
 Until `SPEC.md` carries `<!-- v2-bootstrap:a0.5-sign-off:complete -->`, the gate
 allows substrate docs, metadata, schemas, and this bootstrap hook only. It blocks

--- a/core/v2/SPEC.md
+++ b/core/v2/SPEC.md
@@ -165,8 +165,9 @@ idempotency key.
 
 Canonical roles are `manager`, `planner`, `worker`, `reviewer`, `qa-engineer`,
 `flow-tester`, `perf`, `release-manager`, `host-adapter`, and `operator`.
-Compatibility names such as `chanakya`, `achilles`, `argus`, and `apollo` are
-aliases resolved by A1; role contracts use canonical names.
+Compatibility names such as `chanakya`, `achilles`, `argus`, and `apollo`
+resolve through `core/v2/registry/roles.json` and
+`scripts/v2-role-resolve.sh`; role contracts use canonical names.
 
 Every executable role contract declares purpose, inputs, outputs, reads, writes,
 idempotency key, decision rights, escalation triggers, failure semantics, and
@@ -305,7 +306,12 @@ warning-tier review feedback into hidden implementation behavior.
 
 - A0.6 turns this SPEC into schemas, pre-commit hooks, CI checks, and invariant
   validators.
-- A1 defines role registry and alias resolution.
+- A1 defines role registry and alias resolution in
+  `core/v2/registry/roles.json`, validated by
+  `scripts/test-fixtures/515-role-registry/test-role-registry.sh`.
+  The A1 schema fixes the canonical role set for this phase; future registry
+  expansion must either retire the A1 `parent_issue`/`leaf_issue` constants or
+  fork the schema deliberately.
 - A2/A2a implement the `/dev-studio` umbrella router and modular router
   contract.
 - A3/A3b/A3c implement vendored skill loading and the iOS skill catalog.

--- a/core/v2/registry/roles.json
+++ b/core/v2/registry/roles.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": 1,
+  "kind": "studio-v2-role-registry",
+  "parent_issue": 444,
+  "leaf_issue": 515,
+  "status": "active",
+  "alias_policy": {
+    "normalization": "case-insensitive; underscores and spaces normalize to hyphens",
+    "unknown_role": "resolver exits non-zero",
+    "conflict": "aliases must resolve to exactly one canonical role"
+  },
+  "roles": [
+    {
+      "name": "manager",
+      "purpose": "Own intake, prioritization, lifecycle state, dispatch, status, user escalation, and final acceptance routing.",
+      "aliases": ["chanakya", "coordinator", "orchestrator"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "planner",
+      "purpose": "Convert shaped intent into executable plans, dependency graphs, acceptance criteria, and worker contracts.",
+      "aliases": ["architect", "luban", "lu-ban"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "worker",
+      "purpose": "Implement one bounded task contract in an isolated worktree.",
+      "aliases": ["achilles", "implementer"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "reviewer",
+      "purpose": "Verify plan or spec compliance, code quality, safety gates, and contract adherence.",
+      "aliases": ["argus", "verifier"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "qa-engineer",
+      "purpose": "Produce and execute automated test contracts beyond the worker's local checks.",
+      "aliases": ["qa", "chiron", "synthetic-qa"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "flow-tester",
+      "purpose": "Produce human or manual exploratory flow checklists tied to builds and releases.",
+      "aliases": ["flow", "manual-qa", "exploratory-tester"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "perf",
+      "purpose": "Investigate performance, battery, memory, thermal, and instrumentation evidence.",
+      "aliases": ["apollo", "performance", "performance-engineer"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "release-manager",
+      "purpose": "Assemble beta and production release packets, verify prerequisites, and draft release notes.",
+      "aliases": ["release", "shipper"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "host-adapter",
+      "purpose": "Expose host capabilities as data and execute portable role invocations.",
+      "aliases": ["adapter", "host"],
+      "source": "A0d-role-topology-rfc"
+    },
+    {
+      "name": "operator",
+      "purpose": "Hold human authority for irreversible, ambiguous, or externally visible decisions.",
+      "aliases": ["user", "human", "owner"],
+      "source": "A0d-role-topology-rfc"
+    }
+  ]
+}

--- a/core/v2/schemas/role-registry.schema.json
+++ b/core/v2/schemas/role-registry.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "role-registry.schema.json",
+  "title": "Studio v2 role registry",
+  "description": "Canonical Studio v2 role names and compatibility aliases for A1 alias resolution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "parent_issue",
+    "leaf_issue",
+    "status",
+    "alias_policy",
+    "roles"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "kind": {
+      "const": "studio-v2-role-registry"
+    },
+    "parent_issue": {
+      "const": 444
+    },
+    "leaf_issue": {
+      "const": 515
+    },
+    "status": {
+      "enum": ["active", "retired"]
+    },
+    "alias_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["normalization", "unknown_role", "conflict"],
+      "properties": {
+        "normalization": {
+          "const": "case-insensitive; underscores and spaces normalize to hyphens"
+        },
+        "unknown_role": {
+          "const": "resolver exits non-zero"
+        },
+        "conflict": {
+          "const": "aliases must resolve to exactly one canonical role"
+        }
+      }
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 10,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "purpose", "aliases", "source"],
+        "properties": {
+          "name": {
+            "enum": [
+              "manager",
+              "planner",
+              "worker",
+              "reviewer",
+              "qa-engineer",
+              "flow-tester",
+              "perf",
+              "release-manager",
+              "host-adapter",
+              "operator"
+            ]
+          },
+          "purpose": {
+            "type": "string",
+            "minLength": 1
+          },
+          "aliases": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9 _-]*$"
+            }
+          },
+          "source": {
+            "const": "A0d-role-topology-rfc"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T16:01:36Z",
+  "generated_at": "2026-05-03T16:22:18Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -173,6 +173,7 @@ scripts/pr-reviewer-eligibility.sh claude-reviewer      # same reviewer floor fo
 scripts/phase-review.sh --review-host claude-reviewer --input phase-plan.md --output review.md   # sibling-host phase gate; emits PHASE_REVIEW_VERDICT=clean|blocked|ambiguous
 scripts/pre-commit-review.sh                            # manual reviewer gate for risky staged diffs; accepts approved/approved_with_fixes only
 scripts/lint-field-review-surfaces.sh --staged          # blocks raw cross-host review snippets outside phase-review wrappers
+scripts/v2-role-resolve.sh chanakya                     # resolve Studio v2 compatibility aliases to canonical role names
 scripts/lint-v2-bootstrap.sh --staged                   # blocks pre-A0.5 substrate code outside the A0.4 bootstrap/meta boundary
 scripts/lint-v2-enforcement.sh --staged                 # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/lint-project-skill-links.sh [--host codex]      # repo-local project skill discovery link invariant + repair helper

--- a/scripts/test-fixtures/515-role-registry/test-role-registry.sh
+++ b/scripts/test-fixtures/515-role-registry/test-role-registry.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RESOLVE="$ROOT/scripts/v2-role-resolve.sh"
+REGISTRY="$ROOT/core/v2/registry/roles.json"
+SCHEMA="$ROOT/core/v2/schemas/role-registry.schema.json"
+TMPROOT=$(mktemp -d -t role-registry-515.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$RESOLVE" ] || fail "resolver is not executable"
+[ -f "$REGISTRY" ] || fail "missing role registry"
+[ -f "$SCHEMA" ] || fail "missing role registry schema"
+
+jq -e '.["$schema"] and .type == "object"' "$SCHEMA" >/dev/null || fail "schema is not a JSON schema"
+jq -e '.schema_version == 1 and .kind == "studio-v2-role-registry" and .leaf_issue == 515' "$REGISTRY" >/dev/null || fail "registry envelope invalid"
+
+for role in manager planner worker reviewer qa-engineer flow-tester perf release-manager host-adapter operator; do
+  "$RESOLVE" "$role" | grep -Fxq "$role" || fail "canonical role does not resolve: $role"
+done
+
+[ "$("$RESOLVE" chanakya)" = manager ] || fail "chanakya alias did not resolve to manager"
+[ "$("$RESOLVE" Achilles)" = worker ] || fail "case-insensitive alias did not resolve"
+[ "$("$RESOLVE" qa_engineer)" = qa-engineer ] || fail "underscore alias did not normalize"
+[ "$("$RESOLVE" "manual qa" 2>/dev/null || true)" = flow-tester ] || fail "space alias did not normalize"
+[ "$("$RESOLVE" --format json apollo | jq -r '.canonical_role + ":" + .matched_as')" = perf:alias ] || fail "json output did not include alias resolution"
+
+if "$RESOLVE" unknown-role >"$TMPROOT/unknown.out" 2>"$TMPROOT/unknown.err"; then
+  fail "unknown alias resolved successfully"
+fi
+grep -Fq 'unknown role or alias' "$TMPROOT/unknown.err" || fail "unknown alias error was not explicit"
+
+cat > "$TMPROOT/conflict.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "studio-v2-role-registry",
+  "roles": [
+    {"name": "manager", "aliases": ["same"]},
+    {"name": "worker", "aliases": ["same"]}
+  ]
+}
+JSON
+
+if "$RESOLVE" --registry "$TMPROOT/conflict.json" same >"$TMPROOT/conflict.out" 2>"$TMPROOT/conflict.err"; then
+  fail "conflicting aliases resolved successfully"
+fi
+grep -Fq 'alias conflict' "$TMPROOT/conflict.err" || fail "conflicting alias error was not explicit"
+
+printf 'PASS: role registry and alias resolver\n'

--- a/scripts/v2-role-resolve.sh
+++ b/scripts/v2-role-resolve.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Resolve Studio v2 canonical roles from canonical names or compatibility aliases.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REGISTRY="$REPO_ROOT/core/v2/registry/roles.json"
+FORMAT="text"
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/v2-role-resolve.sh [--registry <path>] [--format text|json] <role-or-alias>
+       scripts/v2-role-resolve.sh [--registry <path>] --list
+USAGE
+}
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    printf 'v2-role-resolve: jq is required\n' >&2
+    exit 3
+  }
+}
+
+validate_registry() {
+  [ -r "$REGISTRY" ] || {
+    printf 'v2-role-resolve: registry not readable: %s\n' "$REGISTRY" >&2
+    exit 3
+  }
+
+  jq -e '
+    .schema_version == 1 and
+    .kind == "studio-v2-role-registry" and
+    (.roles | type == "array") and
+    (.roles | length > 0) and
+    ([.roles[].name] | unique | length) == (.roles | length)
+  ' "$REGISTRY" >/dev/null 2>&1 || {
+    printf 'v2-role-resolve: invalid role registry: %s\n' "$REGISTRY" >&2
+    exit 3
+  }
+
+  jq -e '
+    def norm: ascii_downcase | gsub("[ _]"; "-");
+    ([.roles[] | .name, (.aliases // [])[] | norm] | length) ==
+    ([.roles[] | .name, (.aliases // [])[] | norm] | unique | length)
+  ' "$REGISTRY" >/dev/null 2>&1 || {
+    printf 'v2-role-resolve: alias conflict in registry: %s\n' "$REGISTRY" >&2
+    exit 3
+  }
+}
+
+list_roles() {
+  jq -r '.roles[].name' "$REGISTRY"
+}
+
+resolve_role() {
+  local input="$1"
+  local query
+  query='
+    def norm: ascii_downcase | gsub("[ _]"; "-");
+    ($input | norm) as $needle |
+    [
+      .roles[]
+      | select((.name | norm) == $needle or ((.aliases // []) | map(norm) | index($needle)))
+    ] as $matches |
+    if ($matches | length) == 1 then
+      $matches[0] as $role |
+      {
+        schema_version: 1,
+        input: $input,
+        canonical_role: $role.name,
+        matched_as: (if (($role.name | norm) == $needle) then "canonical" else "alias" end),
+        role: $role
+      }
+    elif ($matches | length) == 0 then
+      empty
+    else
+      error("ambiguous role alias: " + $input)
+    end
+  '
+
+  if [ "$FORMAT" = "json" ]; then
+    jq -e --arg input "$input" "$query" "$REGISTRY"
+  else
+    jq -er --arg input "$input" "$query | .canonical_role" "$REGISTRY"
+  fi
+}
+
+require_jq
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --registry)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      REGISTRY="$2"
+      shift 2
+      ;;
+    --format)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      FORMAT="$2"
+      case "$FORMAT" in
+        text|json) ;;
+        *) usage; exit 2 ;;
+      esac
+      shift 2
+      ;;
+    --list)
+      validate_registry
+      list_roles
+      exit 0
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      usage
+      exit 2
+      ;;
+    *)
+      INPUT="$1"
+      shift
+      [ "$#" -eq 0 ] || { usage; exit 2; }
+      validate_registry
+      if ! resolve_role "$INPUT"; then
+        printf 'v2-role-resolve: unknown role or alias: %s\n' "$INPUT" >&2
+        exit 1
+      fi
+      exit 0
+      ;;
+  esac
+done
+
+usage
+exit 2


### PR DESCRIPTION
## Summary

Implements A1 from #444 as the first `v2-substrate-core` leaf.

- Adds `core/v2/registry/roles.json` with the canonical Studio v2 role set and compatibility aliases.
- Adds `scripts/v2-role-resolve.sh` for canonical role and alias resolution, including JSON output, `--list`, unknown-role failure, and alias-conflict validation.
- Adds a JSON Schema and focused fixture for registry/resolver behavior.
- References the A1 registry and resolver from `core/v2/SPEC.md`, `core/v2/README.md`, `README.md`, and `scripts/README.md`.

## Review Notes

The sibling outcome review was clean. It noted that the A1 schema intentionally fixes the canonical phase role set; `core/v2/SPEC.md` now records that future registry expansion must deliberately retire the A1 issue constants or fork the schema.

The existing `W_MISSING_SCHEMA_REF:capability-manifest.json:chanakya/reopen` pre-commit warning is pre-existing and unrelated to this leaf.

## Verification

- `scripts/test-fixtures/515-role-registry/test-role-registry.sh`
- `scripts/lint-v2-bootstrap.sh --full`
- `scripts/lint-v2-enforcement.sh --full`
- `check-jsonschema --schemafile core/v2/schemas/role-registry.schema.json core/v2/registry/roles.json`
- `bash -n scripts/v2-role-resolve.sh scripts/test-fixtures/515-role-registry/test-role-registry.sh`
- `zsh -c 'scripts/v2-role-resolve.sh chanakya'`
- `.githooks/pre-commit`
- Sibling outcome review: clean (`2026-05-03-issue-515-outcome-review.md`)

No build was run; this is shell/schema/docs substrate work.

Refs #444
Closes #515
