### PR TITLE
Implement v2 topology role contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ scripts/chanakya-task-train.sh --train export-flow --yes     # serial plan-revie
 scripts/issue-body-edit.sh 463 --repo owner/repo --body-file generated.md --apply  # guarded issue body replacement; dry-run unless --apply
 scripts/pre-commit-review.sh                                # manual no-secret reviewer gate for risky staged diffs
 scripts/v2-role-resolve.sh chanakya                         # resolve Studio v2 compatibility aliases to canonical role names
-scripts/v2-role-contract.sh --resolve --role achilles        # resolve migrated A8 worker/reviewer/perf contracts
+scripts/v2-role-contract.sh --resolve --role architect       # resolve migrated planner/worker/reviewer/perf contracts
 scripts/lint-v2-enforcement.sh --staged                     # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/v2-profile.sh --profile ios-turnip --list           # A6 project-profile operation resolver
 scripts/v2-cutover.sh --status                              # A9 v1 archive / v2 traffic-switch status
@@ -258,7 +258,7 @@ scripts/                # multi-worker fleet (BETA)
   lint-architecture.sh  # staged router/frontmatter checks; --full runs repository-wide audits
   lint-project-skill-links.sh # blocks missing repo-local project skill discovery links
   v2-role-resolve.sh    # Studio v2 canonical role + compatibility alias resolver
-  v2-role-contract.sh   # Studio v2 A8 worker/reviewer/perf contract resolver
+  v2-role-contract.sh   # Studio v2 migrated planner/worker/reviewer/perf contract resolver
   lint-v2-enforcement.sh # A0.6 Studio v2 SPEC-derived substrate/profile gates
   v2-profile.sh          # A6 resolver/runner for profile-owned build/test/lint/release operations
   lint-build-release-message.sh # A11 build/release message shape + duplicate linter

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ scripts/chanakya-task-train.sh --train export-flow --yes     # serial plan-revie
 scripts/issue-body-edit.sh 463 --repo owner/repo --body-file generated.md --apply  # guarded issue body replacement; dry-run unless --apply
 scripts/pre-commit-review.sh                                # manual no-secret reviewer gate for risky staged diffs
 scripts/v2-role-resolve.sh chanakya                         # resolve Studio v2 compatibility aliases to canonical role names
-scripts/v2-role-contract.sh --resolve --role architect       # resolve migrated planner/worker/reviewer/perf contracts
+scripts/v2-role-contract.sh --resolve --role shipper         # resolve migrated v2 role contracts
 scripts/lint-v2-enforcement.sh --staged                     # A0.6 Studio v2 SPEC-derived substrate/profile gates
 scripts/v2-profile.sh --profile ios-turnip --list           # A6 project-profile operation resolver
 scripts/v2-cutover.sh --status                              # A9 v1 archive / v2 traffic-switch status
@@ -258,7 +258,7 @@ scripts/                # multi-worker fleet (BETA)
   lint-architecture.sh  # staged router/frontmatter checks; --full runs repository-wide audits
   lint-project-skill-links.sh # blocks missing repo-local project skill discovery links
   v2-role-resolve.sh    # Studio v2 canonical role + compatibility alias resolver
-  v2-role-contract.sh   # Studio v2 migrated planner/worker/reviewer/perf contract resolver
+  v2-role-contract.sh   # Studio v2 migrated role-contract resolver
   lint-v2-enforcement.sh # A0.6 Studio v2 SPEC-derived substrate/profile gates
   v2-profile.sh          # A6 resolver/runner for profile-owned build/test/lint/release operations
   lint-build-release-message.sh # A11 build/release message shape + duplicate linter

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T21:12:26Z",
+  "generated_at": "2026-05-03T21:31:15Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T21:31:15Z",
+  "generated_at": "2026-05-03T21:49:43Z",
   "agents": [
     {
       "name": "studio",

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -13,9 +13,12 @@ Current substrate artifacts:
   to `scripts/lint-v2-bootstrap.sh`.
 - `registry/roles.json` is the A1 canonical role registry. Resolve canonical
   names and compatibility aliases with `scripts/v2-role-resolve.sh`.
-- `roles/worker.yaml`, `roles/reviewer.yaml`, and `roles/perf.yaml` are the A8
-  executable role contracts for the migrated worker, reviewer, and perf roles.
-  Validate or resolve them with `scripts/v2-role-contract.sh`.
+- `roles/planner.yaml`, `roles/worker.yaml`, `roles/reviewer.yaml`, and
+  `roles/perf.yaml` are executable role contracts for the migrated planner,
+  worker, reviewer, and perf roles. Validate or resolve them with
+  `scripts/v2-role-contract.sh`.
+- `schemas/handoff.schema.json` and `handoffs/planner-output.yaml` define the
+  planner-output handoff validation fixture.
 - `skills/dev-studio/` is the A2 umbrella skill. It defines `/dev-studio`,
   lists canonical role dispatch rows, and records v1 compatibility forwarders
   for `/chanakya`, `/achilles`, `/argus`, and `/apollo`.

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -13,12 +13,12 @@ Current substrate artifacts:
   to `scripts/lint-v2-bootstrap.sh`.
 - `registry/roles.json` is the A1 canonical role registry. Resolve canonical
   names and compatibility aliases with `scripts/v2-role-resolve.sh`.
-- `roles/planner.yaml`, `roles/worker.yaml`, `roles/reviewer.yaml`, and
-  `roles/perf.yaml` are executable role contracts for the migrated planner,
-  worker, reviewer, and perf roles. Validate or resolve them with
-  `scripts/v2-role-contract.sh`.
-- `schemas/handoff.schema.json` and `handoffs/planner-output.yaml` define the
-  planner-output handoff validation fixture.
+- `roles/*.yaml` contains executable role contracts for the migrated planner,
+  worker, reviewer, qa-engineer, flow-tester, perf, and release-manager roles.
+  Validate or resolve them with `scripts/v2-role-contract.sh`.
+- `schemas/handoff.schema.json` and `handoffs/*.yaml` define role-specific
+  handoff validation fixtures for planner output, QA contracts, flow-test
+  checklists, and release packets.
 - `skills/dev-studio/` is the A2 umbrella skill. It defines `/dev-studio`,
   lists canonical role dispatch rows, and records v1 compatibility forwarders
   for `/chanakya`, `/achilles`, `/argus`, and `/apollo`.

--- a/core/v2/SPEC.md
+++ b/core/v2/SPEC.md
@@ -172,6 +172,9 @@ resolve through `core/v2/registry/roles.json` and
 Every executable role contract declares purpose, inputs, outputs, reads, writes,
 idempotency key, decision rights, escalation triggers, failure semantics, and
 verification floor. Extracted helpers follow the same minimum before code moves.
+Planner owns scope shaping, reusable API discovery, task decomposition, and
+acceptance criteria for shaped work; irreducible conflicts over scope, priority,
+authority, or user-visible tradeoffs escalate back to manager before dispatch.
 
 Handoff artifacts use this shared envelope:
 

--- a/core/v2/SPEC.md
+++ b/core/v2/SPEC.md
@@ -175,6 +175,10 @@ verification floor. Extracted helpers follow the same minimum before code moves.
 Planner owns scope shaping, reusable API discovery, task decomposition, and
 acceptance criteria for shaped work; irreducible conflicts over scope, priority,
 authority, or user-visible tradeoffs escalate back to manager before dispatch.
+QA engineer owns automated test contracts with partial multi-spawn completion
+semantics; flow tester owns scenario-level user-flow evidence and severity
+thresholds; release manager owns release readiness packets and blocks external
+release actions until operator approval exists.
 
 Handoff artifacts use this shared envelope:
 
@@ -199,14 +203,14 @@ Required handoff families:
   ask for an epic, phase, or batch.
 - `worker-contract`: issue/task reference, ownership, allowed files, checks,
   stop conditions, and summary artifact path.
-- `qa-contract`: test objective, target build or worktree, scenarios,
-  environment, expected evidence, and pass/fail semantics.
+- `qa-contract`: task contract reference, test strategy, QA targets, required
+  checks, partial completion rule, and escalation state.
 - `reviewer-verdict`: blocking findings, warnings, evidence reviewed, and
   explicit `nothing_fatal` status when clean.
-- `flow-test-checklist`: manual flow checklist tied to a build or release
-  packet with result capture fields.
-- `release-packet`: beta/prod release bundle with commits, issues, verification,
-  notes draft, rollback notes, approvals, tag, and build metadata.
+- `flow-test-checklist`: scenario IDs, severity, pass/fail/blocked state,
+  evidence refs, distinction from QA/reviewer, and merge-block rule.
+- `release-packet`: release scope, anchor issues, notes state, build/release
+  message state, tag/GitHub release/TestFlight/App Store states, and blockers.
 
 Routing intelligence is advisory unless a contract grants authority. Novelty,
 architectural concern, or model-role recommendations produce suggestions or

--- a/core/v2/handoffs/flow-test-checklist.yaml
+++ b/core/v2/handoffs/flow-test-checklist.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+artifact_kind: flow-test-checklist
+artifact_id: flow-test-checklist:issue-542
+created_at: "2026-05-03T22:20:00Z"
+producer_role: flow-tester
+consumer_role: reviewer
+subject_ref: issue:542
+idempotency_key: flow-tester:issue-542:role-contract
+payload:
+  flow_scope:
+    - Validate the substrate distinction between exploratory user-flow checks, QA automation, and reviewer code review.
+  distinction: Flow tester owns scenario-level user outcomes and severity thresholds; qa-engineer owns automated test contracts; reviewer owns plan/spec/code compliance.
+  scenarios:
+    - scenario_id: role-contract-flow
+      description: Role contract names flow scope, scenario states, severity, evidence refs, and merge-block semantics.
+      severity: high
+      status: pass
+      evidence_refs:
+        - core/v2/roles/flow-tester.yaml
+    - scenario_id: checklist-schema
+      description: Handoff fixture validates scenario IDs, evidence refs, severity, and pass/fail/blocked states.
+      severity: medium
+      status: pass
+      evidence_refs:
+        - core/v2/handoffs/flow-test-checklist.yaml
+  merge_block_rule: Critical or high severity failed or blocked scenarios block merge until manager or operator resolves the risk.
+  escalation:
+    required: false
+    reason: ""
+    manager_decision_needed: ""
+evidence_refs:
+  - core/v2/roles/flow-tester.yaml
+  - core/v2/schemas/handoff.schema.json
+privacy_classification: public
+status: ready

--- a/core/v2/handoffs/planner-output.yaml
+++ b/core/v2/handoffs/planner-output.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+artifact_kind: planner-output
+artifact_id: planner-output:issue-540
+created_at: "2026-05-03T21:24:24Z"
+producer_role: planner
+consumer_role: reviewer
+subject_ref: issue:540
+idempotency_key: planner:issue-540:role-contract
+payload:
+  scope:
+    - Add the planner role contract and its typed handoff validation fixture.
+  non_goals:
+    - Do not implement qa-engineer, flow-tester, or release-manager role contracts.
+    - Do not switch user-project runtime traffic.
+  dependencies:
+    - A0d role topology and handoff RFC.
+    - Existing worker, reviewer, and perf role-contract migration.
+  reusable_api_findings:
+    - scripts/v2-role-resolve.sh already resolves planner aliases from core/v2/registry/roles.json.
+    - scripts/v2-role-contract.sh is the existing resolver/list/validation primitive for executable role contracts.
+    - scripts/lint-v2-enforcement.sh already checks minimum handoff envelope and role-contract fields.
+  risks:
+    - Planner must not take manager-owned final acceptance or dispatch authority.
+    - Planner-output must preserve manager escalation for irreducible conflicts.
+  acceptance_criteria:
+    - Planner resolves through role-contract list and alias resolution without regressing worker, reviewer, or perf.
+    - Planner-output fixture validates against the v2 handoff schema.
+    - Planner contract documents decision rights, failure semantics, verification floor, and manager escalation triggers.
+  decomposition:
+    - contract_id: worker-contract:issue-540
+      summary: Implement planner role contract, resolver coverage, and planner-output handoff fixture.
+      owner_role: worker
+      allowed_paths:
+        - core/v2/roles/planner.yaml
+        - core/v2/schemas/role-contract.schema.json
+        - core/v2/schemas/handoff.schema.json
+        - core/v2/handoffs/planner-output.yaml
+        - scripts/v2-role-contract.sh
+        - scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+        - scripts/test-fixtures/540-planner-contract/test-planner-contract.sh
+      required_checks:
+        - scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+        - scripts/test-fixtures/540-planner-contract/test-planner-contract.sh
+        - scripts/lint-v2-enforcement.sh --full
+      stop_conditions:
+        - Required schema validation tooling is unavailable.
+        - Resolver changes would remove worker, reviewer, or perf coverage.
+        - Implementation would need qa-engineer, flow-tester, or release-manager role contracts.
+      summary_artifact: .studio/chain-worker-summary.json
+  review_ask: Verify the planner contract preserves manager escalation and the handoff fixture validates without broadening adjacent role scope.
+  escalation:
+    required: false
+    reason: ""
+    manager_decision_needed: ""
+evidence_refs:
+  - core/v2/roles/planner.yaml
+  - core/v2/schemas/handoff.schema.json
+privacy_classification: public
+status: ready

--- a/core/v2/handoffs/qa-contract.yaml
+++ b/core/v2/handoffs/qa-contract.yaml
@@ -1,0 +1,36 @@
+schema_version: 1
+artifact_kind: qa-contract
+artifact_id: qa-contract:issue-541
+created_at: "2026-05-03T22:20:00Z"
+producer_role: qa-engineer
+consumer_role: reviewer
+subject_ref: issue:541
+idempotency_key: qa-engineer:issue-541:role-contract
+payload:
+  task_contract_ref: worker-contract:issue-541
+  test_strategy:
+    - Validate the role contract, resolver mapping, and handoff payload without adding user-project tests.
+    - Treat independent QA targets as partially completable when their evidence is stable and named.
+  qa_targets:
+    - target_id: role-contract
+      scope: qa-engineer role contract validates against the shared role-contract schema.
+      required_checks:
+        - scripts/test-fixtures/541-qa-engineer-contract/test-qa-engineer-contract.sh
+      status: passed
+    - target_id: handoff-fixture
+      scope: qa-contract fixture validates against the shared handoff schema.
+      required_checks:
+        - scripts/test-fixtures/541-qa-engineer-contract/test-qa-engineer-contract.sh
+      status: passed
+  parallel_completion:
+    partial_allowed: true
+    completion_rule: Independent QA targets may finish separately; unresolved targets remain explicit blockers or partials.
+  escalation:
+    required: false
+    reason: ""
+    manager_decision_needed: ""
+evidence_refs:
+  - core/v2/roles/qa-engineer.yaml
+  - core/v2/schemas/handoff.schema.json
+privacy_classification: public
+status: ready

--- a/core/v2/handoffs/release-packet.yaml
+++ b/core/v2/handoffs/release-packet.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+artifact_kind: release-packet
+artifact_id: release-packet:issue-543
+created_at: "2026-05-03T22:20:00Z"
+producer_role: release-manager
+consumer_role: manager
+subject_ref: issue:543
+idempotency_key: release-manager:issue-543:role-contract
+payload:
+  release_scope:
+    - Define release-manager substrate only; do not tag, publish, submit, or draft a release.
+  anchor_issues:
+    - "#214"
+    - "#543"
+  release_notes: []
+  build_release_message: pending
+  tags: pending
+  github_release: pending
+  testflight: pending
+  app_store: pending
+  blockers:
+    - Release is deferred until the full v2 transition finishes and operator approval exists.
+evidence_refs:
+  - core/v2/roles/release-manager.yaml
+  - core/v2/schemas/handoff.schema.json
+privacy_classification: public
+status: blocked

--- a/core/v2/roles/flow-tester.yaml
+++ b/core/v2/roles/flow-tester.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 542
+status: active
+role: flow-tester
+aliases:
+  - flow
+  - manual-qa
+  - exploratory-tester
+purpose: Validate user-flow scenarios from the spec and block merges on severe user-flow regressions with concrete evidence.
+inputs:
+  - kind: flow-scope
+    required: true
+    description: User-facing scenarios, target build or branch, affected workflows, and severity threshold.
+  - kind: worker-summary
+    required: false
+    description: Implementation summary and evidence refs for the changed behavior under flow test.
+  - kind: qa-contract
+    required: false
+    description: Automated QA results that can inform, but not replace, exploratory flow coverage.
+outputs:
+  - kind: flow-test-checklist
+    required: true
+    description: Scenario IDs, descriptions, severity, pass/fail/blocked state, evidence refs, and merge-block rule.
+reads:
+  - scope: owned worktree
+    description: Specs, docs, screenshots, fixtures, builds, and test instructions needed to run user-flow scenarios.
+  - scope: ~/.dev-studio/**
+    description: Runtime worker summaries, QA contracts, build refs, flow evidence, and prior checklist attempts.
+writes:
+  - scope: owned worktree
+    description: Flow checklist fixtures or checked-in flow-test contracts when the source issue explicitly asks for substrate artifacts.
+  - scope: ~/.dev-studio/**
+    description: Flow-test checklists, screenshots or evidence refs, blocked-flow records, and manager escalation notes.
+idempotency_key: flow-tester:{subject_ref}:{flow_scope}:{build_or_branch_ref}
+decision_rights:
+  - Define user-flow scenarios and severity from the accepted spec without changing product scope.
+  - Distinguish exploratory flow failures from reviewer code-quality findings and QA automated test failures.
+  - Block merge when a critical or high severity flow scenario fails or cannot be evaluated.
+  - Mark low-risk scenarios not-run only when the checklist explains why the gap is acceptable.
+escalation_triggers:
+  - Critical or high severity scenario fails, is blocked, or lacks required evidence.
+  - Flow scope conflicts with QA contract, reviewer verdict, or manager acceptance criteria.
+  - Scenario execution needs external credentials, real-user data, release authority, or operator approval.
+failure_semantics:
+  - Return blocked for missing build, environment, credentials, or scenario instructions.
+  - Return failed with scenario IDs and evidence refs rather than broad narrative summaries.
+  - Preserve partial checklist state so resolved scenarios are not rerun unnecessarily.
+verification_floor:
+  - Flow checklist names scenario IDs, severity, state, evidence refs, and merge-block rule.
+  - The checklist documents how flow-tester differs from qa-engineer and reviewer for this scope.
+  - Any merge-blocking scenario includes exact evidence or missing-input reason.

--- a/core/v2/roles/planner.yaml
+++ b/core/v2/roles/planner.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 540
+status: active
+role: planner
+aliases:
+  - architect
+  - luban
+  - lu-ban
+purpose: Convert shaped intent into executable plans, dependency graphs, acceptance criteria, and worker contracts before implementation starts.
+inputs:
+  - kind: shaped-intent
+    required: true
+    description: Manager-shaped goal, impact, constraints, non-goals, dependencies, and explicit planning ask.
+  - kind: repo-context
+    required: false
+    description: Current repository state, prior decisions, reusable APIs, contracts, and relevant docs needed to plan safely.
+  - kind: project-profile
+    required: false
+    description: Profile command mapping for build, test, lint, format, and release-independent verification constraints.
+outputs:
+  - kind: planner-output
+    required: true
+    description: Structured scope, dependencies, reusable API findings, risks, acceptance criteria, decomposition, review ask, and escalation state.
+  - kind: worker-contract
+    required: false
+    description: Bounded executable leaf contract with ownership, allowed files, checks, stop conditions, and summary artifact path.
+reads:
+  - scope: owned worktree
+    description: Source, docs, schemas, mode packs, profiles, and tests needed to discover reusable APIs and shape executable work.
+  - scope: ~/.dev-studio/**
+    description: Runtime plans, issue graph exports, prior review outcomes, and private analysis artifacts explicitly named by the manager contract.
+writes:
+  - scope: owned worktree
+    description: Planner-output fixtures or checked-in planning contracts when the source issue explicitly asks for substrate artifacts.
+  - scope: ~/.dev-studio/**
+    description: Planner outputs, worker contracts, dependency graphs, review packets, and blocked or needs-context artifacts.
+idempotency_key: planner:{subject_ref}:{planning_scope}
+decision_rights:
+  - Define in-scope and out-of-scope work for a shaped request without changing manager-owned priority or final acceptance.
+  - Discover and require reuse of existing APIs, scripts, schemas, profiles, and conventions before proposing new substrate.
+  - Decompose L/XL work into S/M worker contracts and combine related XS leaves only when acceptance criteria remain explicit.
+  - Mark a plan blocked when dependencies, authority, reusable API evidence, or acceptance criteria are insufficient.
+escalation_triggers:
+  - Scope, dependencies, or priorities conflict in a way that cannot be reduced without changing the manager-owned brief.
+  - The requested implementation would require qa-engineer, flow-tester, release-manager, operator approval, or permission expansion not granted by the planning contract.
+  - Reusable API discovery finds multiple incompatible approaches and the tradeoff changes user-visible behavior, runtime risk, or chain cost.
+  - Acceptance criteria cannot be made testable or bounded without manager clarification.
+failure_semantics:
+  - Return needs_context with exact missing inputs rather than inventing scope, dependencies, APIs, or acceptance criteria.
+  - Return blocked for irreducible conflicts and escalate to manager; the planner must not silently choose between conflicting manager-owned goals.
+  - Preserve partial planner outputs with stable idempotency key and explicit unsafe-to-dispatch status when decomposition is incomplete.
+verification_floor:
+  - Planner output names scope, non-goals, dependencies, risks, reusable API findings, acceptance criteria, and explicit review ask.
+  - Each worker contract produced by the planner has bounded ownership, required checks, stop conditions, and a private summary artifact path.
+  - Irreducible conflicts are escalated to manager before worker dispatch.

--- a/core/v2/roles/qa-engineer.yaml
+++ b/core/v2/roles/qa-engineer.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 541
+status: active
+role: qa-engineer
+aliases:
+  - qa
+  - chiron
+  - synthetic-qa
+purpose: Produce and execute stable test contracts against bounded worker outputs without chasing live implementation churn.
+inputs:
+  - kind: task-contract
+    required: true
+    description: Bounded worker contract, acceptance criteria, changed surface, and required verification floor.
+  - kind: worker-summary
+    required: false
+    description: Completed worker evidence, checks, artifacts, and carryover supplied after implementation.
+  - kind: project-profile
+    required: false
+    description: Profile-owned test, lint, fixture, simulator, and retry commands available for QA execution.
+outputs:
+  - kind: qa-contract
+    required: true
+    description: Structured QA targets, test strategy, required checks, partial completion state, and escalation status.
+reads:
+  - scope: owned worktree
+    description: Source, tests, fixtures, docs, profiles, and worker artifacts needed to design and run stable checks.
+  - scope: ~/.dev-studio/**
+    description: Runtime task contracts, worker summaries, prior QA attempts, and private evidence paths named by the manager or planner.
+writes:
+  - scope: owned worktree
+    description: QA fixtures or checked-in QA contracts only when the source issue explicitly requests substrate artifacts.
+  - scope: ~/.dev-studio/**
+    description: QA contracts, test evidence, partial completion summaries, retry notes, and blocked-state records.
+idempotency_key: qa-engineer:{subject_ref}:{task_contract_ref}:{qa_scope}
+decision_rights:
+  - Select tests and fixtures that prove the accepted task contract without expanding worker implementation scope.
+  - Run QA in parallel for independent task contracts and report partial completion when some targets finish before others.
+  - Mark QA blocked when required worker evidence, profile commands, simulator state, or test data is unavailable.
+  - Escalate suspected acceptance-criteria gaps to manager or planner instead of redefining the task contract.
+escalation_triggers:
+  - Required QA target cannot be evaluated with available profile commands or evidence.
+  - A failed QA target changes release, merge, or user-visible risk and needs manager prioritization.
+  - Parallel QA children disagree on pass/fail state for the same target.
+  - The requested QA would require flow-tester exploratory scenarios or release-manager authority.
+failure_semantics:
+  - Return partial when independent QA targets complete but at least one target is pending, failed, or blocked.
+  - Return blocked with exact missing inputs rather than inventing test commands, fixtures, or acceptance criteria.
+  - Preserve evidence refs and idempotency key so retrying the same QA contract is deduplicable.
+verification_floor:
+  - QA contract names task reference, strategy, targets, required checks, completion rule, and escalation state.
+  - Each QA target has a stable ID, scoped assertion, required checks, and pass/fail/blocked state.
+  - Partial multi-spawn completion records which targets finished and why unfinished targets are safe or unsafe to defer.

--- a/core/v2/roles/release-manager.yaml
+++ b/core/v2/roles/release-manager.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 543
+status: active
+role: release-manager
+aliases:
+  - release
+  - shipper
+purpose: Assemble release packets, verify release prerequisites, and hold release-block semantics without prematurely tagging or shipping.
+inputs:
+  - kind: release-scope
+    required: true
+    description: Intended release train, included changes, excluded changes, target channels, and operator constraints.
+  - kind: verification-summary
+    required: false
+    description: Worker, reviewer, QA, flow-tester, perf, and build/release message evidence required for release readiness.
+  - kind: release-anchor
+    required: false
+    description: Detailed release-management scope from issue #214 or a successor planning artifact.
+outputs:
+  - kind: release-packet
+    required: true
+    description: Release notes, tag state, GitHub release state, TestFlight/App Store state, build/release message evidence, and blockers.
+reads:
+  - scope: owned worktree
+    description: Release docs, changelog, build/release scripts, tags, issue references, and verification artifacts.
+  - scope: ~/.dev-studio/**
+    description: Private chain reports, review outcomes, QA and flow evidence, perf packets, and release-decision escrow records.
+writes:
+  - scope: owned worktree
+    description: Release-packet fixtures or checked-in release contracts when the source issue explicitly asks for substrate artifacts.
+  - scope: ~/.dev-studio/**
+    description: Release packets, blocker records, operator-decision escrows, and private release-readiness notes.
+idempotency_key: release-manager:{subject_ref}:{release_scope}:{channel}
+decision_rights:
+  - Declare release readiness, release blockers, and required operator decisions from gathered verification evidence.
+  - Reference issue #214 as the detailed release-manager anchor without closing or duplicating its implementation scope.
+  - Require build/release message lint, tag, GitHub release, TestFlight, and App Store evidence before external release actions.
+  - Stop release preparation when the user has deferred release or when verification evidence is incomplete.
+escalation_triggers:
+  - Tagging, GitHub release publication, TestFlight submission, App Store submission, or production messaging needs operator approval.
+  - Included changes, release notes, or channel state conflict with manager or operator instructions.
+  - Required QA, flow, perf, build, or release-message evidence is missing or failed.
+  - The work would close #214 or perform an actual release instead of preserving the detailed anchor.
+failure_semantics:
+  - Return blocked when release evidence, operator approval, or channel credentials are missing.
+  - Return partial when packet assembly is complete but any external channel remains pending or intentionally deferred.
+  - Do not tag, publish, submit, or draft public release notes unless the operator explicitly authorizes that phase.
+verification_floor:
+  - Release packet names release scope, anchor issues including #214, notes state, tag state, GitHub release state, TestFlight/App Store state, and blockers.
+  - Build/release message lint and external-channel states are represented as explicit evidence states.
+  - Any release-blocking item names the missing evidence or required operator decision.

--- a/core/v2/schemas/handoff.schema.json
+++ b/core/v2/schemas/handoff.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "v2-handoff.schema.json",
   "title": "Studio v2 handoff artifact",
-  "description": "Shared Studio v2 handoff envelope with planner-output payload validation.",
+  "description": "Shared Studio v2 handoff envelope with role-specific payload validation.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -32,10 +32,7 @@
       ]
     },
     "artifact_id": {"type": "string", "minLength": 1},
-    "created_at": {
-      "type": "string",
-      "format": "date-time"
-    },
+    "created_at": {"type": "string", "format": "date-time"},
     "producer_role": {"$ref": "#/$defs/role"},
     "consumer_role": {"$ref": "#/$defs/role"},
     "subject_ref": {"type": "string", "minLength": 1},
@@ -45,24 +42,47 @@
       "type": "array",
       "items": {"type": "string", "minLength": 1}
     },
-    "privacy_classification": {
-      "enum": ["public", "private-runtime", "secret"]
-    },
-    "status": {
-      "enum": ["draft", "ready", "blocked", "approved", "rejected", "completed", "partial"]
-    }
+    "privacy_classification": {"enum": ["public", "private-runtime", "secret"]},
+    "status": {"enum": ["draft", "ready", "blocked", "approved", "rejected", "completed", "partial"]}
   },
   "allOf": [
     {
-      "if": {
-        "properties": {"artifact_kind": {"const": "planner-output"}},
-        "required": ["artifact_kind"]
-      },
+      "if": {"properties": {"artifact_kind": {"const": "planner-output"}}, "required": ["artifact_kind"]},
       "then": {
         "properties": {
           "producer_role": {"const": "planner"},
           "consumer_role": {"enum": ["manager", "reviewer"]},
           "payload": {"$ref": "#/$defs/plannerOutputPayload"}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"artifact_kind": {"const": "qa-contract"}}, "required": ["artifact_kind"]},
+      "then": {
+        "properties": {
+          "producer_role": {"const": "qa-engineer"},
+          "consumer_role": {"enum": ["manager", "worker", "reviewer"]},
+          "payload": {"$ref": "#/$defs/qaContractPayload"}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"artifact_kind": {"const": "flow-test-checklist"}}, "required": ["artifact_kind"]},
+      "then": {
+        "properties": {
+          "producer_role": {"const": "flow-tester"},
+          "consumer_role": {"enum": ["manager", "reviewer", "release-manager"]},
+          "payload": {"$ref": "#/$defs/flowTestChecklistPayload"}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"artifact_kind": {"const": "release-packet"}}, "required": ["artifact_kind"]},
+      "then": {
+        "properties": {
+          "producer_role": {"const": "release-manager"},
+          "consumer_role": {"enum": ["manager", "operator"]},
+          "payload": {"$ref": "#/$defs/releasePacketPayload"}
         }
       }
     }
@@ -87,6 +107,23 @@
       "minItems": 1,
       "items": {"type": "string", "minLength": 1}
     },
+    "optionalTextArray": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "evidenceState": {
+      "enum": ["pending", "passed", "failed", "blocked", "partial", "not-applicable"]
+    },
+    "escalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "reason", "manager_decision_needed"],
+      "properties": {
+        "required": {"type": "boolean"},
+        "reason": {"type": "string"},
+        "manager_decision_needed": {"type": "string"}
+      }
+    },
     "taskContract": {
       "type": "object",
       "additionalProperties": false,
@@ -109,6 +146,29 @@
         "summary_artifact": {"type": "string", "minLength": 1}
       }
     },
+    "qaTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_id", "scope", "required_checks", "status"],
+      "properties": {
+        "target_id": {"type": "string", "minLength": 1},
+        "scope": {"type": "string", "minLength": 1},
+        "required_checks": {"$ref": "#/$defs/textArray"},
+        "status": {"$ref": "#/$defs/evidenceState"}
+      }
+    },
+    "flowScenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenario_id", "description", "severity", "status", "evidence_refs"],
+      "properties": {
+        "scenario_id": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "severity": {"enum": ["critical", "high", "medium", "low"]},
+        "status": {"enum": ["pass", "fail", "blocked", "not-run"]},
+        "evidence_refs": {"$ref": "#/$defs/optionalTextArray"}
+      }
+    },
     "plannerOutputPayload": {
       "type": "object",
       "additionalProperties": false,
@@ -125,10 +185,10 @@
       ],
       "properties": {
         "scope": {"$ref": "#/$defs/textArray"},
-        "non_goals": {"type": "array", "items": {"type": "string", "minLength": 1}},
-        "dependencies": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "non_goals": {"$ref": "#/$defs/optionalTextArray"},
+        "dependencies": {"$ref": "#/$defs/optionalTextArray"},
         "reusable_api_findings": {"$ref": "#/$defs/textArray"},
-        "risks": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "risks": {"$ref": "#/$defs/optionalTextArray"},
         "acceptance_criteria": {"$ref": "#/$defs/textArray"},
         "decomposition": {
           "type": "array",
@@ -136,16 +196,73 @@
           "items": {"$ref": "#/$defs/taskContract"}
         },
         "review_ask": {"type": "string", "minLength": 1},
-        "escalation": {
+        "escalation": {"$ref": "#/$defs/escalation"}
+      }
+    },
+    "qaContractPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["task_contract_ref", "test_strategy", "qa_targets", "parallel_completion", "escalation"],
+      "properties": {
+        "task_contract_ref": {"type": "string", "minLength": 1},
+        "test_strategy": {"$ref": "#/$defs/textArray"},
+        "qa_targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/qaTarget"}
+        },
+        "parallel_completion": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["required", "reason", "manager_decision_needed"],
+          "required": ["partial_allowed", "completion_rule"],
           "properties": {
-            "required": {"type": "boolean"},
-            "reason": {"type": "string"},
-            "manager_decision_needed": {"type": "string"}
+            "partial_allowed": {"type": "boolean"},
+            "completion_rule": {"type": "string", "minLength": 1}
           }
-        }
+        },
+        "escalation": {"$ref": "#/$defs/escalation"}
+      }
+    },
+    "flowTestChecklistPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["flow_scope", "distinction", "scenarios", "merge_block_rule", "escalation"],
+      "properties": {
+        "flow_scope": {"$ref": "#/$defs/textArray"},
+        "distinction": {"type": "string", "minLength": 1},
+        "scenarios": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/flowScenario"}
+        },
+        "merge_block_rule": {"type": "string", "minLength": 1},
+        "escalation": {"$ref": "#/$defs/escalation"}
+      }
+    },
+    "releasePacketPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "release_scope",
+        "anchor_issues",
+        "release_notes",
+        "build_release_message",
+        "tags",
+        "github_release",
+        "testflight",
+        "app_store",
+        "blockers"
+      ],
+      "properties": {
+        "release_scope": {"$ref": "#/$defs/textArray"},
+        "anchor_issues": {"$ref": "#/$defs/textArray"},
+        "release_notes": {"$ref": "#/$defs/optionalTextArray"},
+        "build_release_message": {"$ref": "#/$defs/evidenceState"},
+        "tags": {"$ref": "#/$defs/evidenceState"},
+        "github_release": {"$ref": "#/$defs/evidenceState"},
+        "testflight": {"$ref": "#/$defs/evidenceState"},
+        "app_store": {"$ref": "#/$defs/evidenceState"},
+        "blockers": {"$ref": "#/$defs/optionalTextArray"}
       }
     }
   }

--- a/core/v2/schemas/handoff.schema.json
+++ b/core/v2/schemas/handoff.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "v2-handoff.schema.json",
+  "title": "Studio v2 handoff artifact",
+  "description": "Shared Studio v2 handoff envelope with planner-output payload validation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "artifact_id",
+    "created_at",
+    "producer_role",
+    "consumer_role",
+    "subject_ref",
+    "idempotency_key",
+    "payload",
+    "evidence_refs",
+    "privacy_classification",
+    "status"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "artifact_kind": {
+      "enum": [
+        "planner-output",
+        "worker-contract",
+        "qa-contract",
+        "reviewer-verdict",
+        "flow-test-checklist",
+        "release-packet"
+      ]
+    },
+    "artifact_id": {"type": "string", "minLength": 1},
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "producer_role": {"$ref": "#/$defs/role"},
+    "consumer_role": {"$ref": "#/$defs/role"},
+    "subject_ref": {"type": "string", "minLength": 1},
+    "idempotency_key": {"type": "string", "minLength": 1},
+    "payload": {"type": "object"},
+    "evidence_refs": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "privacy_classification": {
+      "enum": ["public", "private-runtime", "secret"]
+    },
+    "status": {
+      "enum": ["draft", "ready", "blocked", "approved", "rejected", "completed", "partial"]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"artifact_kind": {"const": "planner-output"}},
+        "required": ["artifact_kind"]
+      },
+      "then": {
+        "properties": {
+          "producer_role": {"const": "planner"},
+          "consumer_role": {"enum": ["manager", "reviewer"]},
+          "payload": {"$ref": "#/$defs/plannerOutputPayload"}
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "role": {
+      "enum": [
+        "manager",
+        "planner",
+        "worker",
+        "reviewer",
+        "qa-engineer",
+        "flow-tester",
+        "perf",
+        "release-manager",
+        "host-adapter",
+        "operator"
+      ]
+    },
+    "textArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "taskContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_id",
+        "summary",
+        "owner_role",
+        "allowed_paths",
+        "required_checks",
+        "stop_conditions",
+        "summary_artifact"
+      ],
+      "properties": {
+        "contract_id": {"type": "string", "minLength": 1},
+        "summary": {"type": "string", "minLength": 1},
+        "owner_role": {"const": "worker"},
+        "allowed_paths": {"$ref": "#/$defs/textArray"},
+        "required_checks": {"$ref": "#/$defs/textArray"},
+        "stop_conditions": {"$ref": "#/$defs/textArray"},
+        "summary_artifact": {"type": "string", "minLength": 1}
+      }
+    },
+    "plannerOutputPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope",
+        "non_goals",
+        "dependencies",
+        "reusable_api_findings",
+        "risks",
+        "acceptance_criteria",
+        "decomposition",
+        "review_ask",
+        "escalation"
+      ],
+      "properties": {
+        "scope": {"$ref": "#/$defs/textArray"},
+        "non_goals": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "dependencies": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "reusable_api_findings": {"$ref": "#/$defs/textArray"},
+        "risks": {"type": "array", "items": {"type": "string", "minLength": 1}},
+        "acceptance_criteria": {"$ref": "#/$defs/textArray"},
+        "decomposition": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/taskContract"}
+        },
+        "review_ask": {"type": "string", "minLength": 1},
+        "escalation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "reason", "manager_decision_needed"],
+          "properties": {
+            "required": {"type": "boolean"},
+            "reason": {"type": "string"},
+            "manager_decision_needed": {"type": "string"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/v2/schemas/role-contract.schema.json
+++ b/core/v2/schemas/role-contract.schema.json
@@ -27,10 +27,19 @@
     "schema_version": {"const": 1},
     "kind": {"const": "studio-v2-role-contract"},
     "parent_issue": {"const": 444},
-    "leaf_issue": {"const": 526},
+    "leaf_issue": {"enum": [526, 540]},
     "status": {"enum": ["active", "reserved", "retired"]},
     "role": {
-      "enum": ["worker", "reviewer", "perf"]
+      "enum": ["planner", "worker", "reviewer", "perf"]
+    },
+    "aliases": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^[A-Za-z0-9][A-Za-z0-9 _-]*$"
+      }
     },
     "purpose": {"type": "string", "minLength": 1},
     "inputs": {

--- a/core/v2/schemas/role-contract.schema.json
+++ b/core/v2/schemas/role-contract.schema.json
@@ -27,10 +27,10 @@
     "schema_version": {"const": 1},
     "kind": {"const": "studio-v2-role-contract"},
     "parent_issue": {"const": 444},
-    "leaf_issue": {"enum": [526, 540]},
+    "leaf_issue": {"enum": [526, 540, 541, 542, 543]},
     "status": {"enum": ["active", "reserved", "retired"]},
     "role": {
-      "enum": ["planner", "worker", "reviewer", "perf"]
+      "enum": ["planner", "worker", "reviewer", "qa-engineer", "flow-tester", "perf", "release-manager"]
     },
     "aliases": {
       "type": "array",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T21:12:26Z",
+  "generated_at": "2026-05-03T21:31:14Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T21:31:14Z",
+  "generated_at": "2026-05-03T21:49:42Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+++ b/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
@@ -22,7 +22,7 @@ jq -e '.["$schema"] and .type == "object"' "$SCHEMA" >/dev/null || fail "schema 
 }
 grep -Fq 'v2-role-contract: ok' "$TMPROOT/validate.err" || fail "validation did not report success"
 
-for role in planner worker reviewer perf; do
+for role in planner worker reviewer qa-engineer flow-tester perf release-manager; do
   "$CMD" --resolve --role "$role" | grep -Fxq "core/v2/roles/$role.yaml" || fail "canonical role did not resolve: $role"
   "$CMD" --resolve --role "$role" --format json | jq -e --arg role "$role" '.role == $role and .contract_file == ("core/v2/roles/" + $role + ".yaml")' >/dev/null || fail "json resolution invalid for $role"
   if command -v check-jsonschema >/dev/null 2>&1; then
@@ -34,7 +34,10 @@ done
 [ "$("$CMD" --resolve --role architect)" = "core/v2/roles/planner.yaml" ] || fail "architect alias did not resolve to planner contract"
 [ "$("$CMD" --resolve --role achilles)" = "core/v2/roles/worker.yaml" ] || fail "achilles alias did not resolve to worker contract"
 [ "$("$CMD" --resolve --role argus)" = "core/v2/roles/reviewer.yaml" ] || fail "argus alias did not resolve to reviewer contract"
+[ "$("$CMD" --resolve --role chiron)" = "core/v2/roles/qa-engineer.yaml" ] || fail "chiron alias did not resolve to qa-engineer contract"
+[ "$("$CMD" --resolve --role manual-qa)" = "core/v2/roles/flow-tester.yaml" ] || fail "manual-qa alias did not resolve to flow-tester contract"
 [ "$("$CMD" --resolve --role apollo)" = "core/v2/roles/perf.yaml" ] || fail "apollo alias did not resolve to perf contract"
+[ "$("$CMD" --resolve --role shipper)" = "core/v2/roles/release-manager.yaml" ] || fail "shipper alias did not resolve to release-manager contract"
 
 if "$CMD" --resolve --role manager >"$TMPROOT/manager.out" 2>"$TMPROOT/manager.err"; then
   fail "manager unexpectedly resolved to a migrated contract"
@@ -46,6 +49,8 @@ mkdir -p "$BAD"
 cp "$ROOT/core/v2/roles/planner.yaml" "$BAD/planner.yaml"
 cp "$ROOT/core/v2/roles/worker.yaml" "$BAD/worker.yaml"
 cp "$ROOT/core/v2/roles/reviewer.yaml" "$BAD/reviewer.yaml"
+cp "$ROOT/core/v2/roles/qa-engineer.yaml" "$BAD/qa-engineer.yaml"
+cp "$ROOT/core/v2/roles/flow-tester.yaml" "$BAD/flow-tester.yaml"
 if "$CMD" --contract-dir "$BAD" --validate >"$TMPROOT/bad.out" 2>"$TMPROOT/bad.err"; then
   fail "missing perf contract passed validation"
 fi

--- a/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+++ b/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
@@ -22,27 +22,33 @@ jq -e '.["$schema"] and .type == "object"' "$SCHEMA" >/dev/null || fail "schema 
 }
 grep -Fq 'v2-role-contract: ok' "$TMPROOT/validate.err" || fail "validation did not report success"
 
-for role in worker reviewer perf; do
+for role in planner worker reviewer perf; do
   "$CMD" --resolve --role "$role" | grep -Fxq "core/v2/roles/$role.yaml" || fail "canonical role did not resolve: $role"
-  "$CMD" --resolve --role "$role" --format json | jq -e --arg role "$role" '.role == $role and .leaf_issue == 526 and .contract_file == ("core/v2/roles/" + $role + ".yaml")' >/dev/null || fail "json resolution invalid for $role"
+  "$CMD" --resolve --role "$role" --format json | jq -e --arg role "$role" '.role == $role and .contract_file == ("core/v2/roles/" + $role + ".yaml")' >/dev/null || fail "json resolution invalid for $role"
+  if command -v check-jsonschema >/dev/null 2>&1; then
+    PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$SCHEMA" "$ROOT/core/v2/roles/$role.yaml" >/dev/null \
+      || fail "schema rejected role contract: $role"
+  fi
 done
 
+[ "$("$CMD" --resolve --role architect)" = "core/v2/roles/planner.yaml" ] || fail "architect alias did not resolve to planner contract"
 [ "$("$CMD" --resolve --role achilles)" = "core/v2/roles/worker.yaml" ] || fail "achilles alias did not resolve to worker contract"
 [ "$("$CMD" --resolve --role argus)" = "core/v2/roles/reviewer.yaml" ] || fail "argus alias did not resolve to reviewer contract"
 [ "$("$CMD" --resolve --role apollo)" = "core/v2/roles/perf.yaml" ] || fail "apollo alias did not resolve to perf contract"
 
 if "$CMD" --resolve --role manager >"$TMPROOT/manager.out" 2>"$TMPROOT/manager.err"; then
-  fail "manager unexpectedly resolved to an A8 contract"
+  fail "manager unexpectedly resolved to a migrated contract"
 fi
-grep -Fq 'role has no A8 migrated contract: manager' "$TMPROOT/manager.err" || fail "manager error was not explicit"
+grep -Fq 'role has no migrated contract: manager' "$TMPROOT/manager.err" || fail "manager error was not explicit"
 
 BAD="$TMPROOT/bad-contracts"
 mkdir -p "$BAD"
+cp "$ROOT/core/v2/roles/planner.yaml" "$BAD/planner.yaml"
 cp "$ROOT/core/v2/roles/worker.yaml" "$BAD/worker.yaml"
 cp "$ROOT/core/v2/roles/reviewer.yaml" "$BAD/reviewer.yaml"
 if "$CMD" --contract-dir "$BAD" --validate >"$TMPROOT/bad.out" 2>"$TMPROOT/bad.err"; then
   fail "missing perf contract passed validation"
 fi
-grep -Fq 'missing A8 role contract: perf' "$TMPROOT/bad.err" || fail "missing perf error was not explicit"
+grep -Fq 'missing migrated role contract: perf' "$TMPROOT/bad.err" || fail "missing perf error was not explicit"
 
 printf 'PASS: v2 role contracts\n'

--- a/scripts/test-fixtures/540-planner-contract/test-planner-contract.sh
+++ b/scripts/test-fixtures/540-planner-contract/test-planner-contract.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Verifies the planner role contract and planner-output handoff fixture.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+ROLE_CMD="$ROOT/scripts/v2-role-contract.sh"
+ROLE_CONTRACT="$ROOT/core/v2/roles/planner.yaml"
+ROLE_SCHEMA="$ROOT/core/v2/schemas/role-contract.schema.json"
+HANDOFF="$ROOT/core/v2/handoffs/planner-output.yaml"
+HANDOFF_SCHEMA="$ROOT/core/v2/schemas/handoff.schema.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail "yq is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+
+[ -x "$ROLE_CMD" ] || fail "role-contract resolver is not executable"
+[ -f "$ROLE_CONTRACT" ] || fail "missing planner role contract"
+[ -f "$ROLE_SCHEMA" ] || fail "missing role contract schema"
+[ -f "$HANDOFF" ] || fail "missing planner-output handoff fixture"
+[ -f "$HANDOFF_SCHEMA" ] || fail "missing handoff schema"
+
+"$ROLE_CMD" --validate >/tmp/planner-role-contract.out 2>/tmp/planner-role-contract.err || {
+  cat /tmp/planner-role-contract.err >&2
+  fail "role contracts failed validation"
+}
+
+[ "$("$ROLE_CMD" --resolve --role planner)" = "core/v2/roles/planner.yaml" ] \
+  || fail "planner did not resolve to planner contract"
+[ "$("$ROLE_CMD" --resolve --role architect)" = "core/v2/roles/planner.yaml" ] \
+  || fail "architect alias did not resolve to planner contract"
+[ "$("$ROLE_CMD" --resolve --role luban)" = "core/v2/roles/planner.yaml" ] \
+  || fail "luban alias did not resolve to planner contract"
+
+yq -e '
+  .role == "planner" and
+  .leaf_issue == 540 and
+  (.outputs[] | select(.kind == "planner-output")) and
+  (.outputs[] | select(.kind == "worker-contract")) and
+  (.decision_rights[] | test("reuse|Decompose|blocked")) and
+  (.escalation_triggers[] | test("manager|Acceptance|Scope|priorities")) and
+  (.failure_semantics[] | test("escalate to manager"))
+' "$ROLE_CONTRACT" >/dev/null || fail "planner contract is missing expected authority or escalation text"
+
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$ROLE_SCHEMA" "$ROLE_CONTRACT" >/dev/null \
+  || fail "role schema rejected planner contract"
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$HANDOFF_SCHEMA" "$HANDOFF" >/dev/null \
+  || fail "handoff schema rejected planner-output fixture"
+
+yq -e '
+  .artifact_kind == "planner-output" and
+  .producer_role == "planner" and
+  .consumer_role == "reviewer" and
+  (.payload.reusable_api_findings | length > 0) and
+  (.payload.acceptance_criteria | length > 0) and
+  (.payload.decomposition[0].owner_role == "worker") and
+  (.payload.escalation.required == false)
+' "$HANDOFF" >/dev/null || fail "planner-output fixture is missing expected planner payload"
+
+printf 'PASS: planner role contract and handoff\n'

--- a/scripts/test-fixtures/541-qa-engineer-contract/test-qa-engineer-contract.sh
+++ b/scripts/test-fixtures/541-qa-engineer-contract/test-qa-engineer-contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+ROLE_CMD="$ROOT/scripts/v2-role-contract.sh"
+ROLE_CONTRACT="$ROOT/core/v2/roles/qa-engineer.yaml"
+ROLE_SCHEMA="$ROOT/core/v2/schemas/role-contract.schema.json"
+HANDOFF="$ROOT/core/v2/handoffs/qa-contract.yaml"
+HANDOFF_SCHEMA="$ROOT/core/v2/schemas/handoff.schema.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail "yq is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+
+"$ROLE_CMD" --validate >/tmp/qa-role-contract.out 2>/tmp/qa-role-contract.err || {
+  cat /tmp/qa-role-contract.err >&2
+  fail "role contracts failed validation"
+}
+
+[ "$("$ROLE_CMD" --resolve --role qa-engineer)" = "core/v2/roles/qa-engineer.yaml" ] || fail "qa-engineer did not resolve"
+[ "$("$ROLE_CMD" --resolve --role chiron)" = "core/v2/roles/qa-engineer.yaml" ] || fail "chiron alias did not resolve"
+[ "$("$ROLE_CMD" --resolve --role synthetic-qa)" = "core/v2/roles/qa-engineer.yaml" ] || fail "synthetic-qa alias did not resolve"
+
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$ROLE_SCHEMA" "$ROLE_CONTRACT" >/dev/null \
+  || fail "role schema rejected qa-engineer contract"
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$HANDOFF_SCHEMA" "$HANDOFF" >/dev/null \
+  || fail "handoff schema rejected qa-contract fixture"
+
+yq -e '
+  .role == "qa-engineer" and
+  .leaf_issue == 541 and
+  (.outputs[] | select(.kind == "qa-contract")) and
+  (.decision_rights[] | test("parallel|blocked|Escalate")) and
+  (.failure_semantics[] | test("partial|blocked|idempotency"))
+' "$ROLE_CONTRACT" >/dev/null || fail "qa-engineer contract missing expected semantics"
+
+yq -e '
+  .artifact_kind == "qa-contract" and
+  .producer_role == "qa-engineer" and
+  (.payload.qa_targets | length > 0) and
+  (.payload.parallel_completion.partial_allowed == true)
+' "$HANDOFF" >/dev/null || fail "qa-contract fixture missing expected payload"
+
+printf 'PASS: qa-engineer role contract and handoff\n'

--- a/scripts/test-fixtures/542-flow-tester-contract/test-flow-tester-contract.sh
+++ b/scripts/test-fixtures/542-flow-tester-contract/test-flow-tester-contract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+ROLE_CMD="$ROOT/scripts/v2-role-contract.sh"
+ROLE_CONTRACT="$ROOT/core/v2/roles/flow-tester.yaml"
+ROLE_SCHEMA="$ROOT/core/v2/schemas/role-contract.schema.json"
+HANDOFF="$ROOT/core/v2/handoffs/flow-test-checklist.yaml"
+HANDOFF_SCHEMA="$ROOT/core/v2/schemas/handoff.schema.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail "yq is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+
+"$ROLE_CMD" --validate >/tmp/flow-role-contract.out 2>/tmp/flow-role-contract.err || {
+  cat /tmp/flow-role-contract.err >&2
+  fail "role contracts failed validation"
+}
+
+[ "$("$ROLE_CMD" --resolve --role flow-tester)" = "core/v2/roles/flow-tester.yaml" ] || fail "flow-tester did not resolve"
+[ "$("$ROLE_CMD" --resolve --role manual-qa)" = "core/v2/roles/flow-tester.yaml" ] || fail "manual-qa alias did not resolve"
+[ "$("$ROLE_CMD" --resolve --role exploratory-tester)" = "core/v2/roles/flow-tester.yaml" ] || fail "exploratory-tester alias did not resolve"
+
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$ROLE_SCHEMA" "$ROLE_CONTRACT" >/dev/null \
+  || fail "role schema rejected flow-tester contract"
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$HANDOFF_SCHEMA" "$HANDOFF" >/dev/null \
+  || fail "handoff schema rejected flow-test checklist fixture"
+
+yq -e '
+  .role == "flow-tester" and
+  .leaf_issue == 542 and
+  (.outputs[] | select(.kind == "flow-test-checklist")) and
+  (.decision_rights[] | test("scenario|severity|Block")) and
+  (.verification_floor[] | test("differs from qa-engineer and reviewer"))
+' "$ROLE_CONTRACT" >/dev/null || fail "flow-tester contract missing expected semantics"
+
+yq -e '
+  .artifact_kind == "flow-test-checklist" and
+  .producer_role == "flow-tester" and
+  (.payload.scenarios | length > 0) and
+  (.payload.merge_block_rule | test("block"))
+' "$HANDOFF" >/dev/null || fail "flow-test checklist fixture missing expected payload"
+
+printf 'PASS: flow-tester role contract and handoff\n'

--- a/scripts/test-fixtures/543-release-manager-contract/test-release-manager-contract.sh
+++ b/scripts/test-fixtures/543-release-manager-contract/test-release-manager-contract.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+ROLE_CMD="$ROOT/scripts/v2-role-contract.sh"
+ROLE_CONTRACT="$ROOT/core/v2/roles/release-manager.yaml"
+ROLE_SCHEMA="$ROOT/core/v2/schemas/role-contract.schema.json"
+HANDOFF="$ROOT/core/v2/handoffs/release-packet.yaml"
+HANDOFF_SCHEMA="$ROOT/core/v2/schemas/handoff.schema.json"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v yq >/dev/null 2>&1 || fail "yq is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+
+"$ROLE_CMD" --validate >/tmp/release-role-contract.out 2>/tmp/release-role-contract.err || {
+  cat /tmp/release-role-contract.err >&2
+  fail "role contracts failed validation"
+}
+
+[ "$("$ROLE_CMD" --resolve --role release-manager)" = "core/v2/roles/release-manager.yaml" ] || fail "release-manager did not resolve"
+[ "$("$ROLE_CMD" --resolve --role release)" = "core/v2/roles/release-manager.yaml" ] || fail "release alias did not resolve"
+[ "$("$ROLE_CMD" --resolve --role shipper)" = "core/v2/roles/release-manager.yaml" ] || fail "shipper alias did not resolve"
+
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$ROLE_SCHEMA" "$ROLE_CONTRACT" >/dev/null \
+  || fail "role schema rejected release-manager contract"
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml --schemafile "$HANDOFF_SCHEMA" "$HANDOFF" >/dev/null \
+  || fail "handoff schema rejected release-packet fixture"
+
+yq -e '
+  .role == "release-manager" and
+  .leaf_issue == 543 and
+  ((.outputs | map(.kind)) | contains(["release-packet"]))
+' "$ROLE_CONTRACT" >/dev/null || fail "release-manager contract missing expected semantics"
+grep -Fq '#214' "$ROLE_CONTRACT" || fail "release-manager contract does not reference #214"
+grep -Fq 'Do not tag' "$ROLE_CONTRACT" || fail "release-manager contract does not prevent tagging"
+
+yq -e '
+  .artifact_kind == "release-packet" and
+  .producer_role == "release-manager" and
+  (.payload.tags == "pending") and
+  (.payload.blockers | length > 0)
+' "$HANDOFF" >/dev/null || fail "release-packet fixture missing expected payload"
+grep -Fq '#214' "$HANDOFF" || fail "release-packet fixture does not reference #214"
+
+printf 'PASS: release-manager role contract and handoff\n'

--- a/scripts/v2-role-contract.sh
+++ b/scripts/v2-role-contract.sh
@@ -42,6 +42,9 @@ expected_leaf_issue_for_role() {
   case "$1" in
     worker|reviewer|perf) printf '526\n' ;;
     planner) printf '540\n' ;;
+    qa-engineer) printf '541\n' ;;
+    flow-tester) printf '542\n' ;;
+    release-manager) printf '543\n' ;;
     *) return 1 ;;
   esac
 }
@@ -108,7 +111,7 @@ validate_contracts() {
     roles="${roles}${role}"$'\n'
   done < <(contract_files)
 
-  for role in planner worker reviewer perf; do
+  for role in planner worker reviewer qa-engineer flow-tester perf release-manager; do
     printf '%s' "$roles" | grep -Fxq "$role" || {
       printf 'v2-role-contract: missing migrated role contract: %s\n' "$role" >&2
       exit 3

--- a/scripts/v2-role-contract.sh
+++ b/scripts/v2-role-contract.sh
@@ -38,8 +38,20 @@ role_for_file() {
   yq -r '.role // ""' "$1"
 }
 
+expected_leaf_issue_for_role() {
+  case "$1" in
+    worker|reviewer|perf) printf '526\n' ;;
+    planner) printf '540\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+is_migrated_role() {
+  expected_leaf_issue_for_role "$1" >/dev/null 2>&1
+}
+
 validate_contract_file() {
-  local file="$1" rel key role
+  local file="$1" rel key role expected_leaf actual_leaf
   case "$file" in
     "$REPO_ROOT"/*) rel="${file#"$REPO_ROOT/"}" ;;
     *) rel="$file" ;;
@@ -52,7 +64,7 @@ validate_contract_file() {
     }
   done
 
-  yq -e '.schema_version == 1 and .kind == "studio-v2-role-contract" and .parent_issue == 444 and .leaf_issue == 526' "$file" >/dev/null 2>&1 || {
+  yq -e '.schema_version == 1 and .kind == "studio-v2-role-contract" and .parent_issue == 444' "$file" >/dev/null 2>&1 || {
     printf 'v2-role-contract: invalid contract envelope: %s\n' "$rel" >&2
     return 1
   }
@@ -63,13 +75,17 @@ validate_contract_file() {
     return 1
   }
 
-  case "$role" in
-    worker|reviewer|perf) ;;
-    *)
-      printf 'v2-role-contract: A8 contract has out-of-scope role in %s: %s\n' "$rel" "$role" >&2
-      return 1
-      ;;
-  esac
+  if ! is_migrated_role "$role"; then
+    printf 'v2-role-contract: migrated contract has out-of-scope role in %s: %s\n' "$rel" "$role" >&2
+    return 1
+  fi
+
+  expected_leaf=$(expected_leaf_issue_for_role "$role")
+  actual_leaf=$(yq -r '.leaf_issue // ""' "$file")
+  [ "$actual_leaf" = "$expected_leaf" ] || {
+    printf 'v2-role-contract: %s has wrong leaf_issue for %s: got %s want %s\n' "$rel" "$role" "$actual_leaf" "$expected_leaf" >&2
+    return 1
+  }
 
   yq -e '(.inputs | length > 0) and (.outputs | length > 0) and (.reads | length > 0) and (.writes | length > 0) and (.decision_rights | length > 0) and (.escalation_triggers | length > 0) and (.failure_semantics | length > 0) and (.verification_floor | length > 0)' "$file" >/dev/null 2>&1 || {
     printf 'v2-role-contract: empty contract section in %s\n' "$rel" >&2
@@ -92,9 +108,9 @@ validate_contracts() {
     roles="${roles}${role}"$'\n'
   done < <(contract_files)
 
-  for role in worker reviewer perf; do
+  for role in planner worker reviewer perf; do
     printf '%s' "$roles" | grep -Fxq "$role" || {
-      printf 'v2-role-contract: missing A8 role contract: %s\n' "$role" >&2
+      printf 'v2-role-contract: missing migrated role contract: %s\n' "$role" >&2
       exit 3
     }
   done
@@ -122,13 +138,10 @@ resolve_contract() {
     exit 1
   }
 
-  case "$canonical" in
-    worker|reviewer|perf) ;;
-    *)
-      printf 'v2-role-contract: role has no A8 migrated contract: %s\n' "$canonical" >&2
-      exit 1
-      ;;
-  esac
+  if ! is_migrated_role "$canonical"; then
+    printf 'v2-role-contract: role has no migrated contract: %s\n' "$canonical" >&2
+    exit 1
+  fi
 
   file="$CONTRACT_DIR/$canonical.yaml"
   [ -f "$file" ] || {


### PR DESCRIPTION
## Summary

- adds v2 role contracts for planner, qa-engineer, flow-tester, and release-manager
- adds typed handoff fixtures and schema validation for planner output, QA contracts, flow-test checklists, and release packets
- extends `scripts/v2-role-contract.sh`, role-contract schema validation, fixtures, and v2 docs for the migrated role set

## Verification

- `scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- `scripts/test-fixtures/540-planner-contract/test-planner-contract.sh`
- `scripts/test-fixtures/541-qa-engineer-contract/test-qa-engineer-contract.sh`
- `scripts/test-fixtures/542-flow-tester-contract/test-flow-tester-contract.sh`
- `scripts/test-fixtures/543-release-manager-contract/test-release-manager-contract.sh`
- `scripts/test-fixtures/513-v2-spec/test-v2-spec.sh`
- `scripts/test-fixtures/514-v2-enforcement/test-v2-enforcement.sh`
- `scripts/lint-v2-enforcement.sh --full`
- `scripts/lint-v2-enforcement.sh --staged`
- `scripts/lint-host-agnostic.sh --staged` (existing `W_ARGUS_SECRET_SCOPE` warning only)
- pre-commit hook (existing `W_MISSING_SCHEMA_REF:capability-manifest.json:chanakya/reopen` warning)

## Review Gates

- Chain plan review: clean
- #540 corrected outcome review: clean
- Manual recovery plan review: clean
- Manual recovery outcome review: clean

Closes #540
Closes #541
Closes #542
Closes #543
