### PR TITLE
Report v2 role context-budget evidence

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T03:42:58Z",
+  "generated_at": "2026-05-04T03:58:14Z",
   "agents": [
 
   ]

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -40,7 +40,8 @@ Current substrate artifacts:
   skill-routing rules and resolver behavior.
 - `context-budget/manifest.json` is the A5 unified context-budget policy for
   role, skill, and invocation ceilings. Resolve and check effective budgets with
-  `scripts/v2-context-budget.sh`.
+  `scripts/v2-context-budget.sh`; emit static role-surface evidence with
+  `scripts/v2-context-budget.sh --report`.
 - `schemas/durable-event.schema.json` defines the bounded JSONL event envelope.
 - `schemas/subscriber-checkpoint.schema.json` defines durable replay coordinates.
 - `schemas/subscriber-lag.schema.json` defines subscriber lag status artifacts.

--- a/core/v2/SPEC.md
+++ b/core/v2/SPEC.md
@@ -263,8 +263,9 @@ select skills only; they do not mutate host registries or embed skill guidance.
 Context-budget enforcement is a shared subsystem, not duplicated prose inside
 each role. A5 defines budgets and telemetry in
 `core/v2/context-budget/manifest.json`; `scripts/v2-context-budget.sh` resolves
-the effective role + skill + invocation ceiling for a contract. A0.6 ensures new
-role contracts declare what they read before relying on it.
+the effective role + skill + invocation ceiling for a contract and can emit a
+static role-surface report with `--report`. A0.6 ensures new role contracts
+declare what they read before relying on it.
 
 <!-- v2-spec:testing-release -->
 ## Testing, Review, and Release Workflow

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T03:42:58Z",
+  "generated_at": "2026-05-04T03:58:14Z",
   "schema": 1,
   "commands": [
     {"name": "fullSendToAppStore", "source": "commands/fullSendToAppStore.md", "description": "Tag current commit, draft GitHub release, and submit build to App Store review", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/552-context-budget/test-context-budget-report.sh
+++ b/scripts/test-fixtures/552-context-budget/test-context-budget-report.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+CMD="$REPO_ROOT/scripts/v2-context-budget.sh"
+MANIFEST="$REPO_ROOT/core/v2/context-budget/manifest.json"
+TMPROOT=$(mktemp -d -t context-budget-552.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+report="$TMPROOT/report.json"
+"$CMD" --report --format json --output "$report"
+
+jq -e '
+  (.roles | length) == 9 and
+  (.summary.unmeasured | length) == 0 and
+  (["manager","planner","worker","reviewer","qa-engineer","flow-tester","perf","release-manager"] - [.roles[].role] | length) == 0 and
+  all(.roles[]; .status != "unmeasured" and (.evidence_files | length) > 0) and
+  .manifest_path == "core/v2/context-budget/manifest.json" and
+  .evidence_scope == "static contract-surface lower bound; not runtime token telemetry"
+' "$report" >/dev/null || fail "default report did not cover measured #552 roles"
+
+markdown="$TMPROOT/report.md"
+"$CMD" --report --format markdown --output "$markdown"
+grep -q 'static contract-surface lower bound' "$markdown" || fail "markdown missing evidence disclosure"
+grep -q 'On-demand skill content is excluded' "$markdown" || fail "markdown missing on-demand skill caveat"
+grep -q '## Under Budget' "$markdown" || fail "markdown missing under-budget section"
+grep -q '## Unmeasured' "$markdown" || fail "markdown missing unmeasured section"
+
+missing_manifest="$TMPROOT/missing-manifest.json"
+jq '.roles += [{
+  "role": "operator",
+  "max_context_tokens": 1000,
+  "required_declared_reads": true,
+  "telemetry_scope": "role"
+}]' "$MANIFEST" > "$missing_manifest"
+"$CMD" --manifest "$missing_manifest" --report --roles operator --format json > "$TMPROOT/missing.json"
+jq -e '
+  .summary.unmeasured == ["operator"] and
+  .roles[0].status == "unmeasured" and
+  (.roles[0].missing_evidence_files | index("core/v2/roles/operator.yaml"))
+' "$TMPROOT/missing.json" >/dev/null || fail "missing role surface was not reported as unmeasured"
+
+planner_estimated=$(jq -r '.roles[] | select(.role == "planner") | .estimated_tokens' "$report")
+
+warning_manifest="$TMPROOT/warning-manifest.json"
+jq --argjson budget "$((planner_estimated + 1))" '
+  (.roles[] | select(.role == "planner") | .max_context_tokens) = $budget
+' "$MANIFEST" > "$warning_manifest"
+"$CMD" --manifest "$warning_manifest" --report --roles planner --format json > "$TMPROOT/warning.json"
+jq -e '.summary.warning == ["planner"] and .roles[0].status == "warning"' "$TMPROOT/warning.json" >/dev/null \
+  || fail "warning classification was not reported"
+
+over_manifest="$TMPROOT/over-manifest.json"
+jq '(.roles[] | select(.role == "planner") | .max_context_tokens) = 1' "$MANIFEST" > "$over_manifest"
+"$CMD" --manifest "$over_manifest" --report --roles planner --format json > "$TMPROOT/over.json"
+jq -e '.summary.over_budget == ["planner"] and .roles[0].status == "over_budget"' "$TMPROOT/over.json" >/dev/null \
+  || fail "over-budget classification was not reported"
+
+printf 'PASS: context budget report\n'

--- a/scripts/v2-context-budget.sh
+++ b/scripts/v2-context-budget.sh
@@ -13,11 +13,14 @@ ROLE=""
 SKILL=""
 INVOCATION=""
 ESTIMATED_TOKENS=""
+ROLES_CSV=""
+OUTPUT=""
 
 usage() {
   cat >&2 <<'USAGE'
 usage: scripts/v2-context-budget.sh [--manifest <path>] --validate
        scripts/v2-context-budget.sh [--manifest <path>] --resolve --role <role-or-alias> [--skill <name>] [--invocation <name>] [--estimated-tokens <n>] [--format text|json]
+       scripts/v2-context-budget.sh [--manifest <path>] --report [--roles <csv>] [--format json|markdown] [--output <file>]
 USAGE
 }
 
@@ -73,6 +76,10 @@ validate_manifest() {
 
 resolve_budget() {
   [ -n "$ROLE" ] || { usage; exit 2; }
+  case "$FORMAT" in
+    text|json) ;;
+    *) usage; exit 2 ;;
+  esac
   case "$ESTIMATED_TOKENS" in
     ""|*[!0-9]*)
       [ -z "$ESTIMATED_TOKENS" ] || { usage; exit 2; }
@@ -141,6 +148,240 @@ resolve_budget() {
   fi
 }
 
+unique_lines() {
+  awk 'NF && !seen[$0]++'
+}
+
+common_surface_paths() {
+  cat <<'PATHS'
+core/v2/context-budget/manifest.json
+core/v2/registry/roles.json
+core/v2/BOOTSTRAP.md
+PATHS
+}
+
+role_surface_paths() {
+  local role="$1"
+  common_surface_paths
+  case "$role" in
+    manager)
+      cat <<'PATHS'
+core/v2/skills/dev-studio/SKILL.md
+core/v2/skills/dev-studio/routing.yaml
+core/v2/skills/dev-studio/forwarders.yaml
+core/v2/skills/dev-studio/portability.yaml
+PATHS
+      ;;
+    host-adapter)
+      cat <<'PATHS'
+hosts/ADAPTER-SPEC.md
+hosts/registry.yaml
+.claude-plugin/capabilities.yaml
+.claude-reviewer/capabilities.yaml
+.codex-reviewer/capabilities.yaml
+.codex/capabilities.yaml
+PATHS
+      ;;
+    *)
+      printf 'core/v2/roles/%s.yaml\n' "$role"
+      ;;
+  esac
+}
+
+report_roles() {
+  if [ -n "$ROLES_CSV" ]; then
+    printf '%s\n' "$ROLES_CSV" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | unique_lines
+  else
+    jq -r '.roles[].role' "$MANIFEST"
+  fi
+}
+
+json_array_from_lines() {
+  jq -R . | jq -s .
+}
+
+role_report_row() {
+  local role="$1"
+  local budget paths_json missing_json bytes estimated row_status ratio
+
+  budget=$(jq -er --arg role "$role" '.roles[] | select(.role == $role) | .max_context_tokens' "$MANIFEST") || {
+    printf 'v2-context-budget: role not in manifest: %s\n' "$role" >&2
+    exit 2
+  }
+
+  local paths_file missing_file
+  paths_file=$(mktemp -t v2-context-budget-paths.XXXXXX) || exit 2
+  missing_file=$(mktemp -t v2-context-budget-missing.XXXXXX) || exit 2
+  role_surface_paths "$role" | unique_lines > "$paths_file"
+  : > "$missing_file"
+
+  bytes=0
+  local path full_path path_bytes
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    full_path="$REPO_ROOT/$path"
+    if [ ! -r "$full_path" ]; then
+      printf '%s\n' "$path" >> "$missing_file"
+      continue
+    fi
+    path_bytes=$(wc -c < "$full_path" | tr -d ' ')
+    bytes=$((bytes + path_bytes))
+  done < "$paths_file"
+
+  paths_json=$(json_array_from_lines < "$paths_file")
+  missing_json=$(json_array_from_lines < "$missing_file")
+  rm -f "$paths_file" "$missing_file"
+
+  if [ "$missing_json" != "[]" ]; then
+    estimated=null
+    ratio=null
+    row_status="unmeasured"
+  else
+    estimated=$(((bytes + 2) / 3))
+    ratio=$(jq -n --argjson estimated "$estimated" --argjson budget "$budget" '(($estimated / $budget) * 1000 | round) / 1000')
+    row_status=$(jq -nr \
+      --argjson estimated "$estimated" \
+      --argjson budget "$budget" \
+      --argjson warning "$(jq '.defaults.warning_ratio' "$MANIFEST")" \
+      --argjson exceeded "$(jq '.defaults.exceeded_ratio' "$MANIFEST")" \
+      '($estimated / $budget) as $ratio |
+       if $ratio >= $exceeded then "over_budget" elif $ratio >= $warning then "warning" else "under_budget" end')
+  fi
+
+  jq -n \
+    --arg role "$role" \
+    --arg status "$row_status" \
+    --arg estimator "ceil(bytes / 3)" \
+    --argjson budget "$budget" \
+    --argjson bytes "$bytes" \
+    --argjson estimated "$estimated" \
+    --argjson ratio "$ratio" \
+    --argjson paths "$paths_json" \
+    --argjson missing "$missing_json" \
+    '{
+      role: $role,
+      budget_tokens: $budget,
+      estimated_tokens: $estimated,
+      source_bytes: $bytes,
+      ratio: $ratio,
+      status: $status,
+      estimator: $estimator,
+      evidence_files: $paths,
+      missing_evidence_files: $missing
+    }'
+}
+
+build_report_json() {
+  validate_manifest
+
+  local rows_file
+  rows_file=$(mktemp -t v2-context-budget-report.XXXXXX) || exit 2
+  : > "$rows_file"
+
+  local role
+  while IFS= read -r role; do
+    [ -n "$role" ] || continue
+    role=$(normalize_role "$role") || {
+      printf 'v2-context-budget: unknown role or alias: %s\n' "$role" >&2
+      rm -f "$rows_file"
+      exit 2
+    }
+    role_report_row "$role" >> "$rows_file"
+  done < <(report_roles)
+
+  jq -s \
+    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg manifest_path "${MANIFEST#$REPO_ROOT/}" \
+    --arg estimator "ceil(bytes / 3)" \
+    --arg evidence_scope "static contract-surface lower bound; not runtime token telemetry" \
+    --argjson warning_ratio "$(jq '.defaults.warning_ratio' "$MANIFEST")" \
+    --argjson exceeded_ratio "$(jq '.defaults.exceeded_ratio' "$MANIFEST")" \
+    '{
+      schema_version: {"name": "context-budget-report", "version": "1.0.0", "min_reader": "1.0.0", "deprecated_at": null},
+      generated_at: $generated_at,
+      manifest_path: $manifest_path,
+      estimator: $estimator,
+      evidence_scope: $evidence_scope,
+      warning_ratio: $warning_ratio,
+      exceeded_ratio: $exceeded_ratio,
+      roles: .,
+      summary: {
+        under_budget: [.[] | select(.status == "under_budget") | .role],
+        warning: [.[] | select(.status == "warning") | .role],
+        over_budget: [.[] | select(.status == "over_budget") | .role],
+        unmeasured: [.[] | select(.status == "unmeasured") | .role]
+      }
+    }' "$rows_file"
+  rm -f "$rows_file"
+}
+
+render_report_markdown() {
+  jq -r '
+    "# Studio v2 Context Budget Report",
+    "",
+    "- Manifest: `\(.manifest_path)`",
+    "- Estimator: `\(.estimator)`",
+    "- Evidence scope: \(.evidence_scope)",
+    "",
+    "This report measures the committed static files each role is expected to load first. It is a lower-bound estimate, not runtime token telemetry from a model invocation.",
+    "",
+    "On-demand skill content is excluded from each role surface and remains governed by the skill ceilings in the context-budget manifest.",
+    "",
+    "## Summary",
+    "",
+    "- Under budget: \((.summary.under_budget | length))",
+    "- Warning: \((.summary.warning | length))",
+    "- Over budget: \((.summary.over_budget | length))",
+    "- Unmeasured: \((.summary.unmeasured | length))",
+    "",
+    "## Under Budget",
+    "",
+    (if (.summary.under_budget | length) == 0 then "_None_"
+     else (.roles[] | select(.status == "under_budget") | "- `\(.role)`: \(.estimated_tokens) / \(.budget_tokens) tokens (ratio \(.ratio))")
+     end),
+    "",
+    "## Warning",
+    "",
+    (if (.summary.warning | length) == 0 then "_None_"
+     else (.roles[] | select(.status == "warning") | "- `\(.role)`: \(.estimated_tokens) / \(.budget_tokens) tokens (ratio \(.ratio))")
+     end),
+    "",
+    "## Over Budget",
+    "",
+    (if (.summary.over_budget | length) == 0 then "_None_"
+     else (.roles[] | select(.status == "over_budget") | "- `\(.role)`: \(.estimated_tokens) / \(.budget_tokens) tokens (ratio \(.ratio))")
+     end),
+    "",
+    "## Unmeasured",
+    "",
+    (if (.summary.unmeasured | length) == 0 then "_None_"
+     else (.roles[] | select(.status == "unmeasured") | "- `\(.role)`: missing \((.missing_evidence_files | map("`" + . + "`") | join(", ")))")
+     end),
+    "",
+    "## Role Evidence",
+    "",
+    (.roles[] | "### `\(.role)`\n\n- Status: `\(.status)`\n- Budget tokens: \(.budget_tokens)\n- Estimated tokens: \(.estimated_tokens // "unmeasured")\n- Source bytes: \(.source_bytes)\n- Evidence files:\n\(.evidence_files | map("  - `" + . + "`") | join("\n"))")
+  '
+}
+
+write_or_print() {
+  if [ -n "$OUTPUT" ]; then
+    cat > "$OUTPUT"
+  else
+    cat
+  fi
+}
+
+report_budget() {
+  local report_json
+  report_json=$(build_report_json)
+  case "$FORMAT" in
+    json) printf '%s\n' "$report_json" | write_or_print ;;
+    markdown) printf '%s\n' "$report_json" | render_report_markdown | write_or_print ;;
+    *) usage; exit 2 ;;
+  esac
+}
+
 require_jq
 
 if [ "$#" -eq 0 ]; then
@@ -160,11 +401,17 @@ while [ "$#" -gt 0 ]; do
       ACTION="validate"
       shift
       ;;
-    --resolve)
-      [ -z "$ACTION" ] || { usage; exit 2; }
-      ACTION="resolve"
-      shift
-      ;;
+	    --resolve)
+	      [ -z "$ACTION" ] || { usage; exit 2; }
+	      ACTION="resolve"
+	      shift
+	      ;;
+	    --report)
+	      [ -z "$ACTION" ] || { usage; exit 2; }
+	      ACTION="report"
+	      FORMAT="json"
+	      shift
+	      ;;
     --role)
       [ "$#" -ge 2 ] || { usage; exit 2; }
       ROLE="$2"
@@ -185,15 +432,25 @@ while [ "$#" -gt 0 ]; do
       ESTIMATED_TOKENS="$2"
       shift 2
       ;;
-    --format)
-      [ "$#" -ge 2 ] || { usage; exit 2; }
-      FORMAT="$2"
-      case "$FORMAT" in
-        text|json) ;;
-        *) usage; exit 2 ;;
-      esac
-      shift 2
-      ;;
+	    --format)
+	      [ "$#" -ge 2 ] || { usage; exit 2; }
+	      FORMAT="$2"
+	      case "$FORMAT" in
+	        text|json|markdown) ;;
+	        *) usage; exit 2 ;;
+	      esac
+	      shift 2
+	      ;;
+	    --roles)
+	      [ "$#" -ge 2 ] || { usage; exit 2; }
+	      ROLES_CSV="$2"
+	      shift 2
+	      ;;
+	    --output)
+	      [ "$#" -ge 2 ] || { usage; exit 2; }
+	      OUTPUT="$2"
+	      shift 2
+	      ;;
     --help|-h)
       usage
       exit 0
@@ -210,10 +467,13 @@ case "$ACTION" in
     validate_manifest
     printf 'v2-context-budget: ok\n' >&2
     ;;
-  resolve)
-    validate_manifest
-    resolve_budget
-    ;;
+	  resolve)
+	    validate_manifest
+	    resolve_budget
+	    ;;
+	  report)
+	    report_budget
+	    ;;
   *)
     usage
     exit 2


### PR DESCRIPTION
## Summary

- Extend `scripts/v2-context-budget.sh` with `--report` for JSON/Markdown static role-surface evidence.
- Cover all v2 manifest roles and classify under-budget, warning, over-budget, and unmeasured roles.
- Add #552 fixture coverage for default coverage, disclosure text, unmeasured surfaces, warning classification, and over-budget classification.
- Document the report flag in the v2 substrate README and SPEC.

## Evidence

Private evidence reports generated:

- `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-552-context-budget-evidence.md`
- `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-552-context-budget-evidence.json`

Result: manager, planner, worker, reviewer, qa-engineer, flow-tester, perf, release-manager, and host-adapter are under budget in the static lower-bound report. Warning: none. Over budget: none. Unmeasured: none.

Scope note: this is static contract-surface evidence, not runtime token telemetry, and it excludes on-demand skill content.

## Verification

- `scripts/test-fixtures/552-context-budget/test-context-budget-report.sh`
- `scripts/test-fixtures/523-context-budget/test-context-budget.sh`
- `scripts/lint-v2-bootstrap.sh --full`
- `scripts/lint-v2-enforcement.sh --full`
- `scripts/lint-build-invocations.sh`
- `scripts/capability-manifest.sh --validate`
- `STUDIO_ALLOW_SURFACE_REMOVALS=1 scripts/lint-architecture.sh --staged`
- `scripts/lint-host-agnostic.sh --staged`
- `git diff --cached --check`

Phase plan review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-c8-context-budget-plan-review.md` (clean).
Phase outcome review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-c8-context-budget-outcome-review.md` (clean).

Remaining #445 gates after this: #548, #551, #549.

Closes #552