### PR TITLE
fix: expose dev-studio command surface

### DIFF
--- a/.claude/commands/dev-studio.md
+++ b/.claude/commands/dev-studio.md
@@ -1,0 +1,47 @@
+---
+description: Studio v2 umbrella router. Dispatches by canonical role: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.
+allowed-tools: [Bash, Read]
+argument-hint: "[role] [request]"
+---
+
+# dev-studio
+
+Thin Claude Code slash-command wrapper for the repo-local Studio v2 router.
+
+## Steps
+
+1. Resolve the repo root:
+
+   ```bash
+   REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)"
+   ```
+
+2. Read `$REPO_ROOT/core/v2/skills/dev-studio/SKILL.md`.
+
+3. Parse `$ARGUMENTS`:
+   - Empty arguments route to `manager`.
+   - A canonical role or compatibility alias in the first token routes through
+     `scripts/v2-role-resolve.sh`.
+   - Unknown role tokens fail before side effects.
+
+4. Execute the matched role workflow by following the router and role contract:
+   - `manager` -> shaping, status, resume, ingest, guard, audit.
+   - `worker` -> bounded task contract in an isolated worktree.
+   - `reviewer` -> plan, outcome, diff, or PR review.
+   - `perf` -> performance, battery, memory, thermal, network, or instrumentation evidence.
+   - `planner`, `qa-engineer`, `flow-tester`, `release-manager` -> active role contracts, usually manager-mediated or approval-gated.
+
+5. If the user asks for help, open:
+
+   ```bash
+   open "$REPO_ROOT/core/v2/skills/dev-studio/docs.html"
+   ```
+
+   Then say: "Studio v2 router docs opened. Path in the repo:
+   `core/v2/skills/dev-studio/docs.html`."
+
+## Notes
+
+Former top-level v1 names are aliases under this command, not restored v1
+surfaces. For example, `/dev-studio achilles T123` resolves to
+`/dev-studio worker T123`.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ core/v2/handoffs/
   *.yaml           # typed handoff fixtures shared across roles
 
 .claude/commands/       # project-scoped slash commands (fire only when cwd is this repo)
+  dev-studio.md         # /dev-studio — v2 umbrella role router
   studio-help.md        # /studio-help — opens the v2 router docs
   studio-setup.md       # /studio-setup — onboard THIS machine (--manager/--worker/--dual; no args = auto-pilot prompting only for role)
   resume-plan.md        # /resume-plan — routes through /dev-studio manager

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T06:13:29Z",
+  "generated_at": "2026-05-04T06:21:37Z",
   "agents": [
 
   ]

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -423,6 +423,9 @@
       <nav aria-label="Page sections">
         <a href="#quick-start">Quick Start</a>
         <a href="#usage">Usage</a>
+        <a href="#availability">Availability</a>
+        <a href="#state">State</a>
+        <a href="#automation">Automation</a>
         <a href="#roles">Roles</a>
         <a href="#resolution">Resolution</a>
         <a href="#cutover">Cutover</a>
@@ -524,6 +527,150 @@ scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt;</code>
             <h3>Release Readiness</h3>
             <p>Use release-manager after implementation evidence exists. It can assemble blockers and notes; tagging, publishing, TestFlight, and App Store actions still need operator approval.</p>
             <code class="shell">/dev-studio release-manager prepare beta readiness for the latest merged fixes</code>
+          </article>
+        </div>
+      </div>
+    </details>
+
+    <details class="section" id="availability">
+      <summary>
+        <span>
+          <h2>Host Availability</h2>
+          <p class="summary-copy">Where `/dev-studio` and `$dev-studio` come from in Claude and Codex sessions.</p>
+        </span>
+      </summary>
+      <div class="section-body">
+        <div class="grid">
+          <article class="role">
+            <h3>Claude Code</h3>
+            <p>The visible slash command is a project-scoped wrapper at <code>.claude/commands/dev-studio.md</code>. It reads this router and dispatches to the selected role contract.</p>
+            <code class="shell">/dev-studio manager resume-plan
+/dev-studio reviewer review</code>
+          </article>
+          <article class="role">
+            <h3>Codex</h3>
+            <p>The router is a project-scoped skill linked at <code>.codex/skills/dev-studio</code>. In Codex sessions, use the skill as <code>$dev-studio</code> when the host exposes skill invocation.</p>
+            <code class="shell">$dev-studio manager resume-plan
+$dev-studio worker T123</code>
+          </article>
+          <article class="role">
+            <h3>Sync</h3>
+            <p>After pulling changes, run install or host sync from this repo. It refreshes repo-local skill links and removes stale deleted v1 skill links.</p>
+            <code class="shell">scripts/install.sh
+scripts/sync-host-skills.sh --all</code>
+          </article>
+          <article class="role">
+            <h3>Scope</h3>
+            <p>The v2 router is project-scoped. It is available when the session is rooted in this repo or a host has loaded this repo's project skill links.</p>
+            <code class="shell">core/v2/skills/dev-studio/
+.claude/commands/dev-studio.md
+.codex/skills/dev-studio</code>
+          </article>
+        </div>
+      </div>
+    </details>
+
+    <details class="section" id="state">
+      <summary>
+        <span>
+          <h2>Existing State</h2>
+          <p class="summary-copy">What happens to old task IDs, Chanakya master-plan data, and runtime artifacts.</p>
+        </span>
+      </summary>
+      <div class="section-body">
+        <div class="split">
+          <div>
+            <p>
+              The v2 router changes the command surface, not the project ledger.
+              Existing task IDs, briefs, debriefs, reviews, event logs, chain
+              runs, worktrees, and rendered master plans stay under
+              <code>~/.dev-studio/&lt;project&gt;/</code>.
+            </p>
+            <p>
+              The master plan is a rendered projection. Structured task state
+              lives under <code>plans/tasks/*.yaml</code>; legacy markdown
+              surfaces are import or archive inputs where migration already
+              moved them.
+            </p>
+          </div>
+          <aside class="notice">
+            <h3>Expected continuity</h3>
+            <p>
+              A pre-v2 task ID remains the same task reference. The manager
+              should read the existing runtime state before minting or
+              dispatching new work.
+            </p>
+          </aside>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Artifact</th>
+                <th>Current role</th>
+                <th>Path</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Task state</td>
+                <td>Source of truth for task IDs and lifecycle fields</td>
+                <td><code>~/.dev-studio/&lt;project&gt;/plans/tasks/*.yaml</code></td>
+              </tr>
+              <tr>
+                <td>Master plan</td>
+                <td>Rendered view, not hand-edited state</td>
+                <td><code>~/.dev-studio/&lt;project&gt;/plans/chanakya-master.md</code></td>
+              </tr>
+              <tr>
+                <td>Briefs and debriefs</td>
+                <td>Worker inputs and completion evidence</td>
+                <td><code>~/.dev-studio/&lt;project&gt;/plans/briefs/</code>, <code>plans/debriefs/</code></td>
+              </tr>
+              <tr>
+                <td>Events</td>
+                <td>Append-only lifecycle and orchestration log</td>
+                <td><code>~/.dev-studio/&lt;project&gt;/events/YYYY-MM-DD.jsonl</code></td>
+              </tr>
+              <tr>
+                <td>Chain runs</td>
+                <td>Private reports, worker summaries, and phase-review evidence</td>
+                <td><code>~/.dev-studio/&lt;project&gt;/chain-runs/</code></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </details>
+
+    <details class="section" id="automation">
+      <summary>
+        <span>
+          <h2>Automation</h2>
+          <p class="summary-copy">Which parts are automated today and which still need an explicit user/session trigger.</p>
+        </span>
+      </summary>
+      <div class="section-body">
+        <div class="grid">
+          <article class="role">
+            <h3>Automated Today</h3>
+            <p>Worker queues, isolated task worktrees, chain-runner resume state, PR headless review, phase review wrappers, event logs, and generated master-plan views are implemented as scripts and runtime artifacts.</p>
+          </article>
+          <article class="role">
+            <h3>User-Started</h3>
+            <p>The studio does not run as an always-on autonomous daemon by default. A human starts a manager session, worker panes, chain runner, release flow, or scheduled helper.</p>
+          </article>
+          <article class="role">
+            <h3>Chain Runs</h3>
+            <p>Issue chains can run with persisted private reports and resume markers. Use dry-run first, then launch independent chains in separate shells when their write boundaries are disjoint.</p>
+            <code class="shell">scripts/studio-chain-runner.sh &lt;manifest&gt; --dry-run
+scripts/studio-chain-runner.sh &lt;manifest&gt; --auto</code>
+          </article>
+          <article class="role">
+            <h3>Fleet Work</h3>
+            <p>Multiple workers can watch a queue and claim tasks atomically. The manager dispatches; workers take isolated worktrees and report completion evidence.</p>
+            <code class="shell">/dev-studio worker
+scripts/worker-status.sh</code>
           </article>
         </div>
       </div>

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,11 +1,12 @@
 {
-  "generated_at": "2026-05-04T06:13:29Z",
+  "generated_at": "2026-05-04T06:21:36Z",
   "schema": 1,
   "commands": [
     {"name": "fullSendToAppStore", "source": "commands/fullSendToAppStore.md", "description": "Tag current commit, draft GitHub release, and submit build to App Store review", "agent": null, "scope": "global"},
     {"name": "postSlackTesting", "source": "commands/postSlackTesting.md", "description": "Post an iOS TestFlight build notification to the #testing Slack channel", "agent": null, "scope": "global"},
     {"name": "pushTFBuild", "source": "commands/pushTFBuild.md", "description": "Bump build number/version, archive, and push to TestFlight via App Store Connect", "agent": null, "scope": "global"},
     {"name": "capture", "source": ".claude/commands/capture.md", "description": "Retrospectively scan the current session for idea-worthy content and update IDEAS.md with dedup", "agent": null, "scope": "project"},
+    {"name": "dev-studio", "source": ".claude/commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "project"},
     {"name": "resume-plan", "source": ".claude/commands/resume-plan.md", "description": "Resume the architecture refactor — read roadmap + memory, report current state, ask pending questions", "agent": null, "scope": "project"},
     {"name": "studio-help", "source": ".claude/commands/studio-help.md", "description": "", "agent": null, "scope": "project"},
     {"name": "studio-setup", "source": ".claude/commands/studio-setup.md", "description": "Onboard the current machine via scripts/bootstrap.sh. Auto-pilot by default — only prompts for role if not given. Flags: --manager, --worker, --dual, --interactive, --dry-run, --help.", "agent": null, "scope": "project"}


### PR DESCRIPTION
## Summary
- add the missing project-scoped Claude slash wrapper for /dev-studio
- document Claude/Codex host availability for /dev-studio and -studio
- document continuity for existing task IDs, master-plan projections, runtime artifacts, and current orchestration automation
- regenerate command surface metadata

## Verification
- git diff --check
- scripts/update-surface-manifest.sh
- scripts/lint-v2-bootstrap.sh --full
- scripts/lint-v2-enforcement.sh --full
- scripts/v2-cutover.sh --validate
- scripts/lint-host-agnostic.sh --staged (0 errors, 1 existing host-adapter warning)
- scripts/lint-build-invocations.sh
- scripts/capability-manifest.sh --validate
- scripts/lint-project-skill-links.sh
- opened file:///tmp/studio-dev-command-surface/core/v2/skills/dev-studio/docs.html in Safari