### PR TITLE
Document post-A9 forwarder status

### DIFF
--- a/.claude/skills/studio/SKILL.md
+++ b/.claude/skills/studio/SKILL.md
@@ -10,6 +10,8 @@ version: 1.0.0
 
 Studio-level operations for `generic-dev-studio` itself (not the user's project). This is a **project-scoped vendor skill** shipped at `.claude/skills/studio/`; it auto-loads when your cwd is in this repo and is silent everywhere else. Invoked when the user wants to act on the studio's state: resume an in-flight architecture arc, walk this repo's review rules against a diff, draft release notes for the studio, ingest something studio-flavored, audit plan-vs-memory drift, or guard against repeated work.
 
+Post-A9 v2 status: `/studio` remains the studio compatibility surface and rollback anchor until A10. The primary v2 umbrella surface is `/dev-studio`, with cutover state recorded in `core/v2/skills/dev-studio/forwarders.yaml` and `core/v2/cutover/manifest.yaml`.
+
 Pattern contract: `_shared/patterns/router-pattern.md`. Router <100 lines.
 
 ## Not in scope

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T20:45:59Z",
+  "generated_at": "2026-05-03T21:12:26Z",
   "agents": [
     {
       "name": "studio",

--- a/achilles/SKILL.md
+++ b/achilles/SKILL.md
@@ -8,6 +8,8 @@ version: 1.0.0
 
 # Achilles — Worker Agent (router)
 
+Post-A9 v2 status: `/achilles` remains a compatibility forwarder for the v2 worker role (`/dev-studio worker`) and a rollback surface until A10. The cutover source of truth is `core/v2/skills/dev-studio/forwarders.yaml`.
+
 ## Bootstrap
 
 **Skills-root resolution.** All bare `scripts/…` and `_shared/…` paths in this file and its mode packs are relative to the **skills-root** (the parent of this agent's directory — where `scripts/`, `_shared/`, and per-agent dirs live as siblings), NOT this file's directory. Resolve once at session start and prefix every bare path when running or reading:

--- a/apollo/SKILL.md
+++ b/apollo/SKILL.md
@@ -9,6 +9,8 @@ budget_tokens: 400
 
 # Apollo — Performance Agent (router)
 
+Post-A9 v2 status: `/apollo` remains a compatibility forwarder for the v2 perf role (`/dev-studio perf`) and a rollback surface until A10. The cutover source of truth is `core/v2/skills/dev-studio/forwarders.yaml`.
+
 ## Bootstrap
 
 **Skills-root resolution.** All bare `scripts/…` and `_shared/…` paths in this file and its mode packs are relative to the **skills-root** (the parent of this agent's directory — where `scripts/`, `_shared/`, and per-agent dirs live as siblings), NOT this file's directory. Resolve once at session start and prefix every bare path when running or reading:

--- a/argus/SKILL.md
+++ b/argus/SKILL.md
@@ -10,6 +10,8 @@ budget_tokens: 400
 
 # Argus — Reviewer Agent (router)
 
+Post-A9 v2 status: `/argus` remains a compatibility forwarder for the v2 reviewer role (`/dev-studio reviewer`) and a rollback surface until A10. The cutover source of truth is `core/v2/skills/dev-studio/forwarders.yaml`.
+
 ## Bootstrap
 
 **Skills-root resolution.** All bare `scripts/…` and `_shared/…` paths in this file and its mode packs are relative to the **skills-root** (the parent of this agent's directory — where `scripts/`, `_shared/`, and per-agent dirs live as siblings), NOT this file's directory. Resolve once at session start and prefix every bare path when running or reading:

--- a/chanakya/SKILL.md
+++ b/chanakya/SKILL.md
@@ -8,7 +8,7 @@ version: 1.0.0
 
 # Chanakya — Project Manager (router)
 
-Chanakya is the strategic project manager for the Turnip iOS codebase. It organizes work, generates self-contained briefs for worker agents (Achilles), and maintains the master plan as the single source of truth. This file is the router; every mode's full workflow lives under `modes/`. Pattern contract: `_shared/patterns/router-pattern.md`. Cross-cutting invariants: `_shared/patterns/chanakya-principles.md`. Debt counters: `_shared/rules/debt-tracking.md`.
+Chanakya is the strategic project manager for the Turnip iOS codebase. It organizes work, generates self-contained briefs for worker agents (Achilles), and maintains the master plan as the single source of truth. This file is the router; every mode's full workflow lives under `modes/`. Pattern contract: `_shared/patterns/router-pattern.md`. Cross-cutting invariants: `_shared/patterns/chanakya-principles.md`. Debt counters: `_shared/rules/debt-tracking.md`. Post-A9, `/chanakya` is the compatibility forwarder for `/dev-studio manager`; cutover state lives in `core/v2/skills/dev-studio/forwarders.yaml` until A10.
 
 ## Bootstrap
 

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T20:45:58Z",
+  "generated_at": "2026-05-03T21:12:26Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary

Closes #539 by adding minimal post-A9 compatibility-forwarder status pointers to the v1 top-level router SKILL files:

- `.claude/skills/studio/SKILL.md`
- `chanakya/SKILL.md`
- `achilles/SKILL.md`
- `argus/SKILL.md`
- `apollo/SKILL.md`

These are scope/status pointers only. They do not duplicate `/dev-studio` command tables and do not change runtime behavior. A10 deletion remains deferred until the stability window and operator sign-off.

## Verification

- `scripts/lint-skill-prose.sh --staged`
- `scripts/lint-mode-pack.sh --staged`
- `scripts/lint-v2-enforcement.sh --staged`
- `scripts/lint-host-agnostic.sh --staged`
- `.githooks/pre-commit`

Known existing warnings remain: `W_ARGUS_SECRET_SCOPE`, `W_LONG_DESCRIPTION` for pre-existing long descriptions, and `W_MISSING_SCHEMA_REF:capability-manifest.json:chanakya/reopen`.
