### PR TITLE
fix: avoid duplicate dev-studio command discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ git worktree remove /tmp/studio-<slug>     # clean up when done
 
 ## Studio router (systematic triggers)
 
-The `dev-studio` skill is a **project-scoped v2 skill** shipped at `core/v2/skills/dev-studio/`. It is the canonical role router for studio-level operations after A10 removed the v1 top-level router surfaces. When any of the phrases below fire, route through `/dev-studio manager ...` unless a more specific canonical role is explicit:
+The `dev-studio` router is shipped at `core/v2/skills/dev-studio/` and exposed to Claude Code through the global `/dev-studio` command wrapper. It is the canonical role router for studio-level operations after A10 removed the v1 top-level router surfaces. When any of the phrases below fire, route through `/dev-studio manager ...` unless a more specific canonical role is explicit:
 
 | User intent | Trigger phrases | Dispatch |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ _shared/                # reusable primitives (symlinked from ~/.claude/skills/_
 
 `install.sh` symlinks shared companions (`_shared`, `scripts`, `hosts`) into `~/.claude/skills/` and global slash commands into `~/.claude/commands/`. Portable v2 skills are fanned out by `scripts/sync-host-skills.sh` from `core/v2/skills`.
 
-The `dev-studio` skill is globally discoverable. It lives at `core/v2/skills/dev-studio/` and is linked into each host's global skill directory when `scripts/sync-host-skills.sh` runs, so you can invoke the studio from the project you are actually working on.
+Claude Code uses the global `/dev-studio` command at `~/.claude/commands/dev-studio.md`. Other hosts load the router skill from their global skill directory, for example `~/.codex/skills/dev-studio`, so you can invoke the studio from the project you are actually working on.
 
 Fresh-clone workflow:
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T06:46:51Z",
+  "generated_at": "2026-05-04T06:59:24Z",
   "agents": [
 
   ]

--- a/_shared/standards/portability.json
+++ b/_shared/standards/portability.json
@@ -18,10 +18,19 @@
       },
       "description": "Host slugs from hosts/registry.yaml that this skill runs on, or the literal all wildcard for every registered host."
     },
+    "exclude_hosts": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9._-]*$"
+      },
+      "description": "Host slugs excluded after hosts/all expansion. Use sparingly when a host has a native command surface that would duplicate skill discovery."
+    },
     "scope": {
       "enum": ["global", "project"],
       "default": "global",
-      "description": "Where the symlink farm places this skill. `global` links to the host's global_skill_dir (~/.<host>/skills/<name>); `project` links to the host's project_skill_dir (<repo>/.<host>/skills/<name>) — used for project-scoped vendor skills like the studio router that should auto-load only inside the studio repo."
+      "description": "Where the symlink farm places this skill. `global` links to the host's global_skill_dir (~/.<host>/skills/<name>); `project` links to the host's project_skill_dir (<repo>/.<host>/skills/<name>)."
     },
     "incompatible": {
       "type": "object",

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -537,22 +537,22 @@ scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt;</code>
       <summary>
         <span>
           <h2>Host Availability</h2>
-          <p class="summary-copy">Where `/dev-studio` and `$dev-studio` come from in Claude and Codex sessions.</p>
+          <p class="summary-copy">Where `/dev-studio` comes from in Claude and how Codex loads the router skill.</p>
         </span>
       </summary>
       <div class="section-body">
         <div class="grid">
           <article class="role">
             <h3>Claude Code</h3>
-            <p>The visible slash command is globally installed at <code>~/.claude/commands/dev-studio.md</code>. Invoke it from the project you are working on; it reads the studio router and dispatches to the selected role contract.</p>
+            <p>The visible slash command is globally installed at <code>~/.claude/commands/dev-studio.md</code>. Claude Code does not install the router as a global skill, so the picker has one canonical <code>/dev-studio</code> row.</p>
             <code class="shell">/dev-studio manager resume-plan
 /dev-studio reviewer review</code>
           </article>
           <article class="role">
             <h3>Codex</h3>
-            <p>The router skill is globally linked at <code>~/.codex/skills/dev-studio</code>. In Codex sessions, use <code>$dev-studio</code> when the host exposes skill invocation.</p>
-            <code class="shell">$dev-studio manager resume-plan
-$dev-studio worker T123</code>
+            <p>The router skill is globally linked at <code>~/.codex/skills/dev-studio</code>. Codex hosts may not expose skills in the <code>$</code> picker; invoke it by naming the skill and role in the request.</p>
+            <code class="shell">Use dev-studio manager to resume the plan.
+Use dev-studio perf to profile the urgent task.</code>
           </article>
           <article class="role">
             <h3>Sync</h3>

--- a/core/v2/skills/dev-studio/portability.yaml
+++ b/core/v2/skills/dev-studio/portability.yaml
@@ -1,9 +1,13 @@
 schema_version: 1
 hosts:
   - all
+exclude_hosts:
+  - claude-code
 scope: global
 notes: |
   The v2 umbrella router uses only markdown, YAML, and the role-registry
-  resolver contract. It is globally discoverable so sessions can invoke the
-  studio from the project they are actually working on while the repo artifact
-  remains the source of truth.
+  resolver contract. Claude Code exposes the router through the global
+  commands/dev-studio.md wrapper to avoid duplicate slash-command picker rows.
+  Other hosts receive the skill globally so sessions can invoke the studio from
+  the project they are actually working on while the repo artifact remains the
+  source of truth.

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T06:46:51Z",
+  "generated_at": "2026-05-04T06:59:23Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1156,7 +1156,7 @@ check_step() {
 }
 
 if [ "$ROLE" = "manager" ] || [ "$ROLE" = "dual" ]; then
-  check_step skill_dev_studio "repo-local dev-studio skill linked"  test -L "$STUDIO_REPO_DIR/.claude/skills/dev-studio"
+  check_step command_dev_studio "global /dev-studio command linked"  test -L "$HOME/.claude/commands/dev-studio.md"
   check_step jq              "jq present"                           command -v jq
   check_step git_user_email  "git user.email set"                   bash -c 'test -n "$(git config --global user.email)"'
   [ -n "$STUDIO_REPO_DIR" ] && check_step verify_install "verify-install passes" "$STUDIO_REPO_DIR/scripts/verify-install.sh"
@@ -1183,7 +1183,7 @@ if [ "$FAIL" -gt 0 ]; then
     id="${entry%%:*}"
     label="${entry#*:}"
     case "$id" in
-      skill_dev_studio|verify_install)
+      command_dev_studio|verify_install)
         printf '  %s✗%s %s\n' "$c_red" "$c_reset" "$label"
         printf '       fix: cd %s && scripts/install.sh\n' "${STUDIO_REPO_DIR:-<studio-repo>}"
         ;;

--- a/scripts/generate-routing.sh
+++ b/scripts/generate-routing.sh
@@ -147,6 +147,9 @@ while IFS= read -r routing; do
 
   # Default behavior when portability.yaml is absent: claude-code only.
   if [ -f "$portability" ]; then
+    if yq -r '.exclude_hosts[]?' "$portability" 2>/dev/null | grep -Fxq "$HOST"; then
+      continue
+    fi
     if ! yq -r '.hosts[]' "$portability" 2>/dev/null | grep -Fxq -e "$HOST" -e "all"; then
       continue
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,8 +8,10 @@
 # skills to every detected host (Codex, Gemini, Cursor, etc.) whose binary is
 # on PATH. New hosts added to hosts/registry.yaml are picked up automatically.
 #
-# The `dev-studio` skill is installed globally by sync-host-skills.sh so users
-# can invoke the studio from the project they are actually working on.
+# The `dev-studio` command is installed globally for Claude Code. The
+# `dev-studio` skill is installed globally for non-Claude hosts by
+# sync-host-skills.sh so users can invoke the studio from the project they are
+# actually working on without duplicate Claude slash-command picker rows.
 #
 # Usage:
 #   scripts/install.sh            # apply, print summary

--- a/scripts/lib-stepwise.sh
+++ b/scripts/lib-stepwise.sh
@@ -207,7 +207,7 @@ except Exception: pass' 2>/dev/null || true)
 stepwise_validate() {
   local id="${1:?step-id required}"
   case "$id" in
-    skill_dev_studio)      test -L "$_LSW_REPO_ROOT/.claude/skills/dev-studio" ;;
+    command_dev_studio)    test -L "$HOME/.claude/commands/dev-studio.md" ;;
     brew)                  command -v brew >/dev/null 2>&1 || [ -x /opt/homebrew/bin/brew ] || [ -x /usr/local/bin/brew ] ;;
     jq)                    command -v jq >/dev/null 2>&1 ;;
     rsync)                 command -v rsync >/dev/null 2>&1 ;;
@@ -235,7 +235,7 @@ stepwise_recheck_all() {
   local -a steps=()
   case "$role" in
     manager|dual)
-      steps+=(skill_dev_studio brew jq yq coreutils fswatch git git_user_email nodes_json)
+      steps+=(command_dev_studio brew jq yq coreutils fswatch git git_user_email nodes_json)
       ;;
   esac
   case "$role" in

--- a/scripts/sync-host-skills.sh
+++ b/scripts/sync-host-skills.sh
@@ -118,6 +118,9 @@ skill_declares_host() {
     [ "$host" = "claude-code" ] && return 0   # default for unmigrated skills
     return 1
   fi
+  if yq -r '.exclude_hosts[]?' "$portability" 2>/dev/null | grep -Fxq "$host"; then
+    return 1
+  fi
   yq -r '.hosts[]' "$portability" 2>/dev/null | grep -Fxq -e "$host" -e "all"
 }
 

--- a/scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
+++ b/scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
@@ -33,7 +33,9 @@ grep -Fq '<!-- v2-dev-studio:dispatch -->' "$SKILL_DIR/SKILL.md" || fail "missin
 grep -Fq '<!-- v2-dev-studio:forwarders -->' "$SKILL_DIR/SKILL.md" || fail "missing forwarders anchor"
 
 [ "$(yq -r '.invocation.slash_command' "$SKILL_DIR/routing.yaml")" = "/dev-studio" ] || fail "routing slash command mismatch"
-[ "$(yq -r '.scope' "$SKILL_DIR/portability.yaml")" = "project" ] || fail "dev-studio portability scope must be project"
+[ "$(yq -r '.scope' "$SKILL_DIR/portability.yaml")" = "global" ] || fail "dev-studio portability scope must be global"
+yq -e '.hosts[] | select(. == "all")' "$SKILL_DIR/portability.yaml" >/dev/null || fail "dev-studio must declare global host fan-out"
+yq -e '.exclude_hosts[] | select(. == "claude-code")' "$SKILL_DIR/portability.yaml" >/dev/null || fail "dev-studio must avoid duplicate Claude Code command discovery"
 
 yq -o=json "$FORWARDERS" > "$TMPROOT/forwarders.json"
 jq -e '.schema_version == 1 and .kind == "studio-v2-dev-studio-forwarders" and .leaf_issue == 516' "$TMPROOT/forwarders.json" >/dev/null || fail "forwarder envelope invalid"


### PR DESCRIPTION
## Summary
- skip dev-studio skill fan-out for Claude Code so the global command is the only /dev-studio picker provider
- keep non-Claude host skill fan-out and document Codex natural-language invocation when the $ picker does not list skills
- add portability exclude_hosts support across sync and generated routing

## Verification
- scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
- scripts/lint-skill-prose.sh core/v2/skills/dev-studio/portability.yaml _shared/standards/portability.json
- check-jsonschema --schemafile _shared/standards/portability.json core/v2/skills/dev-studio/portability.yaml
- scripts/generate-routing.sh claude-code --domains studio-v2 | rg 'dev-studio|/dev-studio' || true
- scripts/generate-routing.sh codex --domains studio-v2 | rg 'dev-studio|/dev-studio'
- zsh -c 'source scripts/lib-stepwise.sh; stepwise_validate command_dev_studio; case 0 in 0|1) exit 0;; *) exit 1;; esac'
- scripts/lint-host-agnostic.sh --staged (0 errors, existing W_ARGUS_SECRET_SCOPE warning)
- git diff --check
- opened core/v2/skills/dev-studio/docs.html in Safari