### PR TITLE
fix: remove reviewer project dev-studio link

### DIFF
--- a/.claude-reviewer/skills/dev-studio
+++ b/.claude-reviewer/skills/dev-studio
@@ -1,1 +1,0 @@
-../../core/v2/skills/dev-studio

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T06:42:40Z",
+  "generated_at": "2026-05-04T06:46:51Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T06:42:39Z",
+  "generated_at": "2026-05-04T06:46:51Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- remove the stale repo-local claude-reviewer dev-studio symlink now that dev-studio is globally installed
- keep generated surface manifests in sync with the pre-commit hook

## Verification
- scripts/lint-v2-bootstrap.sh --full
- scripts/lint-v2-enforcement.sh --full
- scripts/v2-cutover.sh --validate
- scripts/lint-project-skill-links.sh