### PR TITLE
Add v2 topology runtime telemetry

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-03T23:32:56Z",
+  "generated_at": "2026-05-04T03:42:58Z",
   "agents": [
 
   ]

--- a/core/v2/events/registry.yaml
+++ b/core/v2/events/registry.yaml
@@ -3,3 +3,9 @@ events:
   - v2_event_dead_letter
   - v2_subscriber_recovery
   - manager_proof_of_life
+  - topology_sibling_host_unavailable
+  - topology_conflicting_reviews
+  - topology_stale_plan
+  - topology_worker_deadlock
+  - topology_partial_multi_spawn
+  - topology_budget_exhaustion

--- a/core/v2/schemas/topology-runtime-event.schema.json
+++ b/core/v2/schemas/topology-runtime-event.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://generic-dev-studio.local/core/v2/schemas/topology-runtime-event.schema.json",
+  "title": "Studio v2 topology runtime telemetry event",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "event",
+    "occurred_at",
+    "producer",
+    "subject",
+    "idempotency_key",
+    "writable_action",
+    "data"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "event": {
+      "enum": [
+        "topology_sibling_host_unavailable",
+        "topology_conflicting_reviews",
+        "topology_stale_plan",
+        "topology_worker_deadlock",
+        "topology_partial_multi_spawn",
+        "topology_budget_exhaustion"
+      ]
+    },
+    "occurred_at": { "type": "string", "format": "date-time" },
+    "producer": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["agent"],
+      "properties": {
+        "agent": {
+          "enum": [
+            "manager",
+            "planner",
+            "worker",
+            "reviewer",
+            "qa-engineer",
+            "flow-tester",
+            "perf",
+            "release-manager",
+            "host-adapter",
+            "operator"
+          ]
+        },
+        "mode": { "type": "string" },
+        "instance_id": { "type": "string" }
+      }
+    },
+    "subject": { "type": "string", "minLength": 1 },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "writable_action": { "type": "boolean", "const": true },
+    "data": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "failure_mode",
+        "status",
+        "evidence_ref",
+        "severity_floor",
+        "privacy_classification"
+      ],
+      "properties": {
+        "failure_mode": {
+          "enum": [
+            "sibling_host_unavailable",
+            "conflicting_reviews",
+            "stale_plan",
+            "worker_deadlock",
+            "partial_multi_spawn",
+            "budget_exhaustion"
+          ]
+        },
+        "status": { "enum": ["observed", "blocked", "degraded", "recovered", "partial"] },
+        "evidence_ref": { "type": "string", "minLength": 1 },
+        "severity_floor": { "enum": ["info", "warning", "blocked"] },
+        "privacy_classification": { "const": "private-runtime" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "event": { "const": "topology_sibling_host_unavailable" } } },
+      "then": {
+        "properties": {
+          "data": {
+            "properties": { "failure_mode": { "const": "sibling_host_unavailable" } },
+            "required": ["review_host", "fallback_used"]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "topology_conflicting_reviews" } } },
+      "then": {
+        "properties": {
+          "data": {
+            "properties": { "failure_mode": { "const": "conflicting_reviews" } },
+            "required": ["review_refs", "escalation_ref"]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "topology_stale_plan" } } },
+      "then": {
+        "properties": {
+          "data": {
+            "properties": { "failure_mode": { "const": "stale_plan" } },
+            "required": ["plan_ref", "stale_since"]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "topology_worker_deadlock" } } },
+      "then": {
+        "properties": {
+          "data": {
+            "properties": { "failure_mode": { "const": "worker_deadlock" } },
+            "required": ["worker_ref", "timeout_s"]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "topology_partial_multi_spawn" } } },
+      "then": {
+        "properties": {
+          "data": {
+            "properties": { "failure_mode": { "const": "partial_multi_spawn" } },
+            "required": ["completed_count", "expected_count"]
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "event": { "const": "topology_budget_exhaustion" } } },
+      "then": {
+        "properties": {
+          "data": {
+            "properties": { "failure_mode": { "const": "budget_exhaustion" } },
+            "required": ["budget_kind", "budget_limit", "observed_value"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/core/v2/topology/runtime-failures.yaml
+++ b/core/v2/topology/runtime-failures.yaml
@@ -1,0 +1,67 @@
+schema_version: 1
+kind: studio-v2-topology-runtime-failure-registry
+parent_issue: 445
+leaf_issue: 550
+privacy_classification: private-runtime
+failure_modes:
+  - mode: sibling_host_unavailable
+    event: topology_sibling_host_unavailable
+    severity_floor: warning
+    required_data:
+      - failure_mode
+      - status
+      - evidence_ref
+      - review_host
+      - fallback_used
+    preserved_ac: "Sibling-host unavailable is observable instead of silently degrading."
+  - mode: conflicting_reviews
+    event: topology_conflicting_reviews
+    severity_floor: blocked
+    required_data:
+      - failure_mode
+      - status
+      - evidence_ref
+      - review_refs
+      - escalation_ref
+    preserved_ac: "Conflicting reviews carry explicit escalation telemetry."
+  - mode: stale_plan
+    event: topology_stale_plan
+    severity_floor: blocked
+    required_data:
+      - failure_mode
+      - status
+      - evidence_ref
+      - plan_ref
+      - stale_since
+    preserved_ac: "Post-pause stale plans are detectable before execution continues."
+  - mode: worker_deadlock
+    event: topology_worker_deadlock
+    severity_floor: blocked
+    required_data:
+      - failure_mode
+      - status
+      - evidence_ref
+      - worker_ref
+      - timeout_s
+    preserved_ac: "Worker deadlock and timeout states are explicit runtime facts."
+  - mode: partial_multi_spawn
+    event: topology_partial_multi_spawn
+    severity_floor: warning
+    required_data:
+      - failure_mode
+      - status
+      - evidence_ref
+      - completed_count
+      - expected_count
+    preserved_ac: "Partial multi-spawn completion is measurable at the handoff boundary."
+  - mode: budget_exhaustion
+    event: topology_budget_exhaustion
+    severity_floor: blocked
+    required_data:
+      - failure_mode
+      - status
+      - evidence_ref
+      - budget_kind
+      - budget_limit
+      - observed_value
+    preserved_ac: "Context, token, and wall-clock budget exhaustion are recorded as typed blockers."

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-03T23:32:56Z",
+  "generated_at": "2026-05-04T03:42:58Z",
   "schema": 1,
   "commands": [
     {"name": "fullSendToAppStore", "source": "commands/fullSendToAppStore.md", "description": "Tag current commit, draft GitHub release, and submit build to App Store review", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/550-topology-telemetry/test-topology-telemetry.sh
+++ b/scripts/test-fixtures/550-topology-telemetry/test-topology-telemetry.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+EMIT="$ROOT/scripts/v2-topology-event.sh"
+EVENT_LOG="$ROOT/scripts/v2-event-log.sh"
+SCHEMA="$ROOT/core/v2/schemas/topology-runtime-event.schema.json"
+TMPROOT=$(mktemp -d -t topology-telemetry-550.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+[ -x "$EMIT" ] || fail "v2-topology-event.sh is not executable"
+
+RUNTIME="$TMPROOT/runtime"
+mkdir -p "$RUNTIME"
+
+"$EMIT" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:00Z \
+  --failure-mode sibling_host_unavailable --subject '#445/C6' --producer-role manager \
+  --data-json '{"status":"degraded","evidence_ref":"analysis/sibling-host-unavailable.md","review_host":"claude-reviewer","fallback_used":true}'
+
+"$EMIT" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:01Z \
+  --failure-mode conflicting_reviews --subject '#445/C6' --producer-role manager \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/conflicting-reviews.md","review_refs":["r1","r2"],"escalation_ref":"manager:decision-1"}'
+
+"$EMIT" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:02Z \
+  --failure-mode stale_plan --subject '#445/C6' --producer-role planner \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/stale-plan.md","plan_ref":"plan:123","stale_since":"2026-05-04T00:00:00Z"}'
+
+"$EMIT" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:03Z \
+  --failure-mode worker_deadlock --subject '#445/C6' --producer-role worker \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/worker-deadlock.md","worker_ref":"worker-2","timeout_s":2700}'
+
+"$EMIT" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:04Z \
+  --failure-mode partial_multi_spawn --subject '#445/C6' --producer-role qa-engineer \
+  --data-json '{"status":"partial","evidence_ref":"analysis/partial-multi-spawn.md","completed_count":2,"expected_count":3}'
+
+"$EMIT" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:05Z \
+  --failure-mode budget_exhaustion --subject '#445/C6' --producer-role release-manager \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/budget-exhaustion.md","budget_kind":"context","budget_limit":90000,"observed_value":97000}'
+
+OUT="$TMPROOT/replay.jsonl"
+"$EVENT_LOG" replay --runtime-root "$RUNTIME" --subscriber topology > "$OUT"
+[ "$(wc -l < "$OUT" | tr -d ' ')" = 6 ] || fail "expected six replayed topology events"
+
+for mode in sibling_host_unavailable conflicting_reviews stale_plan worker_deadlock partial_multi_spawn budget_exhaustion; do
+  jq -e --arg mode "$mode" 'select(.data.failure_mode == $mode and (.data.evidence_ref | length > 0))' "$OUT" >/dev/null \
+    || fail "missing replayed event for $mode"
+done
+
+while IFS= read -r line; do
+  sample="$TMPROOT/sample.json"
+  printf '%s\n' "$line" > "$sample"
+  PYTHONWARNINGS=ignore check-jsonschema --schemafile "$SCHEMA" "$sample" >/dev/null \
+    || fail "schema rejected replayed topology event"
+done < "$OUT"
+
+if "$EMIT" emit --runtime-root "$RUNTIME" --quiet \
+  --failure-mode unknown_mode --subject '#445/C6' --producer-role manager \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/bad.md"}' >"$TMPROOT/bad.out" 2>"$TMPROOT/bad.err"; then
+  fail "unknown failure mode was accepted"
+fi
+grep -q 'unknown failure mode: unknown_mode' "$TMPROOT/bad.err" || fail "unknown failure mode error was not explicit"
+
+if "$EMIT" emit --runtime-root "$RUNTIME" --quiet \
+  --failure-mode worker_deadlock --subject '#445/C6' --producer-role worker \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/missing.md","worker_ref":"worker-2"}' >"$TMPROOT/missing.out" 2>"$TMPROOT/missing.err"; then
+  fail "missing required field was accepted"
+fi
+grep -q 'missing required data field(s) for worker_deadlock: timeout_s' "$TMPROOT/missing.err" \
+  || fail "missing required field error was not explicit"
+
+if "$EMIT" emit --runtime-root "$RUNTIME" --quiet \
+  --failure-mode worker_deadlock --subject '#445/C6' --producer-role invalid-role \
+  --data-json '{"status":"blocked","evidence_ref":"analysis/schema-rejected.md","worker_ref":"worker-2","timeout_s":2700}' >"$TMPROOT/schema.out" 2>"$TMPROOT/schema.err"; then
+  fail "schema-invalid event was accepted"
+fi
+grep -q 'event failed schema validation' "$TMPROOT/schema.err" \
+  || fail "schema validation error was not explicit"
+
+printf 'PASS: topology runtime telemetry\n'

--- a/scripts/v2-topology-event.sh
+++ b/scripts/v2-topology-event.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Emit typed Studio v2 topology runtime telemetry through the durable event log.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REGISTRY="$REPO_ROOT/core/v2/topology/runtime-failures.yaml"
+SCHEMA="$REPO_ROOT/core/v2/schemas/topology-runtime-event.schema.json"
+
+COMMAND="${1:-}"
+[ -n "$COMMAND" ] && shift || true
+
+RUNTIME_ROOT=""
+FAILURE_MODE=""
+SUBJECT=""
+PRODUCER_ROLE=""
+DATA_JSON=""
+OCCURRED_AT=""
+QUIET=0
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  scripts/v2-topology-event.sh emit --runtime-root <dir> --failure-mode <mode> --subject <ref> --producer-role <role> --data-json <json> [--occurred-at <iso8601>] [--quiet]
+USAGE
+}
+
+now_utc() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+parse_emit_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --runtime-root=*) RUNTIME_ROOT="${1#--runtime-root=}"; shift ;;
+      --runtime-root) RUNTIME_ROOT="${2:?--runtime-root requires dir}"; shift 2 ;;
+      --failure-mode=*) FAILURE_MODE="${1#--failure-mode=}"; shift ;;
+      --failure-mode) FAILURE_MODE="${2:?--failure-mode requires value}"; shift 2 ;;
+      --subject=*) SUBJECT="${1#--subject=}"; shift ;;
+      --subject) SUBJECT="${2:?--subject requires value}"; shift 2 ;;
+      --producer-role=*) PRODUCER_ROLE="${1#--producer-role=}"; shift ;;
+      --producer-role) PRODUCER_ROLE="${2:?--producer-role requires value}"; shift 2 ;;
+      --data-json=*) DATA_JSON="${1#--data-json=}"; shift ;;
+      --data-json) DATA_JSON="${2:?--data-json requires JSON}"; shift 2 ;;
+      --occurred-at=*) OCCURRED_AT="${1#--occurred-at=}"; shift ;;
+      --occurred-at) OCCURRED_AT="${2:?--occurred-at requires value}"; shift 2 ;;
+      --quiet) QUIET=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) printf 'v2-topology-event: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+  done
+}
+
+require_tools() {
+  command -v jq >/dev/null 2>&1 || {
+    printf 'v2-topology-event: jq is required\n' >&2
+    exit 3
+  }
+  command -v yq >/dev/null 2>&1 || {
+    printf 'v2-topology-event: yq is required\n' >&2
+    exit 3
+  }
+  command -v check-jsonschema >/dev/null 2>&1 || {
+    printf 'v2-topology-event: check-jsonschema is required\n' >&2
+    exit 3
+  }
+}
+
+registry_row_json() {
+  FAILURE_MODE="$FAILURE_MODE" yq -o=json '.failure_modes[] | select(.mode == strenv(FAILURE_MODE))' "$REGISTRY" 2>/dev/null
+}
+
+hash_key() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf 'v2-topology-event: shasum or sha256sum required\n' >&2
+    exit 3
+  fi
+}
+
+cmd_emit() {
+  parse_emit_args "$@"
+  require_tools
+
+  [ -n "$RUNTIME_ROOT" ] || { usage; exit 2; }
+  [ -n "$FAILURE_MODE" ] || { usage; exit 2; }
+  [ -n "$SUBJECT" ] || { usage; exit 2; }
+  [ -n "$PRODUCER_ROLE" ] || { usage; exit 2; }
+  [ -n "$DATA_JSON" ] || { usage; exit 2; }
+
+  local row event severity required_fields missing data event_json tmp id_hash
+  row=$(registry_row_json)
+  if [ -z "$row" ]; then
+    printf 'v2-topology-event: unknown failure mode: %s\n' "$FAILURE_MODE" >&2
+    exit 2
+  fi
+  event=$(printf '%s\n' "$row" | jq -r '.event')
+  severity=$(printf '%s\n' "$row" | jq -r '.severity_floor')
+  required_fields=$(printf '%s\n' "$row" | jq -c '.required_data')
+
+  data=$(printf '%s' "$DATA_JSON" | jq -c \
+    --arg failure_mode "$FAILURE_MODE" \
+    --arg severity_floor "$severity" \
+    '. + {
+      failure_mode: $failure_mode,
+      severity_floor: $severity_floor,
+      privacy_classification: "private-runtime"
+    }') || {
+    printf 'v2-topology-event: --data-json is invalid JSON\n' >&2
+    exit 2
+  }
+
+  missing=$(printf '%s\n' "$data" | jq -r --argjson required "$required_fields" '
+    ($required - keys_unsorted) | join(",")
+  ') || exit 2
+  if [ -n "$missing" ]; then
+    printf 'v2-topology-event: missing required data field(s) for %s: %s\n' "$FAILURE_MODE" "$missing" >&2
+    exit 2
+  fi
+
+  [ -n "$OCCURRED_AT" ] || OCCURRED_AT=$(now_utc)
+  id_hash=$(hash_key "$SUBJECT|$FAILURE_MODE|$OCCURRED_AT|$data")
+  event_json=$(jq -n \
+    --arg event "$event" \
+    --arg occurred_at "$OCCURRED_AT" \
+    --arg producer "$PRODUCER_ROLE" \
+    --arg subject "$SUBJECT" \
+    --arg idempotency_key "topology:$SUBJECT:$FAILURE_MODE:$id_hash" \
+    --argjson data "$data" \
+    '{
+      schema_version: 1,
+      event: $event,
+      occurred_at: $occurred_at,
+      producer: {agent: $producer, mode: "topology-runtime"},
+      subject: $subject,
+      idempotency_key: $idempotency_key,
+      writable_action: true,
+      data: $data
+    }')
+
+  tmp=$(mktemp -t v2-topology-event.XXXXXX) || exit 2
+  printf '%s\n' "$event_json" > "$tmp"
+  if ! PYTHONWARNINGS=ignore check-jsonschema --schemafile "$SCHEMA" "$tmp" >/dev/null; then
+    rm -f "$tmp"
+    printf 'v2-topology-event: event failed schema validation\n' >&2
+    exit 2
+  fi
+  rm -f "$tmp"
+
+  if [ "$QUIET" -eq 1 ]; then
+    "$SCRIPT_DIR/v2-event-log.sh" append --runtime-root "$RUNTIME_ROOT" --quiet --event-json "$event_json"
+  else
+    "$SCRIPT_DIR/v2-event-log.sh" append --runtime-root "$RUNTIME_ROOT" --event-json "$event_json"
+  fi
+}
+
+case "$COMMAND" in
+  emit) cmd_emit "$@" ;;
+  -h|--help|"") usage; [ -n "$COMMAND" ] && exit 0 || exit 2 ;;
+  *) printf 'v2-topology-event: unknown command: %s\n' "$COMMAND" >&2; usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

- Add the v2 topology runtime failure registry for the six #445 failure modes.
- Add a JSON schema and `scripts/v2-topology-event.sh` emit wrapper backed by the durable v2 event log.
- Add focused fixture coverage for valid emits, unknown failure modes, missing required fields, and schema rejection.

## Verification

- `scripts/test-fixtures/550-topology-telemetry/test-topology-telemetry.sh`
- `scripts/test-fixtures/521-v2-event-log/test-v2-event-log.sh`
- `scripts/lint-v2-bootstrap.sh --full`
- `scripts/lint-v2-enforcement.sh --full`
- `scripts/lint-build-invocations.sh`
- `scripts/capability-manifest.sh --validate`
- `STUDIO_ALLOW_SURFACE_REMOVALS=1 scripts/lint-architecture.sh --staged`
- `scripts/lint-host-agnostic.sh --staged`
- `git diff --cached --check`

Phase plan review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-c6-runtime-telemetry-plan-review.md` (clean).
Phase outcome review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-c6-runtime-telemetry-outcome-review.md` (clean).

Closes #550