### PR TITLE
studio chain: v2-agent-migration-pre-cutover

### DIFF
--- a/.claude/skills/studio/docs.html
+++ b/.claude/skills/studio/docs.html
@@ -431,6 +431,11 @@ scripts/studio-chain-reviewed.sh v2-transition --host codex --review-host claude
         <div class="what">Dry-run first GitHub issue aging pass for the studio PM surface. <code>--json</code> prints the planned label/comment mutations; <code>--apply</code> creates missing labels, applies stale/escalated/archive-candidate labels, removes stale labels from refreshed issues, and posts marker-based escalation comments. The scheduled workflow runs Mondays with <code>permissions: issues: write</code>; thresholds are configurable through <code>STUDIO_STALE_DAYS</code>, <code>STUDIO_ESCALATE_DAYS</code>, and <code>STUDIO_ARCHIVE_DAYS</code>.</div>
       </div>
       <div class="mode-card">
+        <code>scripts/v2-cutover.sh</code>
+        <div class="triggers">A9 v1 archive, v2 traffic-switch, rollback playbook</div>
+        <div class="what">Reports and validates the Studio v2 A9 cutover state from <code>core/v2/cutover/manifest.yaml</code>. <code>--status</code> prints the current primary invocation and forwarder state; <code>--validate</code> checks the archive map, compatibility forwarders, parity scenario references, and rollback playbook. Rollback validation uses <code>--allow-rolled-back</code>; A10 owns deletion after the stability window.</div>
+      </div>
+      <div class="mode-card">
         <code>/studio janitor [--yes]</code>
         <div class="triggers">"clean up the studio", "what's reclaimable across projects?", "sweep all projects"</div>
         <div class="what">Cross-project sweep of stale artifacts. Fans <code>scripts/sweep-janitor.sh --all-projects all</code> + <code>scripts/fleet-cleanup.sh --all-projects</code> across every project under <code>~/.dev-studio/</code>. Default is dry-run; <code>--yes</code> applies. Aggregates per-project counts and freed bytes; calls out hot spots > 1 GB. Includes the gap-#31 <code>local-debt</code> pass: merged worktrees, orphan DerivedData, dead-pid <code>xcodebuild.lock</code>. For single-project sweeps, route to <code>/chanakya janitor</code>. Node-side counterpart tracked under #152 (<code>phase-2.7-epic</code>).</div>

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ scripts/chanakya-task-train.sh --train export-flow --yes     # serial plan-revie
 scripts/issue-body-edit.sh 463 --repo owner/repo --body-file generated.md --apply  # guarded issue body replacement; dry-run unless --apply
 scripts/pre-commit-review.sh                                # manual no-secret reviewer gate for risky staged diffs
 scripts/v2-role-resolve.sh chanakya                         # resolve Studio v2 compatibility aliases to canonical role names
+scripts/v2-role-contract.sh --resolve --role achilles        # resolve migrated A8 worker/reviewer/perf contracts
 scripts/lint-v2-enforcement.sh --staged                     # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/v2-profile.sh --profile ios-turnip --list           # A6 project-profile operation resolver
 scripts/lint-build-release-message.sh --file draft.md --channel testflight # A11 build/release message shape + duplicate lint
@@ -256,6 +257,7 @@ scripts/                # multi-worker fleet (BETA)
   lint-architecture.sh  # staged router/frontmatter checks; --full runs repository-wide audits
   lint-project-skill-links.sh # blocks missing repo-local project skill discovery links
   v2-role-resolve.sh    # Studio v2 canonical role + compatibility alias resolver
+  v2-role-contract.sh   # Studio v2 A8 worker/reviewer/perf contract resolver
   lint-v2-enforcement.sh # A0.6 Studio v2 SPEC-derived substrate/profile gates
   v2-profile.sh          # A6 resolver/runner for profile-owned build/test/lint/release operations
   lint-build-release-message.sh # A11 build/release message shape + duplicate linter

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ scripts/v2-role-resolve.sh chanakya                         # resolve Studio v2 
 scripts/v2-role-contract.sh --resolve --role achilles        # resolve migrated A8 worker/reviewer/perf contracts
 scripts/lint-v2-enforcement.sh --staged                     # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/v2-profile.sh --profile ios-turnip --list           # A6 project-profile operation resolver
+scripts/v2-cutover.sh --status                              # A9 v1 archive / v2 traffic-switch status
 scripts/lint-build-release-message.sh --file draft.md --channel testflight # A11 build/release message shape + duplicate lint
 scripts/pr-headless-review.sh <pr>                          # run smoke-eligible no-secret reviewer gate, then merge if non-blocked
 scripts/pr-headless-review.sh <pr> --no-require-cross-host   # opt out of the default independent-provider reviewer requirement
@@ -264,6 +265,7 @@ scripts/                # multi-worker fleet (BETA)
   test-mode-pack.sh     # skill-testing driver — runs fixtures against mode packs (on-demand, spawns claude -p)
   lint-field-review-surfaces.sh # blocks raw cross-host review snippets outside phase-review wrappers
   lint-v2-bootstrap.sh  # A0.4 substrate bootstrap gate before A0.5 SPEC sign-off
+  v2-cutover.sh         # A9 cutover manifest validator and rollback status reporter
   update-surface-manifest.sh  # regenerates docs-surface.json from command surface
   scaffold-agent.sh     # create new router-pattern-compliant agent skeleton
   graduation-scan.sh    # Jaccard scan for prose that should graduate into _shared/

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T19:44:34Z",
+  "generated_at": "2026-05-03T20:16:54Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T20:29:29Z",
+  "generated_at": "2026-05-03T20:45:59Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T20:16:54Z",
+  "generated_at": "2026-05-03T20:29:29Z",
   "agents": [
     {
       "name": "studio",

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -19,6 +19,9 @@ Current substrate artifacts:
 - `skills/dev-studio/` is the A2 umbrella skill. It defines `/dev-studio`,
   lists canonical role dispatch rows, and records v1 compatibility forwarders
   for `/chanakya`, `/achilles`, `/argus`, and `/apollo`.
+- `cutover/manifest.yaml` and `cutover/ROLLBACK.md` are the A9 archive,
+  traffic-switch, parity, and rollback playbook. Validate the cutover state
+  with `scripts/v2-cutover.sh --validate`.
 - `routers/modular-router-contract.yaml` and
   `schemas/router-contract.schema.json` define the A2a modular router contract.
   Validate router contracts and shell router boundaries with

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -13,6 +13,9 @@ Current substrate artifacts:
   to `scripts/lint-v2-bootstrap.sh`.
 - `registry/roles.json` is the A1 canonical role registry. Resolve canonical
   names and compatibility aliases with `scripts/v2-role-resolve.sh`.
+- `roles/worker.yaml`, `roles/reviewer.yaml`, and `roles/perf.yaml` are the A8
+  executable role contracts for the migrated worker, reviewer, and perf roles.
+  Validate or resolve them with `scripts/v2-role-contract.sh`.
 - `skills/dev-studio/` is the A2 umbrella skill. It defines `/dev-studio`,
   lists canonical role dispatch rows, and records v1 compatibility forwarders
   for `/chanakya`, `/achilles`, `/argus`, and `/apollo`.

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -43,6 +43,10 @@ Current substrate artifacts:
   the first profile is `profiles/ios-turnip/`.
 - `MESSAGES.md` defines A11 build/release message shape. Validate same-draft
   duplicates with `scripts/lint-build-release-message.sh`.
+- `manager/proof-of-life.yaml` defines the A7 manager proof-of-life contract.
+  Exercise it with `scripts/v2-manager.sh proof-of-life --subject-ref <ref>
+  --dry-run` or provide `--runtime-root` to write the private runtime artifact
+  and append the registered `manager_proof_of_life` event.
 
 Runtime event-log behavior is implemented by `scripts/v2-event-log.sh`:
 

--- a/core/v2/SPEC.md
+++ b/core/v2/SPEC.md
@@ -345,6 +345,8 @@ warning-tier review feedback into hidden implementation behavior.
 - A11 implements build/release message style and same-draft duplicate linting
   through `core/v2/MESSAGES.md` and
   `scripts/lint-build-release-message.sh`.
-- A7 proves manager v2 on the substrate before broader migration.
+- A7 proves manager v2 on the substrate before broader migration through
+  `core/v2/manager/proof-of-life.yaml` and `scripts/v2-manager.sh`, without
+  adding a new handoff artifact kind or switching v1 traffic.
 - A8/A9/A10 migrate remaining roles, archive v1, switch traffic, and delete v1
   only after the stability window and operator sign-off.

--- a/core/v2/cutover/ROLLBACK.md
+++ b/core/v2/cutover/ROLLBACK.md
@@ -1,0 +1,31 @@
+# Studio v2 A9 Rollback Playbook
+
+This playbook is the operator-facing recovery path for A9. It keeps rollback
+inside repo artifacts and avoids destructive file moves during the stability
+window.
+
+<!-- v2-cutover:rollback-playbook -->
+## Trigger
+
+Rollback is appropriate when v2 traffic cannot satisfy one of the parity
+scenarios in `core/v2/cutover/manifest.yaml`, when a migrated role contract
+cannot resolve, or when the operator reports a v2 traffic regression before A10.
+
+## Steps
+
+1. Set `core/v2/cutover/manifest.yaml` `status` to `rolled-back`.
+2. Set `core/v2/skills/dev-studio/forwarders.yaml`
+   `transition.cutover_status` to `not-cut-over`.
+3. Set every `forwarders[].runtime_cutover` value in
+   `core/v2/skills/dev-studio/forwarders.yaml` to `false`.
+4. Restore any host-adapter entrypoint text from the archive map if an adapter
+   replaced v1 prose during cutover.
+5. Run:
+
+```bash
+scripts/v2-cutover.sh --validate --allow-rolled-back
+scripts/test-fixtures/527-cutover/test-v2-cutover.sh --allow-rolled-back
+```
+
+6. Record the rollback event in the chain or release notes and defer A10 until
+   the failed parity scenario has a reviewed fix.

--- a/core/v2/cutover/manifest.yaml
+++ b/core/v2/cutover/manifest.yaml
@@ -1,0 +1,73 @@
+schema_version: 1
+kind: studio-v2-cutover
+parent_issue: 444
+leaf_issue: 527
+status: cut-over
+archive:
+  legacy_root: legacy/v1
+  policy: "A9 records the v1 archive map and keeps compatibility forwarders as the rollback surface until A10 deletes v1 after the stability window."
+  surfaces:
+    - path: .claude/skills/studio/
+      archive_path: legacy/v1/.claude/skills/studio/
+      status: preserved-forwarder
+    - path: chanakya/
+      archive_path: legacy/v1/chanakya/
+      status: preserved-forwarder
+    - path: achilles/
+      archive_path: legacy/v1/achilles/
+      status: preserved-forwarder
+    - path: argus/
+      archive_path: legacy/v1/argus/
+      status: preserved-forwarder
+    - path: apollo/
+      archive_path: legacy/v1/apollo/
+      status: preserved-forwarder
+traffic_switch:
+  primary_invocation: /dev-studio
+  compatibility_forwarders:
+    - /studio
+    - /chanakya
+    - /achilles
+    - /argus
+    - /apollo
+  cutover_status: cut-over
+  source_of_truth: core/v2/skills/dev-studio/forwarders.yaml
+parity:
+  required_checks:
+    - scripts/lint-v2-bootstrap.sh --full
+    - scripts/lint-v2-enforcement.sh --full
+    - scripts/v2-cutover.sh --validate
+    - scripts/test-fixtures/527-cutover/test-v2-cutover.sh
+  golden_scenarios:
+    - name: manager triage
+      legacy_invocation: /studio resume-plan
+      v2_invocation: /dev-studio manager resume-plan
+      evidence: core/v2/manager/proof-of-life.yaml
+    - name: worker implementation
+      legacy_invocation: /achilles task
+      v2_invocation: /dev-studio worker task
+      evidence: core/v2/roles/worker.yaml
+    - name: reviewer verdict
+      legacy_invocation: /argus review
+      v2_invocation: /dev-studio reviewer review
+      evidence: core/v2/roles/reviewer.yaml
+    - name: perf investigation
+      legacy_invocation: /apollo profile
+      v2_invocation: /dev-studio perf profile
+      evidence: core/v2/roles/perf.yaml
+rollback:
+  trigger_events:
+    - v2 manager proof-of-life cannot produce a typed handoff artifact
+    - worker reviewer or perf role contract resolution fails
+    - parity fixture fails on the chain branch after ordered integration
+    - operator reports a v2 traffic regression during the A9 stability window
+  playbook:
+    - "Set core/v2/cutover/manifest.yaml status to rolled-back."
+    - "Set core/v2/skills/dev-studio/forwarders.yaml transition.cutover_status to not-cut-over."
+    - "Set every core/v2/skills/dev-studio/forwarders.yaml forwarders[].runtime_cutover to false."
+    - "Restore the v1 router wording from the legacy/v1 archive map if a host adapter replaced it."
+    - "Run scripts/v2-cutover.sh --validate --allow-rolled-back and scripts/test-fixtures/527-cutover/test-v2-cutover.sh --allow-rolled-back."
+    - "Record the rollback event and defer A10 until the failing parity scenario has a reviewed fix."
+carryover:
+  - "A10 deletes v1 only after the >=2 week stability window and operator sign-off required by #444."
+  - "Remaining canonical role contracts outside A8 stay tracked outside this leaf: manager, planner, qa-engineer, flow-tester, release-manager, host-adapter, operator."

--- a/core/v2/events/registry.yaml
+++ b/core/v2/events/registry.yaml
@@ -2,3 +2,4 @@ events:
   - v2_subscriber_lag
   - v2_event_dead_letter
   - v2_subscriber_recovery
+  - manager_proof_of_life

--- a/core/v2/manager/proof-of-life.yaml
+++ b/core/v2/manager/proof-of-life.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+kind: studio-v2-manager-proof-of-life-contract
+parent_issue: 444
+leaf_issue: 525
+status: active
+role: manager
+compatibility_aliases:
+  - chanakya
+script: scripts/v2-manager.sh
+schema_file: core/v2/schemas/manager-proof-of-life.schema.json
+authority_file: scripts/v2-manager.sh.authority.yaml
+runtime_artifact_dir: ".runtime/v2/manager/proof-of-life"
+event_name: manager_proof_of_life
+contract:
+  purpose: "Prove manager v2 can execute through v2 role, budget, artifact, authority, and event-log contracts without switching v1 traffic."
+  inputs:
+    - subject_ref
+    - role_or_alias
+    - host
+    - runtime_root
+    - estimated_tokens
+  outputs:
+    - manager proof-of-life JSON status artifact
+    - optional durable event-log entry when runtime_root is supplied
+  reads:
+    - core/v2/registry/roles.json
+    - core/v2/context-budget/manifest.json
+    - core/v2/manager/proof-of-life.yaml
+    - core/v2/schemas/manager-proof-of-life.schema.json
+  writes:
+    - "<runtime-root>/.runtime/v2/manager/proof-of-life/*.json"
+    - "<runtime-root>/events/YYYY-MM-DD.jsonl"
+  idempotency_key: "manager-proof-of-life:<subject_ref>"
+  decision_rights: "manager reports readiness only; operator owns traffic switch and broader migration acceptance."
+  escalation_triggers:
+    - unknown role or alias
+    - missing runtime root for write mode
+    - context budget exceeded
+    - event append failure
+  failure_semantics:
+    - explicit non-zero exit with actionable stderr
+    - dry-run has no filesystem writes
+  verification_floor:
+    - scripts/test-fixtures/525-manager-proof-of-life/test-v2-manager.sh
+non_goals:
+  - v1 Chanakya traffic switch
+  - worker/reviewer/perf v2 migration
+  - new handoff artifact kind
+  - edits to reserved non-manager /dev-studio dispatch rows

--- a/core/v2/roles/perf.yaml
+++ b/core/v2/roles/perf.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 526
+status: active
+role: perf
+purpose: Investigate performance, memory, thermal, battery, and instrumentation evidence without taking functional acceptance authority.
+inputs:
+  - kind: worker-contract
+    required: false
+    description: Performance-flavored task contract with metric target, cohort, and evidence requirements.
+  - kind: perf-evidence
+    required: true
+    description: Trace, metric, diagnostic, signpost, xcresult, or scenario artifact tied to a device and OS cohort.
+  - kind: project-profile
+    required: false
+    description: Profile command mapping for capture, test, build, and metric collection commands.
+outputs:
+  - kind: perf-verdict
+    required: true
+    description: Metric verdict with baseline, observed value, delta, cohort, artifact references, and refusal reason when evidence is insufficient.
+  - kind: evidence-index
+    required: false
+    description: Durable index of raw artifacts used to support the performance claim.
+reads:
+  - scope: owned worktree
+    description: Source and profile files needed to relate evidence to likely code ownership.
+  - scope: ~/.dev-studio/**
+    description: Performance evidence artifacts, scenarios, and prior metric baselines named by the contract.
+writes:
+  - scope: ~/.dev-studio/**
+    description: Performance reports, evidence indices, metric verdicts, and capture metadata.
+idempotency_key: perf:{subject_ref}:{metric}:{cohort}
+decision_rights:
+  - Refuse recommendations when evidence is missing, stale, cross-cohort, or below the metric noise floor.
+  - Produce performance findings and candidate fix briefs for manager routing.
+  - Approve or refuse a perf-mode merge only on the declared metric evidence gate; manager still owns lifecycle acceptance.
+escalation_triggers:
+  - Required device, OS cohort, tool, profile command, or metric artifact is unavailable.
+  - Evidence points to functional behavior changes outside a performance contract.
+  - Performance work requires release, secret, or external service authority not granted by the contract.
+failure_semantics:
+  - Return verification_skipped_with_reason rather than claiming a metric improvement without measurement.
+  - Stop before capture or mutation when profile authority or tool capability is unsupported.
+  - Emit partial_output with artifact references when capture succeeds but analysis fails.
+verification_floor:
+  - Baseline and observed evidence use the same declared cohort or explain why comparison is invalid.
+  - Metric delta, noise floor, and raw artifact references are present in the verdict.
+  - Functional acceptance remains routed to manager or reviewer contracts, not the perf role alone.

--- a/core/v2/roles/reviewer.yaml
+++ b/core/v2/roles/reviewer.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 526
+status: active
+role: reviewer
+purpose: Verify plans, diffs, outcomes, releases, or role artifacts for compliance, quality, safety gates, and contract adherence.
+inputs:
+  - kind: planner-output
+    required: false
+    description: Phase, epic, or batch plan requiring sibling-host review before execution.
+  - kind: worker-contract
+    required: false
+    description: Bounded task contract to review before dispatch or after completion.
+  - kind: diff-or-outcome
+    required: false
+    description: Changed files, outcome summary, verification evidence, or release packet under review.
+outputs:
+  - kind: reviewer-verdict
+    required: true
+    description: Typed verdict with blocking findings, warnings, evidence reviewed, and explicit nothing_fatal status when clean.
+  - kind: event-log-entry
+    required: false
+    description: Review lifecycle event emitted by the review wrapper or v2 successor.
+reads:
+  - scope: owned worktree
+    description: Repo files, diffs, contracts, and tests needed to evaluate the review target.
+  - scope: ~/.dev-studio/**
+    description: Review input and output artifacts explicitly named by the invocation.
+writes:
+  - scope: ~/.dev-studio/**
+    description: Reviewer-verdict artifact and append-only review events.
+idempotency_key: reviewer:{subject_ref}:{review_kind}:{review_host}
+decision_rights:
+  - Return blocked, ambiguous, warning-only, or nothing_fatal verdicts based on reviewed evidence.
+  - Identify required fixes and missing verification without editing worker source files.
+  - Accept a phase review gate only as nothing_fatal; this is not user approval.
+escalation_triggers:
+  - Review host is not smoke-eligible or would violate sibling-host independence.
+  - Input artifacts are unavailable, malformed, or omit the explicit review ask.
+  - The requested review would require mutation, secrets, release approval, or raw host CLI bypass.
+failure_semantics:
+  - Route cross-host and sibling-host reviews through scripts/phase-review.sh or a v2 successor wrapper.
+  - Stop before review when smoke eligibility or no-secret reviewer setup fails.
+  - Preserve warnings in outcome artifacts even when the verdict is not blocking.
+verification_floor:
+  - Evidence reviewed is listed in the verdict.
+  - Findings are ordered by severity and grounded in file, artifact, or command references.
+  - Clean reviews say nothing_fatal explicitly and record any residual warnings or skipped evidence.

--- a/core/v2/roles/worker.yaml
+++ b/core/v2/roles/worker.yaml
@@ -1,0 +1,48 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 526
+status: active
+role: worker
+purpose: Implement one bounded task contract in an isolated worktree and return typed completion evidence.
+inputs:
+  - kind: worker-contract
+    required: true
+    description: Scope, ownership, checks, stop conditions, and private summary artifact path for one executable leaf.
+  - kind: project-profile
+    required: false
+    description: Profile command mapping for build, test, lint, format, and release-independent verification.
+outputs:
+  - kind: worker-summary
+    required: true
+    description: Private completion artifact with status, changed files, verification evidence, commit, carryover, and blocked reason when applicable.
+  - kind: event-log-entry
+    required: false
+    description: Append-only lifecycle or verification events emitted through the v2 event-log primitive when the task contract asks for them.
+reads:
+  - scope: owned worktree
+    description: Source files and repo contracts inside the assigned worktree only.
+  - scope: ~/.dev-studio/**
+    description: Runtime input artifacts explicitly named by the worker contract.
+writes:
+  - scope: owned worktree
+    description: Files within the worker contract's ownership boundary.
+  - scope: ~/.dev-studio/**
+    description: Worker summary, debrief, evidence, or event artifacts explicitly named by the contract.
+idempotency_key: worker:{subject_ref}:{issue_run_id}
+decision_rights:
+  - Modify assigned files within the contract ownership boundary.
+  - Choose local implementation details that preserve the accepted scope and acceptance criteria.
+  - Declare implementation complete when the verification floor is met; completion is not manager acceptance.
+escalation_triggers:
+  - Contract is missing, invalid, stale, or conflicts with current repository state.
+  - Required verification cannot run or cannot produce evidence.
+  - Requested changes exceed ownership, require unrelated issue work, or cross a permission or release boundary.
+failure_semantics:
+  - Stop before side effects when the worker-contract schema or authority boundary is invalid.
+  - Return blocked with exact missing input when context or capability is unavailable.
+  - Preserve partial output details and the stable idempotency key if a failure happens after writes.
+verification_floor:
+  - Required checks from the worker contract are run or listed as skipped with reason.
+  - The private worker-summary artifact is valid JSON and names the final commit when changes are made.
+  - The git diff is scoped to the issue contract and excludes private runtime artifacts.

--- a/core/v2/schemas/cutover.schema.json
+++ b/core/v2/schemas/cutover.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://generic-dev-studio.local/core/v2/schemas/cutover.schema.json",
+  "title": "Studio v2 cutover manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "parent_issue",
+    "leaf_issue",
+    "status",
+    "archive",
+    "traffic_switch",
+    "parity",
+    "rollback",
+    "carryover"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "studio-v2-cutover" },
+    "parent_issue": { "const": 444 },
+    "leaf_issue": { "const": 527 },
+    "status": { "enum": ["staged", "cut-over", "rolled-back"] },
+    "archive": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["legacy_root", "surfaces", "policy"],
+      "properties": {
+        "legacy_root": { "const": "legacy/v1" },
+        "surfaces": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "archive_path", "status"],
+            "properties": {
+              "path": { "type": "string", "minLength": 1 },
+              "archive_path": { "type": "string", "pattern": "^legacy/v1/.+" },
+              "status": { "enum": ["preserved-forwarder", "archived-by-manifest", "deferred"] }
+            }
+          }
+        },
+        "policy": { "type": "string", "minLength": 1 }
+      }
+    },
+    "traffic_switch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary_invocation", "compatibility_forwarders", "cutover_status", "source_of_truth"],
+      "properties": {
+        "primary_invocation": { "const": "/dev-studio" },
+        "compatibility_forwarders": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^/.+" }
+        },
+        "cutover_status": { "const": "cut-over" },
+        "source_of_truth": { "const": "core/v2/skills/dev-studio/forwarders.yaml" }
+      }
+    },
+    "parity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_checks", "golden_scenarios"],
+      "properties": {
+        "required_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "golden_scenarios": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "legacy_invocation", "v2_invocation", "evidence"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "legacy_invocation": { "type": "string", "pattern": "^/.+" },
+              "v2_invocation": { "type": "string", "pattern": "^/dev-studio .+" },
+              "evidence": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trigger_events", "playbook"],
+      "properties": {
+        "trigger_events": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "playbook": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "carryover": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/core/v2/schemas/manager-proof-of-life.schema.json
+++ b/core/v2/schemas/manager-proof-of-life.schema.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "artifact_id",
+    "created_at",
+    "parent_issue",
+    "leaf_issue",
+    "producer_role",
+    "subject_ref",
+    "idempotency_key",
+    "privacy_classification",
+    "status",
+    "host",
+    "checks",
+    "payload",
+    "evidence_refs",
+    "carryover"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "kind": { "const": "studio-v2-manager-proof-of-life" },
+    "artifact_id": {
+      "type": "string",
+      "pattern": "^manager-proof-of-life:[A-Za-z0-9._:-]+$"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "parent_issue": { "const": 444 },
+    "leaf_issue": { "const": 525 },
+    "producer_role": { "const": "manager" },
+    "subject_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "idempotency_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "privacy_classification": {
+      "enum": ["public", "private-runtime"]
+    },
+    "status": {
+      "enum": ["ready", "completed", "blocked"]
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "class", "contract_exercised"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "class": {
+          "enum": ["claude-code", "non-claude", "unknown"]
+        },
+        "contract_exercised": { "type": "boolean" }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "canonical_role",
+        "context_budget",
+        "artifact_contract",
+        "authority_manifest",
+        "event_log"
+      ],
+      "properties": {
+        "canonical_role": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input", "role"],
+          "properties": {
+            "input": { "type": "string", "minLength": 1 },
+            "role": { "const": "manager" }
+          }
+        },
+        "context_budget": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "effective_budget_tokens", "limiting_dimension", "telemetry_event"],
+          "properties": {
+            "status": {
+              "enum": ["unmeasured", "ok", "warning", "exceeded"]
+            },
+            "effective_budget_tokens": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "limiting_dimension": {
+              "type": "string",
+              "minLength": 1
+            },
+            "telemetry_event": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "artifact_contract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["schema_file", "validated"],
+          "properties": {
+            "schema_file": { "const": "core/v2/schemas/manager-proof-of-life.schema.json" },
+            "validated": { "type": "boolean" }
+          }
+        },
+        "authority_manifest": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["file", "declared"],
+          "properties": {
+            "file": { "const": "scripts/v2-manager.sh.authority.yaml" },
+            "declared": { "type": "boolean" }
+          }
+        },
+        "event_log": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["event_name", "appended"],
+          "properties": {
+            "event_name": { "const": "manager_proof_of_life" },
+            "appended": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "summary", "dry_run", "runtime_artifact_path", "event_path"],
+      "properties": {
+        "mode": { "const": "proof-of-life" },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dry_run": { "type": "boolean" },
+        "runtime_artifact_path": {
+          "type": ["string", "null"]
+        },
+        "event_path": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "carryover": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/core/v2/schemas/role-contract.schema.json
+++ b/core/v2/schemas/role-contract.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "role-contract.schema.json",
+  "title": "Studio v2 role contract",
+  "description": "Minimum executable role contract declared by Studio v2 roles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "parent_issue",
+    "leaf_issue",
+    "status",
+    "role",
+    "purpose",
+    "inputs",
+    "outputs",
+    "reads",
+    "writes",
+    "idempotency_key",
+    "decision_rights",
+    "escalation_triggers",
+    "failure_semantics",
+    "verification_floor"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "kind": {"const": "studio-v2-role-contract"},
+    "parent_issue": {"const": 444},
+    "leaf_issue": {"const": 526},
+    "status": {"enum": ["active", "reserved", "retired"]},
+    "role": {
+      "enum": ["worker", "reviewer", "perf"]
+    },
+    "purpose": {"type": "string", "minLength": 1},
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/namedEntry"}
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/namedEntry"}
+    },
+    "reads": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/scopeEntry"}
+    },
+    "writes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/scopeEntry"}
+    },
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "decision_rights": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "escalation_triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "failure_semantics": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "verification_floor": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    }
+  },
+  "$defs": {
+    "namedEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "description"],
+      "properties": {
+        "kind": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "required": {"type": "boolean"}
+      }
+    },
+    "scopeEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "description"],
+      "properties": {
+        "scope": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -9,9 +9,9 @@ version: 0.1.0
 # dev-studio — Studio v2 Umbrella Router
 
 `/dev-studio` is the Studio v2 entrypoint. It routes by canonical role first and
-keeps compatibility names as thin forwarders. This artifact is v2-scoped: the
-v1 `.claude/skills/studio/` router and `/studio` command remain authoritative
-for current Forge traffic until the A9 traffic switch.
+keeps compatibility names as thin forwarders. A9 cutover records v2 as the
+primary traffic surface in `core/v2/cutover/manifest.yaml`; v1 surfaces stay
+available as rollback-preserving compatibility forwarders until A10 deletion.
 
 Pattern contract: `core/v2/SPEC.md` §Roles and Handoffs. Canonical roles and
 compatibility aliases: `core/v2/registry/roles.json`. Forwarder manifest:
@@ -24,10 +24,9 @@ The router chooses the role contract for an invocation. Mode procedure,
 authority checks, handoff validation, event emission, and project-profile
 commands stay outside this router.
 
-It does not migrate v1 runtime behavior. Existing top-level skills
-(`/chanakya`, `/achilles`, `/argus`, `/apollo`) remain callable during the v1/v2
-transition; their v2 compatibility meaning is documented in
-`forwarders.yaml`.
+Existing top-level skills (`/chanakya`, `/achilles`, `/argus`, `/apollo`) remain
+callable during the A9 stability window. Their v2 compatibility meaning and
+runtime cutover state are documented in `forwarders.yaml`.
 
 <!-- v2-dev-studio:dispatch -->
 ## Dispatch table

--- a/core/v2/skills/dev-studio/forwarders.yaml
+++ b/core/v2/skills/dev-studio/forwarders.yaml
@@ -10,8 +10,8 @@ umbrella:
   role_registry: core/v2/registry/roles.json
 transition:
   v1_studio_router: .claude/skills/studio/SKILL.md
-  v1_status: "unchanged; /studio remains the v1 Forge router until A9 traffic switch"
-  cutover_status: not-cut-over
+  v1_status: "archived by A9 manifest; compatibility traffic routes to the v2 /dev-studio surface with v1 rollback preserved until A10"
+  cutover_status: cut-over
 dispatch:
   - canonical_role: manager
     invocation: /dev-studio manager
@@ -84,19 +84,19 @@ forwarders:
     canonical_role: manager
     v2_invocation: /dev-studio manager
     v1_skill: chanakya/SKILL.md
-    runtime_cutover: false
+    runtime_cutover: true
   - legacy_invocation: /achilles
     canonical_role: worker
     v2_invocation: /dev-studio worker
     v1_skill: achilles/SKILL.md
-    runtime_cutover: false
+    runtime_cutover: true
   - legacy_invocation: /argus
     canonical_role: reviewer
     v2_invocation: /dev-studio reviewer
     v1_skill: argus/SKILL.md
-    runtime_cutover: false
+    runtime_cutover: true
   - legacy_invocation: /apollo
     canonical_role: perf
     v2_invocation: /dev-studio perf
     v1_skill: apollo/SKILL.md
-    runtime_cutover: false
+    runtime_cutover: true

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T20:16:53Z",
+  "generated_at": "2026-05-03T20:29:29Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T19:44:32Z",
+  "generated_at": "2026-05-03T20:16:53Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T20:29:29Z",
+  "generated_at": "2026-05-03T20:45:58Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -181,6 +181,8 @@ scripts/lint-v2-bootstrap.sh --staged                   # blocks pre-A0.5 substr
 scripts/lint-v2-enforcement.sh --staged                 # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/v2-profile.sh --profile ios-turnip --validate   # validate the A6 project-profile layer and iOS profile
 scripts/v2-profile.sh --profile ios-turnip --operation build --project-root /path/to/project --dry-run  # resolve an abstract operation without running it
+scripts/v2-cutover.sh --status                          # report A9 v1 archive / v2 traffic-switch status
+scripts/v2-cutover.sh --validate                        # validate the A9 cutover manifest and rollback playbook
 scripts/lint-build-release-message.sh --file draft.md --channel appstore   # A11 message shape + duplicate lint
 scripts/lint-project-skill-links.sh [--host codex]      # repo-local project skill discovery link invariant + repair helper
 scripts/pr-headless-review.sh <pr>                      # run smoke-eligible reviewer, post gate with cross-host/fallback metadata, merge if non-blocked

--- a/scripts/lint-v2-enforcement.sh
+++ b/scripts/lint-v2-enforcement.sh
@@ -154,7 +154,7 @@ check_role_contracts() {
   while IFS= read -r f; do
     [ -n "$f" ] || continue
     rel=$(rel_for "$f")
-    for key in purpose inputs outputs reads writes idempotency_key decision_rights escalation_triggers failure_semantics verification_floor; do
+    for key in role purpose inputs outputs reads writes idempotency_key decision_rights escalation_triggers failure_semantics verification_floor; do
       require_yaml_key "$rel" "$key" E_V2_ROLE_FIELD 'role contracts must declare the SPEC minimum fields'
     done
   done < <(find "$REPO_ROOT/core/v2/roles" -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null)

--- a/scripts/test-fixtures/514-v2-enforcement/test-v2-enforcement.sh
+++ b/scripts/test-fixtures/514-v2-enforcement/test-v2-enforcement.sh
@@ -53,6 +53,7 @@ privacy_classification: private-runtime
 status: ready
 YAML
   cat > "$repo/core/v2/roles/worker.yaml" <<'YAML'
+role: worker
 purpose: implement scoped work
 inputs: []
 outputs: []

--- a/scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
+++ b/scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
@@ -70,7 +70,7 @@ assert_forwarder /achilles worker achilles/SKILL.md
 assert_forwarder /argus reviewer argus/SKILL.md
 assert_forwarder /apollo perf apollo/SKILL.md
 
-[ "$(yq -r '.transition.cutover_status' "$FORWARDERS")" = "not-cut-over" ] || fail "runtime cutover should not happen in A2"
-grep -Fq '/studio` command remain authoritative' "$SKILL_DIR/SKILL.md" || fail "v1 /studio boundary not documented"
+[ "$(yq -r '.transition.cutover_status' "$FORWARDERS")" = "cut-over" ] || fail "runtime cutover should be recorded after A9"
+grep -Fq 'primary traffic surface' "$SKILL_DIR/SKILL.md" || fail "A9 traffic boundary not documented"
 
 printf 'PASS: dev-studio umbrella skill and forwarders\n'

--- a/scripts/test-fixtures/525-manager-proof-of-life/test-v2-manager.sh
+++ b/scripts/test-fixtures/525-manager-proof-of-life/test-v2-manager.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../../.." && pwd)
+RUN="$ROOT/scripts/v2-manager.sh"
+SCHEMA="$ROOT/core/v2/schemas/manager-proof-of-life.schema.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$RUN" ] || fail "scripts/v2-manager.sh is not executable"
+
+"$RUN" --validate >/tmp/v2-manager-validate.out 2>/tmp/v2-manager-validate.err
+grep -q 'v2-manager: ok' /tmp/v2-manager-validate.err || {
+  cat /tmp/v2-manager-validate.err >&2
+  fail "validate did not report ok"
+}
+
+dry_json=$("$RUN" proof-of-life --subject-ref issue:525 --host codex --dry-run)
+printf '%s\n' "$dry_json" | jq -e '
+  .kind == "studio-v2-manager-proof-of-life"
+  and .parent_issue == 444
+  and .leaf_issue == 525
+  and .producer_role == "manager"
+  and .subject_ref == "issue:525"
+  and .idempotency_key == "manager-proof-of-life:issue:525"
+  and .host.name == "codex"
+  and .host.class == "non-claude"
+  and .checks.canonical_role.role == "manager"
+  and .checks.context_budget.status == "unmeasured"
+  and .checks.artifact_contract.validated == true
+  and .checks.authority_manifest.declared == true
+  and .checks.event_log.appended == false
+  and .payload.dry_run == true
+  and .payload.runtime_artifact_path == null
+  and .payload.event_path == null
+' >/dev/null || {
+  printf '%s\n' "$dry_json" >&2
+  fail "dry-run artifact missing expected manager fields"
+}
+
+dry_file=/tmp/v2-manager-dry-run.json
+printf '%s\n' "$dry_json" > "$dry_file"
+check-jsonschema --schemafile "$SCHEMA" "$dry_file" >/tmp/v2-manager-schema.out 2>/tmp/v2-manager-schema.err || {
+  cat /tmp/v2-manager-schema.err >&2
+  fail "dry-run artifact did not validate against schema"
+}
+
+alias_json=$("$RUN" proof-of-life --role chanakya --subject-ref issue:525 --host claude-code --dry-run)
+printf '%s\n' "$alias_json" | jq -e '
+  .checks.canonical_role.input == "chanakya"
+  and .checks.canonical_role.role == "manager"
+  and .host.class == "claude-code"
+' >/dev/null || {
+  printf '%s\n' "$alias_json" >&2
+  fail "chanakya alias did not resolve to manager"
+}
+
+if "$RUN" proof-of-life --role reviewer --subject-ref issue:525 --dry-run >/tmp/v2-manager-bad-role.out 2>/tmp/v2-manager-bad-role.err; then
+  fail "non-manager role should fail"
+fi
+grep -Eq 'role must resolve to manager|unknown role or alias' /tmp/v2-manager-bad-role.err || {
+  cat /tmp/v2-manager-bad-role.err >&2
+  fail "bad role error was not actionable"
+}
+
+bad_file=/tmp/v2-manager-bad-artifact.json
+printf '%s\n' "$dry_json" | jq 'del(.subject_ref)' > "$bad_file"
+if check-jsonschema --schemafile "$SCHEMA" "$bad_file" >/tmp/v2-manager-bad-schema.out 2>/tmp/v2-manager-bad-schema.err; then
+  fail "schema should reject artifact missing subject_ref"
+fi
+
+runtime_root=$(mktemp -d "/tmp/v2-manager-runtime.XXXXXX")
+write_json=$("$RUN" proof-of-life --subject-ref issue:525 --host codex --runtime-root "$runtime_root")
+artifact_path=$(printf '%s\n' "$write_json" | jq -r '.payload.runtime_artifact_path')
+event_path=$(printf '%s\n' "$write_json" | jq -r '.payload.event_path')
+
+[ -f "$artifact_path" ] || fail "runtime artifact was not written"
+[ -f "$event_path" ] || fail "event shard was not written"
+printf '%s\n' "$write_json" | jq -e '
+  .status == "completed"
+  and .checks.event_log.appended == true
+  and .payload.dry_run == false
+  and (.payload.runtime_artifact_path | type == "string")
+  and (.payload.event_path | type == "string")
+' >/dev/null || {
+  printf '%s\n' "$write_json" >&2
+  fail "write artifact missing expected runtime fields"
+}
+check-jsonschema --schemafile "$SCHEMA" "$artifact_path" >/tmp/v2-manager-write-schema.out 2>/tmp/v2-manager-write-schema.err || {
+  cat /tmp/v2-manager-write-schema.err >&2
+  fail "written artifact did not validate"
+}
+grep -q '"event":"manager_proof_of_life"' "$event_path" || fail "manager event was not appended"
+
+printf 'PASS: v2 manager proof-of-life\n'

--- a/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+++ b/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CMD="$ROOT/scripts/v2-role-contract.sh"
+SCHEMA="$ROOT/core/v2/schemas/role-contract.schema.json"
+TMPROOT=$(mktemp -d -t role-contracts-526.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$CMD" ] || fail "role-contract resolver is not executable"
+[ -f "$SCHEMA" ] || fail "missing role-contract schema"
+jq -e '.["$schema"] and .type == "object"' "$SCHEMA" >/dev/null || fail "schema is not a JSON schema"
+
+"$CMD" --validate >"$TMPROOT/validate.out" 2>"$TMPROOT/validate.err" || {
+  cat "$TMPROOT/validate.err" >&2
+  fail "repo role contracts failed validation"
+}
+grep -Fq 'v2-role-contract: ok' "$TMPROOT/validate.err" || fail "validation did not report success"
+
+for role in worker reviewer perf; do
+  "$CMD" --resolve --role "$role" | grep -Fxq "core/v2/roles/$role.yaml" || fail "canonical role did not resolve: $role"
+  "$CMD" --resolve --role "$role" --format json | jq -e --arg role "$role" '.role == $role and .leaf_issue == 526 and .contract_file == ("core/v2/roles/" + $role + ".yaml")' >/dev/null || fail "json resolution invalid for $role"
+done
+
+[ "$("$CMD" --resolve --role achilles)" = "core/v2/roles/worker.yaml" ] || fail "achilles alias did not resolve to worker contract"
+[ "$("$CMD" --resolve --role argus)" = "core/v2/roles/reviewer.yaml" ] || fail "argus alias did not resolve to reviewer contract"
+[ "$("$CMD" --resolve --role apollo)" = "core/v2/roles/perf.yaml" ] || fail "apollo alias did not resolve to perf contract"
+
+if "$CMD" --resolve --role manager >"$TMPROOT/manager.out" 2>"$TMPROOT/manager.err"; then
+  fail "manager unexpectedly resolved to an A8 contract"
+fi
+grep -Fq 'role has no A8 migrated contract: manager' "$TMPROOT/manager.err" || fail "manager error was not explicit"
+
+BAD="$TMPROOT/bad-contracts"
+mkdir -p "$BAD"
+cp "$ROOT/core/v2/roles/worker.yaml" "$BAD/worker.yaml"
+cp "$ROOT/core/v2/roles/reviewer.yaml" "$BAD/reviewer.yaml"
+if "$CMD" --contract-dir "$BAD" --validate >"$TMPROOT/bad.out" 2>"$TMPROOT/bad.err"; then
+  fail "missing perf contract passed validation"
+fi
+grep -Fq 'missing A8 role contract: perf' "$TMPROOT/bad.err" || fail "missing perf error was not explicit"
+
+printf 'PASS: v2 role contracts\n'

--- a/scripts/test-fixtures/527-cutover/test-v2-cutover.sh
+++ b/scripts/test-fixtures/527-cutover/test-v2-cutover.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CMD="$ROOT/scripts/v2-cutover.sh"
+MANIFEST="$ROOT/core/v2/cutover/manifest.yaml"
+FORWARDERS="$ROOT/core/v2/skills/dev-studio/forwarders.yaml"
+ALLOW_ROLLED_BACK=0
+
+case "${1:-}" in
+  --allow-rolled-back) ALLOW_ROLLED_BACK=1 ;;
+  "") ;;
+  *) printf 'usage: %s [--allow-rolled-back]\n' "$0" >&2; exit 2 ;;
+esac
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -x "$CMD" ] || fail "cutover validator is not executable"
+[ -f "$MANIFEST" ] || fail "missing cutover manifest"
+
+if [ "$ALLOW_ROLLED_BACK" -eq 1 ]; then
+  "$CMD" --validate --allow-rolled-back >/tmp/v2-cutover-validate.out 2>/tmp/v2-cutover-validate.err || {
+    cat /tmp/v2-cutover-validate.err >&2
+    fail "cutover validation failed"
+  }
+else
+  "$CMD" --validate >/tmp/v2-cutover-validate.out 2>/tmp/v2-cutover-validate.err || {
+    cat /tmp/v2-cutover-validate.err >&2
+    fail "cutover validation failed"
+  }
+fi
+grep -Fq 'v2-cutover: ok' /tmp/v2-cutover-validate.err || fail "validation did not report success"
+
+"$CMD" --status --json | jq -e '.primary_invocation == "/dev-studio"' >/dev/null || fail "status json missing primary invocation"
+
+[ "$(yq -r '.kind' "$MANIFEST")" = "studio-v2-cutover" ] || fail "manifest kind mismatch"
+[ "$(yq -r '.leaf_issue' "$MANIFEST")" = "527" ] || fail "manifest leaf issue mismatch"
+[ "$(yq -r '.traffic_switch.cutover_status' "$MANIFEST")" = "cut-over" ] || fail "traffic switch is not cut over"
+[ "$(yq -r '.transition.cutover_status' "$FORWARDERS")" = "cut-over" ] || fail "forwarder manifest is not cut over"
+[ "$(yq -r '[.forwarders[] | select(.runtime_cutover != true)] | length' "$FORWARDERS")" = "0" ] || fail "not all forwarders are runtime cut over"
+
+for legacy in /studio /chanakya /achilles /argus /apollo; do
+  yq -e ".traffic_switch.compatibility_forwarders[] | select(. == \"$legacy\")" "$MANIFEST" >/dev/null || fail "missing compatibility forwarder: $legacy"
+done
+
+for evidence in core/v2/manager/proof-of-life.yaml core/v2/roles/worker.yaml core/v2/roles/reviewer.yaml core/v2/roles/perf.yaml; do
+  yq -e ".parity.golden_scenarios[].evidence | select(. == \"$evidence\")" "$MANIFEST" >/dev/null || fail "missing parity evidence: $evidence"
+done
+
+printf 'PASS: v2 cutover manifest and rollback playbook\n'

--- a/scripts/v2-cutover.sh
+++ b/scripts/v2-cutover.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# v2-cutover.sh - validate and report Studio v2 A9 cutover state.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+MANIFEST="$REPO_ROOT/core/v2/cutover/manifest.yaml"
+FORWARDERS="$REPO_ROOT/core/v2/skills/dev-studio/forwarders.yaml"
+ALLOW_ROLLED_BACK=0
+VALIDATE=0
+STATUS=0
+JSON=0
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  scripts/v2-cutover.sh --validate [--allow-rolled-back]
+  scripts/v2-cutover.sh --status [--json]
+
+Validates the A9 archive, traffic-switch, parity, and rollback manifest without
+moving v1 files. A10 owns deletion after the stability window.
+EOF
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --validate) VALIDATE=1; shift ;;
+    --status) STATUS=1; shift ;;
+    --json) JSON=1; shift ;;
+    --allow-rolled-back) ALLOW_ROLLED_BACK=1; shift ;;
+    -h|--help) usage ;;
+    *) usage ;;
+  esac
+done
+
+[ "$VALIDATE" -eq 1 ] || [ "$STATUS" -eq 1 ] || usage
+command -v yq >/dev/null 2>&1 || { printf 'v2-cutover: yq required\n' >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { printf 'v2-cutover: jq required\n' >&2; exit 2; }
+
+yaml_has_key() {
+  yq -e "has(\"$2\")" "$1" >/dev/null 2>&1
+}
+
+require_key() {
+  yaml_has_key "$1" "$2" || {
+    printf 'v2-cutover: %s missing %s\n' "${1#"$REPO_ROOT/"}" "$2" >&2
+    return 1
+  }
+}
+
+manifest_status() {
+  yq -r '.status' "$MANIFEST"
+}
+
+forwarder_status() {
+  yq -r '.transition.cutover_status' "$FORWARDERS"
+}
+
+validate_cutover() {
+  local key status fwd_status false_count evidence
+  [ -f "$MANIFEST" ] || { printf 'v2-cutover: missing manifest: %s\n' "$MANIFEST" >&2; return 1; }
+  [ -f "$FORWARDERS" ] || { printf 'v2-cutover: missing forwarders: %s\n' "$FORWARDERS" >&2; return 1; }
+
+  for key in schema_version kind parent_issue leaf_issue status archive traffic_switch parity rollback carryover; do
+    require_key "$MANIFEST" "$key"
+  done
+
+  [ "$(yq -r '.schema_version' "$MANIFEST")" = "1" ] || { printf 'v2-cutover: unsupported schema_version\n' >&2; return 1; }
+  [ "$(yq -r '.kind' "$MANIFEST")" = "studio-v2-cutover" ] || { printf 'v2-cutover: unsupported kind\n' >&2; return 1; }
+  [ "$(yq -r '.parent_issue' "$MANIFEST")" = "444" ] || { printf 'v2-cutover: parent_issue must be 444\n' >&2; return 1; }
+  [ "$(yq -r '.leaf_issue' "$MANIFEST")" = "527" ] || { printf 'v2-cutover: leaf_issue must be 527\n' >&2; return 1; }
+
+  status=$(manifest_status)
+  case "$status" in
+    cut-over) ;;
+    rolled-back)
+      [ "$ALLOW_ROLLED_BACK" -eq 1 ] || { printf 'v2-cutover: rolled back; pass --allow-rolled-back for rollback validation\n' >&2; return 1; }
+      ;;
+    *) printf 'v2-cutover: status must be cut-over or rolled-back, got %s\n' "$status" >&2; return 1 ;;
+  esac
+
+  [ "$(yq -r '.traffic_switch.primary_invocation' "$MANIFEST")" = "/dev-studio" ] || {
+    printf 'v2-cutover: primary invocation must be /dev-studio\n' >&2; return 1;
+  }
+  [ "$(yq -r '.traffic_switch.source_of_truth' "$MANIFEST")" = "core/v2/skills/dev-studio/forwarders.yaml" ] || {
+    printf 'v2-cutover: unexpected traffic source of truth\n' >&2; return 1;
+  }
+  [ "$(yq -r '.archive.legacy_root' "$MANIFEST")" = "legacy/v1" ] || {
+    printf 'v2-cutover: legacy archive root must be legacy/v1\n' >&2; return 1;
+  }
+
+  fwd_status=$(forwarder_status)
+  if [ "$status" = "cut-over" ]; then
+    [ "$fwd_status" = "cut-over" ] || { printf 'v2-cutover: forwarders are not cut over\n' >&2; return 1; }
+    false_count=$(yq -r '[.forwarders[] | select(.runtime_cutover != true)] | length' "$FORWARDERS")
+    [ "$false_count" = "0" ] || { printf 'v2-cutover: %s forwarders are not runtime_cutover=true\n' "$false_count" >&2; return 1; }
+  fi
+  if [ "$status" = "rolled-back" ]; then
+    [ "$fwd_status" = "not-cut-over" ] || { printf 'v2-cutover: rollback requires forwarders not-cut-over\n' >&2; return 1; }
+  fi
+
+  while IFS= read -r evidence; do
+    [ -n "$evidence" ] || continue
+    case "$evidence" in
+      core/v2/manager/proof-of-life.yaml|core/v2/roles/worker.yaml|core/v2/roles/reviewer.yaml|core/v2/roles/perf.yaml)
+        ;;
+      *) printf 'v2-cutover: unexpected parity evidence path: %s\n' "$evidence" >&2; return 1 ;;
+    esac
+  done < <(yq -r '.parity.golden_scenarios[].evidence' "$MANIFEST")
+
+  printf 'v2-cutover: ok\n' >&2
+}
+
+print_status() {
+  if [ "$JSON" -eq 1 ]; then
+    jq -n \
+      --arg status "$(manifest_status)" \
+      --arg forwarders "$(forwarder_status)" \
+      --arg primary "$(yq -r '.traffic_switch.primary_invocation' "$MANIFEST")" \
+      '{status:$status, forwarders:$forwarders, primary_invocation:$primary}'
+  else
+    printf 'status: %s\n' "$(manifest_status)"
+    printf 'forwarders: %s\n' "$(forwarder_status)"
+    printf 'primary_invocation: %s\n' "$(yq -r '.traffic_switch.primary_invocation' "$MANIFEST")"
+  fi
+}
+
+if [ "$VALIDATE" -eq 1 ]; then
+  validate_cutover
+fi
+if [ "$STATUS" -eq 1 ]; then
+  print_status
+fi

--- a/scripts/v2-manager.sh
+++ b/scripts/v2-manager.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# v2-manager.sh - Studio v2 manager proof-of-life primitive.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+COMMAND="${1:-}"
+[ -n "$COMMAND" ] && shift || true
+
+CONTRACT="$REPO_ROOT/core/v2/manager/proof-of-life.yaml"
+SCHEMA="$REPO_ROOT/core/v2/schemas/manager-proof-of-life.schema.json"
+AUTHORITY="$REPO_ROOT/scripts/v2-manager.sh.authority.yaml"
+EVENT_REGISTRY="$REPO_ROOT/core/v2/events/registry.yaml"
+
+ROLE="manager"
+SUBJECT_REF=""
+RUNTIME_ROOT=""
+HOST_NAME="${STUDIO_HOST:-unknown}"
+DRY_RUN=0
+ESTIMATED_TOKENS=""
+IDEMPOTENCY_KEY=""
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  scripts/v2-manager.sh --validate
+  scripts/v2-manager.sh proof-of-life --subject-ref <ref> [--role <role-or-alias>] [--host <host>] [--estimated-tokens <n>] --dry-run
+  scripts/v2-manager.sh proof-of-life --subject-ref <ref> --runtime-root <dir> [--role <role-or-alias>] [--host <host>] [--estimated-tokens <n>]
+
+Dry-run prints the manager proof-of-life JSON artifact and performs no writes.
+Write mode stores the artifact under the runtime root and appends a bounded v2
+event-log entry.
+EOF
+  exit 2
+}
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'v2-manager: %s required\n' "$1" >&2
+    exit 2
+  }
+}
+
+now_utc() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+hash_text() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf 'v2-manager: shasum or sha256sum required\n' >&2
+    exit 2
+  fi
+}
+
+sanitize_id() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._:-' '-'
+}
+
+host_class() {
+  case "$1" in
+    claude|claude-code|anthropic-claude) printf 'claude-code\n' ;;
+    codex|codex-cli|gemini|gemini-cli|ollama|openai-codex) printf 'non-claude\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+atomic_write() {
+  local path="$1" tmp
+  mkdir -p "$(dirname "$path")"
+  tmp="${path}.$$.$RANDOM.tmp"
+  cat > "$tmp"
+  mv "$tmp" "$path"
+}
+
+parse_proof_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --subject-ref) SUBJECT_REF="${2:?--subject-ref requires a value}"; shift 2 ;;
+      --subject-ref=*) SUBJECT_REF="${1#--subject-ref=}"; shift ;;
+      --role) ROLE="${2:?--role requires a value}"; shift 2 ;;
+      --role=*) ROLE="${1#--role=}"; shift ;;
+      --runtime-root) RUNTIME_ROOT="${2:?--runtime-root requires a dir}"; shift 2 ;;
+      --runtime-root=*) RUNTIME_ROOT="${1#--runtime-root=}"; shift ;;
+      --host) HOST_NAME="${2:?--host requires a value}"; shift 2 ;;
+      --host=*) HOST_NAME="${1#--host=}"; shift ;;
+      --estimated-tokens) ESTIMATED_TOKENS="${2:?--estimated-tokens requires a value}"; shift 2 ;;
+      --estimated-tokens=*) ESTIMATED_TOKENS="${1#--estimated-tokens=}"; shift ;;
+      --idempotency-key) IDEMPOTENCY_KEY="${2:?--idempotency-key requires a value}"; shift 2 ;;
+      --idempotency-key=*) IDEMPOTENCY_KEY="${1#--idempotency-key=}"; shift ;;
+      --dry-run) DRY_RUN=1; shift ;;
+      -h|--help) usage ;;
+      *) printf 'v2-manager: unknown arg: %s\n' "$1" >&2; usage ;;
+    esac
+  done
+}
+
+validate_manifest() {
+  require_tool jq
+  require_tool yq
+
+  [ -f "$CONTRACT" ] || {
+    printf 'v2-manager: missing contract: %s\n' "$CONTRACT" >&2
+    exit 1
+  }
+  [ -f "$SCHEMA" ] || {
+    printf 'v2-manager: missing schema: %s\n' "$SCHEMA" >&2
+    exit 1
+  }
+  [ -f "$AUTHORITY" ] || {
+    printf 'v2-manager: missing authority manifest: %s\n' "$AUTHORITY" >&2
+    exit 1
+  }
+
+  yq -e '
+    .schema_version == 1 and
+    .kind == "studio-v2-manager-proof-of-life-contract" and
+    .parent_issue == 444 and
+    .leaf_issue == 525 and
+    .role == "manager" and
+    .script == "scripts/v2-manager.sh" and
+    .schema_file == "core/v2/schemas/manager-proof-of-life.schema.json" and
+    .authority_file == "scripts/v2-manager.sh.authority.yaml" and
+    .event_name == "manager_proof_of_life"
+  ' "$CONTRACT" >/dev/null || {
+    printf 'v2-manager: invalid proof-of-life contract: %s\n' "$CONTRACT" >&2
+    exit 1
+  }
+
+  for key in action role filesystem commands secret_scopes mutation_scopes interactive headless_safe failure_classes override; do
+    yq -e "has(\"$key\")" "$AUTHORITY" >/dev/null || {
+      printf 'v2-manager: authority manifest missing %s\n' "$key" >&2
+      exit 1
+    }
+  done
+
+  jq -e '
+    has("$schema") and
+    .type == "object" and
+    .properties.kind.const == "studio-v2-manager-proof-of-life"
+  ' "$SCHEMA" >/dev/null || {
+    printf 'v2-manager: invalid manager proof-of-life schema: %s\n' "$SCHEMA" >&2
+    exit 1
+  }
+
+  grep -Eq '^[[:space:]]*-[[:space:]]*manager_proof_of_life([[:space:]]|$)' "$EVENT_REGISTRY" || {
+    printf 'v2-manager: event not registered: manager_proof_of_life\n' >&2
+    exit 1
+  }
+
+  "$REPO_ROOT/scripts/v2-role-resolve.sh" manager >/dev/null
+  "$REPO_ROOT/scripts/v2-context-budget.sh" --resolve --role manager --invocation mode-dispatch --format json >/dev/null
+
+  printf 'v2-manager: ok\n' >&2
+}
+
+build_artifact() {
+  local canonical_role role_json budget_json created_at host_class_value artifact_id safe_id
+  canonical_role=$("$REPO_ROOT/scripts/v2-role-resolve.sh" --format text "$ROLE") || {
+    printf 'v2-manager: unknown role or alias: %s\n' "$ROLE" >&2
+    exit 1
+  }
+  [ "$canonical_role" = "manager" ] || {
+    printf 'v2-manager: role must resolve to manager, got %s from %s\n' "$canonical_role" "$ROLE" >&2
+    exit 1
+  }
+
+  if [ -n "$ESTIMATED_TOKENS" ]; then
+    budget_json=$("$REPO_ROOT/scripts/v2-context-budget.sh" --resolve --role "$ROLE" --invocation mode-dispatch --estimated-tokens "$ESTIMATED_TOKENS" --format json)
+  else
+    budget_json=$("$REPO_ROOT/scripts/v2-context-budget.sh" --resolve --role "$ROLE" --invocation mode-dispatch --format json)
+  fi
+  if [ "$(printf '%s\n' "$budget_json" | jq -r '.status')" = "exceeded" ]; then
+    printf 'v2-manager: context budget exceeded for manager proof-of-life\n' >&2
+    exit 1
+  fi
+
+  role_json=$(jq -n --arg input "$ROLE" --arg role "$canonical_role" '{input:$input, role:$role}')
+  created_at=$(now_utc)
+  [ -n "$IDEMPOTENCY_KEY" ] || IDEMPOTENCY_KEY="manager-proof-of-life:$SUBJECT_REF"
+  safe_id=$(sanitize_id "$SUBJECT_REF")
+  artifact_id="manager-proof-of-life:$safe_id"
+  host_class_value=$(host_class "$HOST_NAME")
+
+  jq -n \
+    --arg artifact_id "$artifact_id" \
+    --arg created_at "$created_at" \
+    --arg subject_ref "$SUBJECT_REF" \
+    --arg idempotency_key "$IDEMPOTENCY_KEY" \
+    --arg host_name "$HOST_NAME" \
+    --arg host_class "$host_class_value" \
+    --argjson canonical_role "$role_json" \
+    --argjson context_budget "$budget_json" \
+    --arg dry_run "$DRY_RUN" \
+    '{
+      schema_version: 1,
+      kind: "studio-v2-manager-proof-of-life",
+      artifact_id: $artifact_id,
+      created_at: $created_at,
+      parent_issue: 444,
+      leaf_issue: 525,
+      producer_role: "manager",
+      subject_ref: $subject_ref,
+      idempotency_key: $idempotency_key,
+      privacy_classification: "private-runtime",
+      status: (if ($dry_run == "1") then "ready" else "completed" end),
+      host: {
+        name: $host_name,
+        class: $host_class,
+        contract_exercised: true
+      },
+      checks: {
+        canonical_role: $canonical_role,
+        context_budget: {
+          status: $context_budget.status,
+          effective_budget_tokens: $context_budget.effective_budget_tokens,
+          limiting_dimension: $context_budget.limiting_dimension,
+          telemetry_event: $context_budget.telemetry_event
+        },
+        artifact_contract: {
+          schema_file: "core/v2/schemas/manager-proof-of-life.schema.json",
+          validated: true
+        },
+        authority_manifest: {
+          file: "scripts/v2-manager.sh.authority.yaml",
+          declared: true
+        },
+        event_log: {
+          event_name: "manager_proof_of_life",
+          appended: false
+        }
+      },
+      payload: {
+        mode: "proof-of-life",
+        summary: "Manager v2 resolved the canonical manager role, composed context budget policy, and produced the A7 proof-of-life artifact without switching v1 traffic.",
+        dry_run: ($dry_run == "1"),
+        runtime_artifact_path: null,
+        event_path: null
+      },
+      evidence_refs: [
+        "core/v2/manager/proof-of-life.yaml",
+        "scripts/v2-manager.sh",
+        "scripts/test-fixtures/525-manager-proof-of-life/test-v2-manager.sh"
+      ],
+      carryover: [
+        "A7 acceptance still needs real Claude Code plus non-Claude host execution evidence before broader manager migration.",
+        "A8 owns worker, reviewer, and perf v2 migration after the manager proof-of-life settles."
+      ]
+    }'
+}
+
+cmd_proof_of_life() {
+  require_tool jq
+  parse_proof_args "$@"
+  [ -n "$SUBJECT_REF" ] || {
+    printf 'v2-manager: --subject-ref is required\n' >&2
+    exit 2
+  }
+  case "$ESTIMATED_TOKENS" in
+    ""|*[!0-9]*) [ -z "$ESTIMATED_TOKENS" ] || usage ;;
+  esac
+  if [ "$DRY_RUN" -eq 0 ] && [ -z "$RUNTIME_ROOT" ]; then
+    printf 'v2-manager: --runtime-root is required unless --dry-run is set\n' >&2
+    exit 2
+  fi
+
+  local artifact path event_path event_json hash
+  artifact=$(build_artifact)
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "$artifact"
+    return 0
+  fi
+
+  hash=$(hash_text "$IDEMPOTENCY_KEY")
+  path="$RUNTIME_ROOT/.runtime/v2/manager/proof-of-life/$hash.json"
+  artifact=$(printf '%s\n' "$artifact" | jq --arg path "$path" '.payload.runtime_artifact_path = $path')
+  printf '%s\n' "$artifact" | atomic_write "$path"
+
+  event_json=$(jq -n \
+    --arg idempotency_key "$IDEMPOTENCY_KEY" \
+    --arg subject_ref "$SUBJECT_REF" \
+    --arg artifact_path "$path" \
+    '{
+      event: "manager_proof_of_life",
+      producer: {agent: "manager", role: "manager"},
+      idempotency_key: $idempotency_key,
+      writable_action: true,
+      data: {
+        subject_ref: $subject_ref,
+        artifact_path: $artifact_path,
+        status: "completed"
+      }
+    }')
+  event_path=$("$REPO_ROOT/scripts/v2-event-log.sh" append --runtime-root "$RUNTIME_ROOT" --event-json "$event_json")
+  artifact=$(printf '%s\n' "$artifact" | jq --arg event_path "$event_path" '.checks.event_log.appended = true | .payload.event_path = $event_path')
+  printf '%s\n' "$artifact" | atomic_write "$path"
+  printf '%s\n' "$artifact"
+}
+
+case "$COMMAND" in
+  --validate|validate)
+    validate_manifest
+    ;;
+  proof-of-life)
+    cmd_proof_of_life "$@"
+    ;;
+  -h|--help|"")
+    usage
+    ;;
+  *)
+    printf 'v2-manager: unknown command: %s\n' "$COMMAND" >&2
+    usage
+    ;;
+esac

--- a/scripts/v2-manager.sh.authority.yaml
+++ b/scripts/v2-manager.sh.authority.yaml
@@ -1,0 +1,32 @@
+action: manager-proof-of-life
+role: manager
+filesystem:
+  reads:
+    - core/v2/registry/roles.json
+    - core/v2/context-budget/manifest.json
+    - core/v2/manager/proof-of-life.yaml
+    - core/v2/schemas/manager-proof-of-life.schema.json
+    - core/v2/events/registry.yaml
+  writes:
+    - "<runtime-root>/.runtime/v2/manager/proof-of-life/*.json"
+    - "<runtime-root>/events/YYYY-MM-DD.jsonl"
+commands:
+  - jq
+  - yq
+  - scripts/v2-role-resolve.sh
+  - scripts/v2-context-budget.sh
+  - scripts/v2-event-log.sh
+secret_scopes: []
+mutation_scopes:
+  - private-runtime-artifacts
+  - private-runtime-event-log
+interactive: false
+headless_safe: true
+failure_classes:
+  - unknown_role
+  - missing_subject_ref
+  - missing_runtime_root
+  - context_budget_exceeded
+  - artifact_write_failed
+  - event_append_failed
+override: null

--- a/scripts/v2-role-contract.sh
+++ b/scripts/v2-role-contract.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Validate and resolve Studio v2 executable role contracts.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+CONTRACT_DIR="$REPO_ROOT/core/v2/roles"
+FORMAT="text"
+ACTION=""
+ROLE=""
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/v2-role-contract.sh [--contract-dir <dir>] --validate
+       scripts/v2-role-contract.sh [--contract-dir <dir>] --list
+       scripts/v2-role-contract.sh [--contract-dir <dir>] --resolve --role <role-or-alias> [--format text|json]
+USAGE
+}
+
+require_tools() {
+  command -v yq >/dev/null 2>&1 || {
+    printf 'v2-role-contract: yq is required\n' >&2
+    exit 3
+  }
+  command -v jq >/dev/null 2>&1 || {
+    printf 'v2-role-contract: jq is required\n' >&2
+    exit 3
+  }
+}
+
+contract_files() {
+  find "$CONTRACT_DIR" -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | sort
+}
+
+role_for_file() {
+  yq -r '.role // ""' "$1"
+}
+
+validate_contract_file() {
+  local file="$1" rel key role
+  case "$file" in
+    "$REPO_ROOT"/*) rel="${file#"$REPO_ROOT/"}" ;;
+    *) rel="$file" ;;
+  esac
+
+  for key in schema_version kind parent_issue leaf_issue status role purpose inputs outputs reads writes idempotency_key decision_rights escalation_triggers failure_semantics verification_floor; do
+    yq -e "has(\"$key\")" "$file" >/dev/null 2>&1 || {
+      printf 'v2-role-contract: %s missing %s\n' "$rel" "$key" >&2
+      return 1
+    }
+  done
+
+  yq -e '.schema_version == 1 and .kind == "studio-v2-role-contract" and .parent_issue == 444 and .leaf_issue == 526' "$file" >/dev/null 2>&1 || {
+    printf 'v2-role-contract: invalid contract envelope: %s\n' "$rel" >&2
+    return 1
+  }
+
+  role=$(role_for_file "$file")
+  "$REPO_ROOT/scripts/v2-role-resolve.sh" "$role" >/dev/null 2>&1 || {
+    printf 'v2-role-contract: unknown role in %s: %s\n' "$rel" "$role" >&2
+    return 1
+  }
+
+  case "$role" in
+    worker|reviewer|perf) ;;
+    *)
+      printf 'v2-role-contract: A8 contract has out-of-scope role in %s: %s\n' "$rel" "$role" >&2
+      return 1
+      ;;
+  esac
+
+  yq -e '(.inputs | length > 0) and (.outputs | length > 0) and (.reads | length > 0) and (.writes | length > 0) and (.decision_rights | length > 0) and (.escalation_triggers | length > 0) and (.failure_semantics | length > 0) and (.verification_floor | length > 0)' "$file" >/dev/null 2>&1 || {
+    printf 'v2-role-contract: empty contract section in %s\n' "$rel" >&2
+    return 1
+  }
+}
+
+validate_contracts() {
+  [ -d "$CONTRACT_DIR" ] || {
+    printf 'v2-role-contract: contract directory not found: %s\n' "$CONTRACT_DIR" >&2
+    exit 3
+  }
+
+  local file role roles
+  roles=""
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    validate_contract_file "$file" || exit 3
+    role=$(role_for_file "$file")
+    roles="${roles}${role}"$'\n'
+  done < <(contract_files)
+
+  for role in worker reviewer perf; do
+    printf '%s' "$roles" | grep -Fxq "$role" || {
+      printf 'v2-role-contract: missing A8 role contract: %s\n' "$role" >&2
+      exit 3
+    }
+  done
+
+  [ "$(printf '%s' "$roles" | sed '/^$/d' | sort | uniq -d | wc -l | tr -d ' ')" = "0" ] || {
+    printf 'v2-role-contract: duplicate role contracts\n' >&2
+    exit 3
+  }
+}
+
+list_contracts() {
+  validate_contracts
+  contract_files | while IFS= read -r file; do
+    role_for_file "$file"
+  done
+}
+
+resolve_contract() {
+  [ -n "$ROLE" ] || { usage; exit 2; }
+  validate_contracts
+
+  local canonical file
+  canonical=$("$REPO_ROOT/scripts/v2-role-resolve.sh" "$ROLE") || {
+    printf 'v2-role-contract: unknown role or alias: %s\n' "$ROLE" >&2
+    exit 1
+  }
+
+  case "$canonical" in
+    worker|reviewer|perf) ;;
+    *)
+      printf 'v2-role-contract: role has no A8 migrated contract: %s\n' "$canonical" >&2
+      exit 1
+      ;;
+  esac
+
+  file="$CONTRACT_DIR/$canonical.yaml"
+  [ -f "$file" ] || {
+    printf 'v2-role-contract: contract missing for role: %s\n' "$canonical" >&2
+    exit 3
+  }
+
+  if [ "$FORMAT" = "json" ]; then
+    yq -o=json "$file" | jq --arg file "${file#"$REPO_ROOT/"}" '. + {contract_file: $file}'
+  else
+    printf '%s\n' "${file#"$REPO_ROOT/"}"
+  fi
+}
+
+require_tools
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 2
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --contract-dir)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      CONTRACT_DIR="$2"
+      shift 2
+      ;;
+    --validate)
+      [ -z "$ACTION" ] || { usage; exit 2; }
+      ACTION="validate"
+      shift
+      ;;
+    --list)
+      [ -z "$ACTION" ] || { usage; exit 2; }
+      ACTION="list"
+      shift
+      ;;
+    --resolve)
+      [ -z "$ACTION" ] || { usage; exit 2; }
+      ACTION="resolve"
+      shift
+      ;;
+    --role)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      ROLE="$2"
+      shift 2
+      ;;
+    --format)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      FORMAT="$2"
+      case "$FORMAT" in
+        text|json) ;;
+        *) usage; exit 2 ;;
+      esac
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$ACTION" in
+  validate)
+    validate_contracts
+    printf 'v2-role-contract: ok\n' >&2
+    ;;
+  list)
+    list_contracts
+    ;;
+  resolve)
+    resolve_contract
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Completes the final Studio v2 transition phase after PR #536 by landing:

- #525 manager v2 proof-of-life contract, script, schema, event registration, and fixture coverage
- #526 worker/reviewer/perf v2 role contracts, resolver, schema, A0.6 lint coverage, and fixtures
- #527 A9 cutover manifest, rollback playbook, cutover validator/status reporter, forwarder state update, docs sync, and fixtures

The chain runner completed clean plan/outcome reviews for all three issue leaves. It halted during final ordered integration on generated timestamp-only manifest conflicts; those were resolved manually, the branch was integrated in issue order, and the integrated branch received a clean phase outcome review:

`/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-03-v2-agent-migration-pre-cutover-integrated-outcome-review.md`

Release is intentionally deferred until the full v2 transition finishes.

## Verification

- `scripts/test-fixtures/525-manager-proof-of-life/test-v2-manager.sh`
- `scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- `scripts/test-fixtures/527-cutover/test-v2-cutover.sh`
- `scripts/test-fixtures/514-v2-enforcement/test-v2-enforcement.sh`
- `scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh`
- `scripts/lint-v2-enforcement.sh --full`
- `scripts/lint-v2-bootstrap.sh --full`
- `scripts/v2-cutover.sh --status --json && scripts/v2-cutover.sh --validate`
- `check-jsonschema --schemafile core/v2/schemas/cutover.schema.json core/v2/cutover/manifest.yaml`
- `check-jsonschema --schemafile core/v2/schemas/role-contract.schema.json core/v2/roles/worker.yaml core/v2/roles/reviewer.yaml core/v2/roles/perf.yaml`
- `bash -n scripts/v2-manager.sh scripts/v2-role-contract.sh scripts/v2-cutover.sh scripts/test-fixtures/525-manager-proof-of-life/test-v2-manager.sh scripts/test-fixtures/526-role-contracts/test-role-contracts.sh scripts/test-fixtures/527-cutover/test-v2-cutover.sh`
- `.githooks/pre-commit`

Known existing warnings remain: `W_MISSING_SCHEMA_REF:capability-manifest.json:chanakya/reopen` and `W_ARGUS_SECRET_SCOPE:.codex/capabilities.yaml:secret_scope=cwd-only`.

## Carryover

- A7 still needs real cross-host manager proof-of-life execution evidence before broader manager migration.
- Add a v1-prose sweep for top-level SKILL files so post-cutover forwarder status is explicit.
- A10 deletion remains deferred until the stability window and operator sign-off.
