### PR TITLE
Add v2 sibling review metrics

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T03:58:14Z",
+  "generated_at": "2026-05-04T04:17:50Z",
   "agents": [
 
   ]

--- a/core/v2/README.md
+++ b/core/v2/README.md
@@ -47,7 +47,12 @@ Current substrate artifacts:
 - `schemas/subscriber-lag.schema.json` defines subscriber lag status artifacts.
 - `schemas/dead-letter.schema.json` defines malformed/partial-line dead letters.
 - `events/registry.yaml` is the v2 event-name registry seed for subscriber
-  operational events.
+  operational events, topology runtime failures, and review finding disposition
+  metrics.
+- `review/metrics.yaml` defines sibling-review severity weights and disposition
+  values. Record and report review finding value with
+  `scripts/v2-review-metrics.sh emit ...` and
+  `scripts/v2-review-metrics.sh report --format markdown|json`.
 - `schemas/project-profile.schema.json` defines profile-owned operation
   mappings. Resolve and validate profile commands with `scripts/v2-profile.sh`;
   the first profile is `profiles/ios-turnip/`.

--- a/core/v2/SPEC.md
+++ b/core/v2/SPEC.md
@@ -267,6 +267,11 @@ the effective role + skill + invocation ceiling for a contract and can emit a
 static role-surface report with `--report`. A0.6 ensures new role contracts
 declare what they read before relying on it.
 
+Sibling-review value is recorded as explicit manager/operator disposition data,
+not inferred from raw finding count. `core/v2/review/metrics.yaml` defines
+severity weights and dispositions; `scripts/v2-review-metrics.sh` emits private
+runtime events and reports accepted weighted score by phase and review host.
+
 <!-- v2-spec:testing-release -->
 ## Testing, Review, and Release Workflow
 

--- a/core/v2/events/registry.yaml
+++ b/core/v2/events/registry.yaml
@@ -9,3 +9,4 @@ events:
   - topology_worker_deadlock
   - topology_partial_multi_spawn
   - topology_budget_exhaustion
+  - review_finding_disposition_recorded

--- a/core/v2/review/metrics.yaml
+++ b/core/v2/review/metrics.yaml
@@ -1,0 +1,26 @@
+kind: studio-v2-review-metrics
+schema_version:
+  name: review-metrics
+  version: 1.0.0
+  min_reader: 1.0.0
+  deprecated_at: null
+scoring:
+  rule: Only accepted findings contribute to accepted_weighted_score. Info findings carry weight 0 by design.
+ordering:
+  rule: Reports use last-write-wins by occurred_at for each review_ref/finding_id. Operator dispositions are expected to be sparse and monotonic; concurrent same-second re-dispositions should be avoided or re-emitted with distinct timestamps.
+severities:
+  - severity: critical
+    weight: 8
+  - severity: high
+    weight: 5
+  - severity: medium
+    weight: 3
+  - severity: low
+    weight: 1
+  - severity: info
+    weight: 0
+dispositions:
+  - accepted
+  - rejected
+  - disputed
+  - superseded

--- a/core/v2/schemas/review-finding-event.schema.json
+++ b/core/v2/schemas/review-finding-event.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://generic-dev-studio.local/core/v2/schemas/review-finding-event.schema.json",
+  "title": "Studio v2 review finding disposition event",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "event",
+    "occurred_at",
+    "producer",
+    "subject",
+    "idempotency_key",
+    "writable_action",
+    "data"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "event": { "const": "review_finding_disposition_recorded" },
+    "occurred_at": { "type": "string", "format": "date-time" },
+    "producer": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["agent", "mode"],
+      "properties": {
+        "agent": { "enum": ["manager", "operator"] },
+        "mode": { "const": "review-metrics" }
+      }
+    },
+    "subject": { "type": "string", "minLength": 1 },
+    "idempotency_key": { "type": "string", "minLength": 1 },
+    "writable_action": { "type": "boolean", "const": true },
+    "data": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "phase_ref",
+        "review_ref",
+        "review_host",
+        "review_kind",
+        "finding_id",
+        "severity",
+        "severity_weight",
+        "disposition",
+        "summary",
+        "privacy_classification"
+      ],
+      "properties": {
+        "phase_ref": { "type": "string", "minLength": 1 },
+        "review_ref": { "type": "string", "minLength": 1 },
+        "review_host": { "type": "string", "minLength": 1 },
+        "review_kind": { "enum": ["plan", "outcome", "pr", "pre-commit"] },
+        "finding_id": { "type": "string", "minLength": 1 },
+        "severity": { "enum": ["critical", "high", "medium", "low", "info"] },
+        "severity_weight": { "type": "integer", "minimum": 0 },
+        "disposition": { "enum": ["accepted", "rejected", "disputed", "superseded"] },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 500 },
+        "prevented_defect_ref": { "type": "string", "minLength": 1 },
+        "follow_up_ref": { "type": "string", "minLength": 1 },
+        "superseded_by": { "type": "string", "minLength": 1 },
+        "privacy_classification": { "const": "private-runtime" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "data": {
+            "properties": {
+              "disposition": { "const": "superseded" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": {
+            "required": ["superseded_by"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T03:58:14Z",
+  "generated_at": "2026-05-04T04:17:50Z",
   "schema": 1,
   "commands": [
     {"name": "fullSendToAppStore", "source": "commands/fullSendToAppStore.md", "description": "Tag current commit, draft GitHub release, and submit build to App Store review", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/551-review-metrics/test-review-metrics.sh
+++ b/scripts/test-fixtures/551-review-metrics/test-review-metrics.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CMD="$ROOT/scripts/v2-review-metrics.sh"
+SCHEMA="$ROOT/core/v2/schemas/review-finding-event.schema.json"
+TMPROOT=$(mktemp -d -t review-metrics-551.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+[ -x "$CMD" ] || fail "v2-review-metrics.sh is not executable"
+
+RUNTIME="$TMPROOT/runtime"
+mkdir -p "$RUNTIME"
+
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:00Z \
+  --phase-ref '#551/C9' --review-ref plan-review --review-host claude-reviewer --review-kind plan \
+  --finding-id host-attribution --severity high --disposition accepted \
+  --summary 'Add review_host attribution' --prevented-defect-ref '#551'
+
+# Duplicate same disposition should not double-count because report groups by review_ref/finding_id.
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:01Z \
+  --phase-ref '#551/C9' --review-ref plan-review --review-host claude-reviewer --review-kind plan \
+  --finding-id host-attribution --severity high --disposition accepted \
+  --summary 'Add review_host attribution' --prevented-defect-ref '#551'
+
+# Re-disposition should be last-write-wins.
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:02Z \
+  --phase-ref '#551/C9' --review-ref outcome-review --review-host claude-reviewer --review-kind outcome \
+  --finding-id style-warning --severity low --disposition accepted \
+  --summary 'Initial style finding disposition'
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:03Z \
+  --phase-ref '#551/C9' --review-ref outcome-review --review-host claude-reviewer --review-kind outcome \
+  --finding-id style-warning --severity low --disposition rejected \
+  --summary 'Style finding rejected as non-substantive'
+
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:04Z \
+  --phase-ref '#551/C9' --review-ref pr-review --review-host codex-reviewer --review-kind pr \
+  --finding-id disputed-finding --severity medium --disposition disputed \
+  --summary 'Disputed finding example'
+
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:05Z \
+  --phase-ref '#548/C7' --review-ref pilot-review --review-host claude-reviewer --review-kind plan \
+  --finding-id old-shape --severity high --disposition superseded --superseded-by new-shape \
+  --summary 'Old pilot shape superseded'
+"$CMD" emit --runtime-root "$RUNTIME" --quiet --occurred-at 2026-05-04T00:00:06Z \
+  --phase-ref '#548/C7' --review-ref pilot-review --review-host claude-reviewer --review-kind plan \
+  --finding-id new-shape --severity low --disposition accepted --follow-up-ref '#548' \
+  --summary 'Replacement pilot shape accepted'
+
+OUT="$TMPROOT/report.json"
+"$CMD" report --runtime-root "$RUNTIME" --format json --output "$OUT"
+
+jq -e '
+  .total_terminal_findings == 5 and
+  .accepted_weighted_score == 6 and
+  .disposition_counts.accepted == 2 and
+  .disposition_counts.rejected == 1 and
+  .disposition_counts.disputed == 1 and
+  .disposition_counts.superseded == 1 and
+  (.phases[] | select(.phase_ref == "#551/C9") | .accepted_weighted_score == 5) and
+  (.phases[] | select(.phase_ref == "#551/C9") | .by_host[] | select(.review_host == "claude-reviewer") | .accepted_weighted_score == 5) and
+  (.phases[] | select(.phase_ref == "#551/C9") | .by_host[] | select(.review_host == "codex-reviewer") | .disposition_counts.disputed == 1) and
+  (.findings[] | select(.finding_id == "host-attribution") | .prevented_defect_ref == "#551") and
+  (.findings[] | select(.finding_id == "new-shape") | .follow_up_ref == "#548") and
+  (.findings[] | select(.finding_id == "style-warning") | .disposition == "rejected")
+' "$OUT" >/dev/null || fail "review metrics report did not aggregate expected weighted findings"
+
+MD="$TMPROOT/report.md"
+"$CMD" report --runtime-root "$RUNTIME" --format markdown --output "$MD"
+grep -q 'Accepted weighted score: 6' "$MD" || fail "markdown report missing score"
+grep -q 'claude-reviewer' "$MD" || fail "markdown report missing host slice"
+
+sample="$TMPROOT/sample.json"
+head -n 1 "$RUNTIME/events/2026-05-04.jsonl" > "$sample"
+PYTHONWARNINGS=ignore check-jsonschema --schemafile "$SCHEMA" "$sample" >/dev/null \
+  || fail "schema rejected review metric event"
+
+if "$CMD" emit --runtime-root "$RUNTIME" --quiet \
+  --phase-ref '#551/C9' --review-ref bad --review-host claude-reviewer --review-kind plan \
+  --finding-id bad-severity --severity urgent --disposition accepted --summary 'bad' >"$TMPROOT/bad-severity.out" 2>"$TMPROOT/bad-severity.err"; then
+  fail "invalid severity was accepted"
+fi
+grep -q 'unknown severity: urgent' "$TMPROOT/bad-severity.err" || fail "invalid severity error was not explicit"
+
+if "$CMD" emit --runtime-root "$RUNTIME" --quiet \
+  --phase-ref '#551/C9' --review-ref bad --review-host claude-reviewer --review-kind plan \
+  --finding-id bad-disposition --severity low --disposition deferred --summary 'bad' >"$TMPROOT/bad-disposition.out" 2>"$TMPROOT/bad-disposition.err"; then
+  fail "invalid disposition was accepted"
+fi
+grep -q 'unknown disposition: deferred' "$TMPROOT/bad-disposition.err" || fail "invalid disposition error was not explicit"
+
+if "$CMD" emit --runtime-root "$RUNTIME" --quiet \
+  --phase-ref '#551/C9' --review-ref bad --review-host claude-reviewer --review-kind plan \
+  --finding-id bad-superseded --severity low --disposition superseded --summary 'bad' >"$TMPROOT/bad-superseded.out" 2>"$TMPROOT/bad-superseded.err"; then
+  fail "superseded without superseded_by was accepted"
+fi
+grep -q 'superseded-by is required' "$TMPROOT/bad-superseded.err" || fail "superseded error was not explicit"
+
+printf 'PASS: review metrics\n'

--- a/scripts/v2-review-metrics.sh
+++ b/scripts/v2-review-metrics.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# Emit and report Studio v2 review finding disposition metrics.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REGISTRY="$REPO_ROOT/core/v2/review/metrics.yaml"
+SCHEMA="$REPO_ROOT/core/v2/schemas/review-finding-event.schema.json"
+
+COMMAND="${1:-}"
+[ -n "$COMMAND" ] && shift || true
+
+RUNTIME_ROOT=""
+PHASE_REF=""
+REVIEW_REF=""
+REVIEW_HOST=""
+REVIEW_KIND=""
+FINDING_ID=""
+SEVERITY=""
+DISPOSITION=""
+SUMMARY=""
+PREVENTED_DEFECT_REF=""
+FOLLOW_UP_REF=""
+SUPERSEDED_BY=""
+OCCURRED_AT=""
+FORMAT="json"
+OUTPUT=""
+QUIET=0
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  scripts/v2-review-metrics.sh emit --runtime-root <dir> --phase-ref <ref> --review-ref <ref> --review-host <id> --review-kind <plan|outcome|pr|pre-commit> --finding-id <id> --severity <severity> --disposition <accepted|rejected|disputed|superseded> --summary <text> [--prevented-defect-ref <ref>] [--follow-up-ref <ref>] [--superseded-by <id>] [--occurred-at <iso8601>] [--quiet]
+  scripts/v2-review-metrics.sh report --runtime-root <dir> [--format json|markdown] [--output <file>]
+USAGE
+}
+
+now_utc() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+require_tools() {
+  command -v jq >/dev/null 2>&1 || { printf 'v2-review-metrics: jq is required\n' >&2; exit 3; }
+  command -v yq >/dev/null 2>&1 || { printf 'v2-review-metrics: yq is required\n' >&2; exit 3; }
+  command -v check-jsonschema >/dev/null 2>&1 || { printf 'v2-review-metrics: check-jsonschema is required\n' >&2; exit 3; }
+}
+
+parse_emit_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --runtime-root=*) RUNTIME_ROOT="${1#--runtime-root=}"; shift ;;
+      --runtime-root) RUNTIME_ROOT="${2:?--runtime-root requires dir}"; shift 2 ;;
+      --quiet) QUIET=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      --phase-ref=*) PHASE_REF="${1#--phase-ref=}"; shift ;;
+      --phase-ref) PHASE_REF="${2:?--phase-ref requires value}"; shift 2 ;;
+      --review-ref=*) REVIEW_REF="${1#--review-ref=}"; shift ;;
+      --review-ref) REVIEW_REF="${2:?--review-ref requires value}"; shift 2 ;;
+      --review-host=*) REVIEW_HOST="${1#--review-host=}"; shift ;;
+      --review-host) REVIEW_HOST="${2:?--review-host requires value}"; shift 2 ;;
+      --review-kind=*) REVIEW_KIND="${1#--review-kind=}"; shift ;;
+      --review-kind) REVIEW_KIND="${2:?--review-kind requires value}"; shift 2 ;;
+      --finding-id=*) FINDING_ID="${1#--finding-id=}"; shift ;;
+      --finding-id) FINDING_ID="${2:?--finding-id requires value}"; shift 2 ;;
+      --severity=*) SEVERITY="${1#--severity=}"; shift ;;
+      --severity) SEVERITY="${2:?--severity requires value}"; shift 2 ;;
+      --disposition=*) DISPOSITION="${1#--disposition=}"; shift ;;
+      --disposition) DISPOSITION="${2:?--disposition requires value}"; shift 2 ;;
+      --summary=*) SUMMARY="${1#--summary=}"; shift ;;
+      --summary) SUMMARY="${2:?--summary requires value}"; shift 2 ;;
+      --prevented-defect-ref=*) PREVENTED_DEFECT_REF="${1#--prevented-defect-ref=}"; shift ;;
+      --prevented-defect-ref) PREVENTED_DEFECT_REF="${2:?--prevented-defect-ref requires value}"; shift 2 ;;
+      --follow-up-ref=*) FOLLOW_UP_REF="${1#--follow-up-ref=}"; shift ;;
+      --follow-up-ref) FOLLOW_UP_REF="${2:?--follow-up-ref requires value}"; shift 2 ;;
+      --superseded-by=*) SUPERSEDED_BY="${1#--superseded-by=}"; shift ;;
+      --superseded-by) SUPERSEDED_BY="${2:?--superseded-by requires value}"; shift 2 ;;
+      --occurred-at=*) OCCURRED_AT="${1#--occurred-at=}"; shift ;;
+      --occurred-at) OCCURRED_AT="${2:?--occurred-at requires value}"; shift 2 ;;
+      *) printf 'v2-review-metrics: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+  done
+}
+
+parse_report_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --runtime-root=*) RUNTIME_ROOT="${1#--runtime-root=}"; shift ;;
+      --runtime-root) RUNTIME_ROOT="${2:?--runtime-root requires dir}"; shift 2 ;;
+      --format=*) FORMAT="${1#--format=}"; shift ;;
+      --format) FORMAT="${2:?--format requires value}"; shift 2 ;;
+      --output=*) OUTPUT="${1#--output=}"; shift ;;
+      --output) OUTPUT="${2:?--output requires path}"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) printf 'v2-review-metrics: unknown arg: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+  done
+}
+
+severity_weight() {
+  SEVERITY="$SEVERITY" yq -r '.severities[] | select(.severity == strenv(SEVERITY)) | .weight' "$REGISTRY"
+}
+
+validate_registry_value() {
+  local kind="$1" value="$2"
+  case "$kind" in
+    severity)
+      VALUE="$value" yq -e '.severities[] | select(.severity == strenv(VALUE))' "$REGISTRY" >/dev/null
+      ;;
+    disposition)
+      VALUE="$value" yq -e '.dispositions[] | select(. == strenv(VALUE))' "$REGISTRY" >/dev/null
+      ;;
+  esac
+}
+
+cmd_emit() {
+  parse_emit_args "$@"
+  require_tools
+
+  [ -n "$RUNTIME_ROOT" ] || { usage; exit 2; }
+  [ -n "$PHASE_REF" ] || { usage; exit 2; }
+  [ -n "$REVIEW_REF" ] || { usage; exit 2; }
+  [ -n "$REVIEW_HOST" ] || { usage; exit 2; }
+  [ -n "$REVIEW_KIND" ] || { usage; exit 2; }
+  [ -n "$FINDING_ID" ] || { usage; exit 2; }
+  [ -n "$SEVERITY" ] || { usage; exit 2; }
+  [ -n "$DISPOSITION" ] || { usage; exit 2; }
+  [ -n "$SUMMARY" ] || { usage; exit 2; }
+  [ "$DISPOSITION" != "superseded" ] || [ -n "$SUPERSEDED_BY" ] || {
+    printf 'v2-review-metrics: --superseded-by is required when disposition is superseded\n' >&2
+    exit 2
+  }
+
+  validate_registry_value severity "$SEVERITY" || {
+    printf 'v2-review-metrics: unknown severity: %s\n' "$SEVERITY" >&2
+    exit 2
+  }
+  validate_registry_value disposition "$DISPOSITION" || {
+    printf 'v2-review-metrics: unknown disposition: %s\n' "$DISPOSITION" >&2
+    exit 2
+  }
+
+  case "$REVIEW_KIND" in plan|outcome|pr|pre-commit) ;; *) printf 'v2-review-metrics: unknown review kind: %s\n' "$REVIEW_KIND" >&2; exit 2 ;; esac
+
+  local weight data event_json tmp
+  weight=$(severity_weight)
+  [ -n "$OCCURRED_AT" ] || OCCURRED_AT=$(now_utc)
+
+  data=$(jq -n \
+    --arg phase_ref "$PHASE_REF" \
+    --arg review_ref "$REVIEW_REF" \
+    --arg review_host "$REVIEW_HOST" \
+    --arg review_kind "$REVIEW_KIND" \
+    --arg finding_id "$FINDING_ID" \
+    --arg severity "$SEVERITY" \
+    --argjson severity_weight "$weight" \
+    --arg disposition "$DISPOSITION" \
+    --arg summary "$SUMMARY" \
+    --arg prevented_defect_ref "$PREVENTED_DEFECT_REF" \
+    --arg follow_up_ref "$FOLLOW_UP_REF" \
+    --arg superseded_by "$SUPERSEDED_BY" \
+    '{
+      phase_ref: $phase_ref,
+      review_ref: $review_ref,
+      review_host: $review_host,
+      review_kind: $review_kind,
+      finding_id: $finding_id,
+      severity: $severity,
+      severity_weight: $severity_weight,
+      disposition: $disposition,
+      summary: $summary,
+      privacy_classification: "private-runtime"
+    }
+    + (if $prevented_defect_ref == "" then {} else {prevented_defect_ref: $prevented_defect_ref} end)
+    + (if $follow_up_ref == "" then {} else {follow_up_ref: $follow_up_ref} end)
+    + (if $superseded_by == "" then {} else {superseded_by: $superseded_by} end)')
+
+  event_json=$(jq -n \
+    --arg occurred_at "$OCCURRED_AT" \
+    --arg subject "$PHASE_REF" \
+    --arg idempotency_key "review_finding_disposition:$REVIEW_REF:$FINDING_ID:$DISPOSITION" \
+    --argjson data "$data" \
+    '{
+      schema_version: 1,
+      event: "review_finding_disposition_recorded",
+      occurred_at: $occurred_at,
+      producer: {agent: "manager", mode: "review-metrics"},
+      subject: $subject,
+      idempotency_key: $idempotency_key,
+      writable_action: true,
+      data: $data
+    }')
+
+  tmp=$(mktemp -t v2-review-metrics.XXXXXX) || exit 2
+  printf '%s\n' "$event_json" > "$tmp"
+  if ! PYTHONWARNINGS=ignore check-jsonschema --schemafile "$SCHEMA" "$tmp" >/dev/null; then
+    rm -f "$tmp"
+    printf 'v2-review-metrics: event failed schema validation\n' >&2
+    exit 2
+  fi
+  rm -f "$tmp"
+
+  if [ "$QUIET" -eq 1 ]; then
+    "$SCRIPT_DIR/v2-event-log.sh" append --runtime-root "$RUNTIME_ROOT" --quiet --event-json "$event_json"
+  else
+    "$SCRIPT_DIR/v2-event-log.sh" append --runtime-root "$RUNTIME_ROOT" --event-json "$event_json"
+  fi
+}
+
+raw_events_json() {
+  if [ ! -d "$RUNTIME_ROOT/events" ]; then
+    printf '[]\n'
+    return
+  fi
+  find "$RUNTIME_ROOT/events" -maxdepth 1 -type f -name '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].jsonl' 2>/dev/null \
+    | sort \
+    | while IFS= read -r f; do cat "$f"; done \
+    | jq -R 'fromjson? | select(type == "object" and .event == "review_finding_disposition_recorded")' \
+    | jq -s '.'
+}
+
+build_report_json() {
+  local events
+  events=$(raw_events_json)
+  jq -n \
+    --arg generated_at "$(now_utc)" \
+    --argjson events "$events" '
+    def disposition_counts($items): {
+      accepted: ([$items[] | select(.data.disposition == "accepted")] | length),
+      rejected: ([$items[] | select(.data.disposition == "rejected")] | length),
+      disputed: ([$items[] | select(.data.disposition == "disputed")] | length),
+      superseded: ([$items[] | select(.data.disposition == "superseded")] | length)
+    };
+    def accepted_score($items):
+      [$items[] | select(.data.disposition == "accepted") | .data.severity_weight] | add // 0;
+    def terminal_items:
+      sort_by(.occurred_at, (.replay.byte_offset // 0))
+      | group_by(.data.review_ref + "\u0000" + .data.finding_id)
+      | map(last);
+    ($events | terminal_items) as $terminal |
+    {
+      schema_version: {"name": "review-metrics-report", "version": "1.0.0", "min_reader": "1.0.0", "deprecated_at": null},
+      generated_at: $generated_at,
+      scoring_rule: "only accepted terminal findings contribute severity_weight",
+      total_terminal_findings: ($terminal | length),
+      accepted_weighted_score: accepted_score($terminal),
+      disposition_counts: disposition_counts($terminal),
+      phases: (
+        $terminal
+        | group_by(.data.phase_ref)
+        | map(. as $phase_items | {
+            phase_ref: $phase_items[0].data.phase_ref,
+            terminal_findings: ($phase_items | length),
+            accepted_weighted_score: accepted_score($phase_items),
+            disposition_counts: disposition_counts($phase_items),
+            by_host: (
+              $phase_items
+              | group_by(.data.review_host)
+              | map(. as $host_items | {
+                  review_host: $host_items[0].data.review_host,
+                  terminal_findings: ($host_items | length),
+                  accepted_weighted_score: accepted_score($host_items),
+                  disposition_counts: disposition_counts($host_items)
+                })
+            )
+          })
+      ),
+      findings: ($terminal | map({
+        phase_ref: .data.phase_ref,
+        review_ref: .data.review_ref,
+        review_host: .data.review_host,
+        review_kind: .data.review_kind,
+        finding_id: .data.finding_id,
+        severity: .data.severity,
+        severity_weight: .data.severity_weight,
+        disposition: .data.disposition,
+        summary: .data.summary,
+        prevented_defect_ref: (.data.prevented_defect_ref // null),
+        follow_up_ref: (.data.follow_up_ref // null),
+        superseded_by: (.data.superseded_by // null),
+        occurred_at: .occurred_at
+      }))
+    }'
+}
+
+render_markdown() {
+  jq -r '
+    "# Studio v2 Review Metrics Report",
+    "",
+    "- Scoring: \(.scoring_rule)",
+    "- Terminal findings: \(.total_terminal_findings)",
+    "- Accepted weighted score: \(.accepted_weighted_score)",
+    "",
+    "## Dispositions",
+    "",
+    "- Accepted: \(.disposition_counts.accepted)",
+    "- Rejected: \(.disposition_counts.rejected)",
+    "- Disputed: \(.disposition_counts.disputed)",
+    "- Superseded: \(.disposition_counts.superseded)",
+    "",
+    "## Phases",
+    "",
+    (if (.phases | length) == 0 then "_None_"
+     else (.phases[] | "### `\(.phase_ref)`\n\n- Terminal findings: \(.terminal_findings)\n- Accepted weighted score: \(.accepted_weighted_score)\n- Accepted/rejected/disputed/superseded: \(.disposition_counts.accepted)/\(.disposition_counts.rejected)/\(.disposition_counts.disputed)/\(.disposition_counts.superseded)\n- By host:\n\(.by_host | map("  - `" + .review_host + "`: score " + (.accepted_weighted_score | tostring) + ", findings " + (.terminal_findings | tostring)) | join("\n"))")
+     end),
+    "",
+    "## Findings",
+    "",
+    (if (.findings | length) == 0 then "_None_"
+     else (.findings[] | "- `\(.phase_ref)` / `\(.review_host)` / `\(.finding_id)`: \(.severity) \(.disposition), weight \(.severity_weight), \(.summary)")
+     end)
+  '
+}
+
+write_or_print() {
+  if [ -n "$OUTPUT" ]; then
+    cat > "$OUTPUT"
+  else
+    cat
+  fi
+}
+
+cmd_report() {
+  parse_report_args "$@"
+  require_tools
+  [ -n "$RUNTIME_ROOT" ] || { usage; exit 2; }
+  case "$FORMAT" in json|markdown) ;; *) usage; exit 2 ;; esac
+
+  local report_json
+  report_json=$(build_report_json)
+  if [ "$FORMAT" = "json" ]; then
+    printf '%s\n' "$report_json" | write_or_print
+  else
+    printf '%s\n' "$report_json" | render_markdown | write_or_print
+  fi
+}
+
+case "$COMMAND" in
+  emit) cmd_emit "$@" ;;
+  report) cmd_report "$@" ;;
+  -h|--help|"") usage; [ -n "$COMMAND" ] && exit 0 || exit 2 ;;
+  *) printf 'v2-review-metrics: unknown command: %s\n' "$COMMAND" >&2; usage; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

- Add v2 review metrics registry, schema, and event name for explicit review finding dispositions.
- Add `scripts/v2-review-metrics.sh` to emit private review disposition telemetry and report accepted weighted score by phase and review host.
- Add fixture coverage for accepted/rejected/disputed/superseded findings, review-host aggregation, last-write-wins re-disposition, invalid values, and schema validation.
- Document the primitive in the v2 README and SPEC.

## Private Evidence

- `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-551-review-metrics-evidence.md`
- `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-551-review-metrics-evidence.json`

Aggregate from same-session sibling-host review dispositions: accepted weighted score 15, accepted findings 5, phase scores #550/C6=4, #551/C9=10, #552/C8=1. Public text intentionally avoids quoting private review prose.

## Verification

- `scripts/test-fixtures/551-review-metrics/test-review-metrics.sh`
- `scripts/test-fixtures/521-v2-event-log/test-v2-event-log.sh`
- `scripts/lint-v2-bootstrap.sh --full`
- `scripts/lint-v2-enforcement.sh --full`
- `scripts/lint-build-invocations.sh`
- `scripts/capability-manifest.sh --validate`
- `STUDIO_ALLOW_SURFACE_REMOVALS=1 scripts/lint-architecture.sh --staged`
- `scripts/lint-host-agnostic.sh --staged`
- `git diff --cached --check`

Phase plan review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-c9-review-metrics-plan-review.md` (clean).
Phase outcome review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-04-c9-review-metrics-outcome-review.md` (clean).

Remaining #445 gates after this: #548 and #549.

Closes #551