### PR TITLE
Add dev-studio bare role landings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 
 ```
 # Studio v2 router — canonical role dispatch
+/dev-studio manager              # bare role landing — suggests next moves, then reports the direct command
 /dev-studio manager resume-plan  # "where were we" — load ROADMAP + ARCHITECTURE + pending memory
 /dev-studio reviewer review      # walk REVIEW.md against the pending diff
 /dev-studio release-manager      # draft release notes per RELEASES.md (never auto-tags)
@@ -82,8 +83,9 @@ STUDIO_TRACK=<track>             # session-start shortcut for v2 track work
 /studio-setup --interactive      # legacy: prompt at every step
 /studio-setup --help             # open the v2 router docs + usage summary
 
-/dev-studio manager              # conversational shaping and status
+/dev-studio manager              # conversational shaping and cwd-aware landing
 /dev-studio worker <contract>    # worker role execution contract
+/dev-studio reviewer             # reviewer landing for diff, plan, outcome, PR, or release packet
 /dev-studio reviewer review      # reviewer role contract
 /dev-studio perf profile         # performance role contract
 /dev-studio planner              # planning/architecture role contract

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T06:59:24Z",
+  "generated_at": "2026-05-04T08:50:10Z",
   "agents": [
 
   ]

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -34,15 +34,19 @@ supplies the task context and runtime slug.
 3. Read `$STUDIO_REPO/core/v2/skills/dev-studio/SKILL.md`.
 
 4. Parse `$ARGUMENTS`:
-   - Empty arguments route to `manager`.
+   - Empty arguments route to the lightweight `manager` landing.
    - A canonical role or compatibility alias in the first token routes through
      `$STUDIO_REPO/scripts/v2-role-resolve.sh`.
+   - A role token with no remaining request starts that role's lightweight
+     landing. Load the role contract, inspect only cheap cwd/profile context,
+     and offer next moves instead of running a heavy default action.
    - Unknown role tokens fail before side effects.
 
 5. Execute the matched role workflow by following the router and role contract:
-   - `manager` -> shaping, status, resume, ingest, guard, audit.
+   - `manager` -> shaping, status, resume, ingest, guard, audit, or a
+     cwd-aware landing when no subcommand/request is present.
    - `worker` -> bounded task contract in an isolated worktree.
-   - `reviewer` -> plan, outcome, diff, or PR review.
+   - `reviewer` -> plan, outcome, diff, PR, or release-packet review.
    - `perf` -> performance, battery, memory, thermal, network, or instrumentation evidence.
    - `planner`, `qa-engineer`, `flow-tester`, `release-manager` -> active role contracts, usually manager-mediated or approval-gated.
 
@@ -50,7 +54,18 @@ supplies the task context and runtime slug.
    explicitly names another project slug. Use studio scripts from
    `$STUDIO_REPO/scripts/`.
 
-7. If the user asks for help, open:
+7. For a bare-role landing:
+   - In `generic-dev-studio`, include studio-internal options such as
+     `resume-plan`, `ingest`, `guard`, `audit`, `sync`, and `nodes` when they
+     match the selected role.
+   - In project repos, bias suggestions toward project task shaping,
+     implementation, review, QA, flow testing, performance, and release
+     readiness.
+   - After the user locks in a workflow, continue without requiring them to
+     retype the command and report the reusable direct invocation for next
+     time.
+
+8. If the user asks for help, open:
 
    ```bash
    open "$STUDIO_REPO/core/v2/skills/dev-studio/docs.html"

--- a/core/v2/cutover/manifest.yaml
+++ b/core/v2/cutover/manifest.yaml
@@ -37,7 +37,7 @@ parity:
     - name: manager triage
       legacy_invocation: /studio resume-plan
       v2_invocation: /dev-studio manager resume-plan
-      evidence: core/v2/manager/proof-of-life.yaml
+      evidence: core/v2/roles/manager.yaml
     - name: worker implementation
       legacy_invocation: /achilles task
       v2_invocation: /dev-studio worker task
@@ -52,7 +52,7 @@ parity:
       evidence: core/v2/roles/perf.yaml
 rollback:
   trigger_events:
-    - v2 manager proof-of-life cannot produce a typed handoff artifact
+    - v2 manager contract cannot produce a typed handoff artifact
     - worker reviewer or perf role contract resolution fails
     - parity fixture fails on the chain branch after ordered integration
     - operator reports a v2 traffic regression after A10 deletion

--- a/core/v2/roles/manager.yaml
+++ b/core/v2/roles/manager.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+kind: studio-v2-role-contract
+parent_issue: 444
+leaf_issue: 564
+status: active
+role: manager
+aliases:
+  - chanakya
+  - coordinator
+  - orchestrator
+purpose: Shape ambiguous user intent into bounded role workflows, route work, preserve lifecycle state, and hold final acceptance routing.
+inputs:
+  - kind: user-intent
+    required: true
+    description: A direct request, bare role invocation, issue reference, track name, or conversational description of the desired outcome.
+  - kind: repo-context
+    required: false
+    description: Current working repository, project profile, visible diff, issue state, and studio/runtime artifacts needed to route safely.
+  - kind: prior-usage
+    required: false
+    description: Recent or commonly used role workflows when available, used only to improve landing suggestions without blocking intake.
+outputs:
+  - kind: shaped-intent
+    required: true
+    description: Goal, impact, scope, non-goals, acceptance criteria, route, and next role or subcommand recommendation.
+  - kind: role-landing
+    required: false
+    description: Lightweight next-step menu for bare manager or no-role invocations, scoped by cwd and project profile.
+  - kind: worker-contract
+    required: false
+    description: Bounded executable leaf contract when the user has locked in implementation work.
+reads:
+  - scope: owned worktree
+    description: Repo docs, role contracts, router metadata, diffs, and profile files needed to classify and shape the request.
+  - scope: ~/.dev-studio/**
+    description: Runtime plans, issue graph exports, recent workflow evidence, private analysis artifacts, and project state explicitly needed for routing.
+writes:
+  - scope: owned worktree
+    description: Studio repo docs, issues, contracts, or routing files only when the accepted request explicitly targets studio substrate.
+  - scope: ~/.dev-studio/**
+    description: Shaped briefs, intake notes, role landing state, worker contracts, review packets, and blocked or needs-context artifacts.
+idempotency_key: manager:{project_slug}:{intent_fingerprint}
+decision_rights:
+  - Ask lightweight clarifying questions or offer role-specific next moves when intent is underspecified.
+  - Route locked-in work to planner, worker, reviewer, qa-engineer, flow-tester, perf, release-manager, or host-adapter without changing their authority boundaries.
+  - Distinguish studio-internal workflows from project workflows using cwd, project profile, and explicit user wording.
+  - Suggest the reusable direct command after intent locks so the next invocation can skip conversational landing.
+escalation_triggers:
+  - The requested route would cross from studio-internal substrate into a target project runtime without explicit user intent.
+  - The work changes permissions, secrets, release actions, blocking rules, or other ask-first policy.
+  - Scope cannot be made bounded, testable, or safely routed after one lightweight clarification.
+  - Multiple roles could own the next step and choosing silently would change cost, latency, or user-visible behavior.
+failure_semantics:
+  - For a bare manager or no-role invocation, return a role landing instead of silently running heavy state sweeps.
+  - For a bare non-manager role routed through manager, preserve the selected role and return landing options for the missing target or review kind.
+  - Return needs_context with exact missing inputs instead of inventing issue state, project profile details, or release readiness.
+  - Stop before side effects when the request is ambiguous across studio-internal and project-runtime boundaries.
+verification_floor:
+  - Shaped intent names the selected route, target repo/profile, in-scope work, non-goals, acceptance criteria, and blocked state if any.
+  - Bare-role landings list only lightweight next moves and defer heavy docs, logs, traces, or issue sweeps until the user chooses a path.
+  - Studio-internal suggestions are shown only for the studio repo or when the user explicitly asks for studio operations.
+  - Locked-in workflows report the direct command or phrasing the user can use next time.

--- a/core/v2/schemas/role-contract.schema.json
+++ b/core/v2/schemas/role-contract.schema.json
@@ -27,10 +27,10 @@
     "schema_version": {"const": 1},
     "kind": {"const": "studio-v2-role-contract"},
     "parent_issue": {"const": 444},
-    "leaf_issue": {"enum": [526, 540, 541, 542, 543]},
+    "leaf_issue": {"enum": [526, 540, 541, 542, 543, 564]},
     "status": {"enum": ["active", "reserved", "retired"]},
     "role": {
-      "enum": ["planner", "worker", "reviewer", "qa-engineer", "flow-tester", "perf", "release-manager"]
+      "enum": ["manager", "planner", "worker", "reviewer", "qa-engineer", "flow-tester", "perf", "release-manager"]
     },
     "aliases": {
       "type": "array",

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -46,6 +46,26 @@ preserved as `/dev-studio <alias>` role resolution and documented in
 | `/dev-studio host-adapter ...` | `host-adapter` | `adapter`, `host` | reserved for adapter operations |
 | `/dev-studio operator ...` | `operator` | `user`, `human`, `owner` | reserved, non-routable human authority |
 
+<!-- v2-dev-studio:landing -->
+## Bare Role Landing
+
+When the invocation names a role but no target or subcommand, start that role in
+a lightweight conversational landing instead of running a heavy default action.
+Load the role contract, identify the current repo/profile, and offer a short
+set of likely next moves. The user can then describe the desired work in plain
+language without retyping `/dev-studio`.
+
+After the user locks in a path, continue into the selected workflow and report
+the direct one-line invocation they can use next time. Existing explicit
+invocations keep routing directly and do not show the landing.
+
+Landing suggestions are cwd/profile-aware. Studio-internal options such as
+`ingest`, `audit`, `guard`, `sync`, `nodes`, and `resume-plan` target
+`generic-dev-studio` unless the user explicitly asks for studio operations from
+another project. Project repositories should bias suggestions toward project
+task shaping, implementation, review, QA, flow testing, performance, and
+release readiness.
+
 <!-- v2-dev-studio:intent -->
 ## Intent detection
 
@@ -57,8 +77,10 @@ Priority order:
    `achilles` through `scripts/v2-role-resolve.sh` and routes to `worker`.
 3. **Former top-level name** — `/dev-studio achilles <contract>` keeps the
    old role name available without restoring the deleted v1 router.
-4. **No role token** — route to `manager`; the manager owns conversational
-   shaping and status.
+4. **Bare role token** — `/dev-studio reviewer` or `/dev-studio
+   release-manager` starts that role's lightweight landing.
+5. **No role token** — route to the `manager` landing; the manager owns
+   conversational shaping and status.
 
 Unknown role tokens fail before side effects with the explicit resolver error.
 Routing intelligence remains advisory unless a role contract grants authority.

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -453,10 +453,15 @@
           <div>
           <p>
             Put the role after <code>/dev-studio</code>. If no role token is
-            present, the invocation defaults to <code>manager</code> for
-            conversational shaping and status.
+            present, the invocation opens the lightweight <code>manager</code>
+            landing for conversational shaping and status. A role with no
+            request, such as <code>/dev-studio reviewer</code>, opens that
+            role's landing instead of running a heavy default action.
           </p>
-          <code class="shell">/dev-studio manager resume-plan
+          <code class="shell">/dev-studio manager
+/dev-studio reviewer
+/dev-studio release-manager
+/dev-studio manager resume-plan
 /dev-studio worker &lt;contract&gt;
 /dev-studio reviewer review
 /dev-studio perf profile
@@ -697,8 +702,9 @@ scripts/worker-status.sh</code>
           <article class="role">
             <h3>manager</h3>
             <p>Shapes intent, resumes arcs, routes work, guards against repeats, captures patterns, and escalates operator decisions.</p>
-            <div class="meta"><span class="pill status-live">direct use</span><span class="pill">proof-of-life script</span></div>
-            <code class="shell">/dev-studio manager resume-plan
+            <div class="meta"><span class="pill status-live">direct use</span><span class="pill">contract-backed landing</span></div>
+            <code class="shell">/dev-studio manager
+/dev-studio manager resume-plan
 /dev-studio manager guard "has this shipped?"
 /dev-studio manager ingest "capture this pattern"</code>
           </article>
@@ -721,7 +727,8 @@ scripts/achilles-queue.sh drain</code>
             <h3>reviewer</h3>
             <p>Reviews plans, diffs, outcomes, PRs, and release packets for blockers, warnings, and missing evidence.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">headless review wrappers</span></div>
-            <code class="shell">/dev-studio reviewer review
+            <code class="shell">/dev-studio reviewer
+/dev-studio reviewer review
 scripts/phase-review.sh --kind plan --input phase-plan.md
 scripts/pr-headless-review.sh &lt;pr&gt;</code>
           </article>
@@ -750,7 +757,8 @@ scripts/v2-multispawn-pilot.sh run</code>
             <h3>release-manager</h3>
             <p>Assembles release readiness, blocker state, notes, tag state, TestFlight/App Store state, and approval gates.</p>
             <div class="meta"><span class="pill status-contract">approval-gated</span><span class="pill">handoff: release-packet</span></div>
-            <code class="shell">/dev-studio release-manager prepare beta readiness
+            <code class="shell">/dev-studio release-manager
+/dev-studio release-manager prepare beta readiness
 /dev-studio release-manager tf-push --background</code>
           </article>
           <article class="role">
@@ -852,14 +860,17 @@ scripts/host-preflight.sh codex /repo</code>
             <li>Explicit canonical role routes directly, such as <code>/dev-studio worker &lt;contract&gt;</code>.</li>
             <li>Compatibility alias resolves through <code>scripts/v2-role-resolve.sh</code>, such as <code>/dev-studio achilles &lt;contract&gt;</code>.</li>
             <li>Former top-level names remain aliases only when placed under <code>/dev-studio</code>.</li>
-            <li>No role token routes to <code>manager</code>.</li>
+            <li>A bare role token opens that role's lightweight landing.</li>
+            <li>No role token opens the <code>manager</code> landing.</li>
+            <li>Unknown role tokens fail before side effects.</li>
           </ol>
         </div>
         <aside class="notice warning">
-          <h3>Unknown roles fail closed</h3>
+          <h3>Landings stay lightweight</h3>
           <p>
-            Unknown role tokens exit before side effects. Alias normalization is
-            case-insensitive and treats underscores or spaces as hyphens.
+            Bare-role landings load role contracts and cheap cwd/profile
+            context only. They suggest next moves, then report the direct
+            command after the user locks in a workflow.
           </p>
           </aside>
         </div>

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T06:59:23Z",
+  "generated_at": "2026-05-04T08:50:10Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
+++ b/scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
@@ -30,6 +30,7 @@ require yq
 grep -Fq 'name: dev-studio' "$SKILL_DIR/SKILL.md" || fail "SKILL.md frontmatter name mismatch"
 grep -Fq 'type: agent-router' "$SKILL_DIR/SKILL.md" || fail "dev-studio is not an agent-router"
 grep -Fq '<!-- v2-dev-studio:dispatch -->' "$SKILL_DIR/SKILL.md" || fail "missing dispatch anchor"
+grep -Fq '<!-- v2-dev-studio:landing -->' "$SKILL_DIR/SKILL.md" || fail "missing bare-role landing anchor"
 grep -Fq '<!-- v2-dev-studio:forwarders -->' "$SKILL_DIR/SKILL.md" || fail "missing forwarders anchor"
 
 [ "$(yq -r '.invocation.slash_command' "$SKILL_DIR/routing.yaml")" = "/dev-studio" ] || fail "routing slash command mismatch"
@@ -66,5 +67,7 @@ assert_alias apollo perf
 [ "$(yq -r '.transition.cutover_status' "$FORWARDERS")" = "v1-deleted" ] || fail "A10 deletion should be recorded"
 [ "$(yq -r '.forwarders | length' "$FORWARDERS")" = "0" ] || fail "A10 should not preserve v1 forwarder rows"
 grep -Fq 'primary traffic surface' "$SKILL_DIR/SKILL.md" || fail "traffic boundary not documented"
+grep -Fq 'Bare Role Landing' "$SKILL_DIR/SKILL.md" || fail "bare role landing not documented"
+grep -Fq 'direct one-line invocation' "$SKILL_DIR/SKILL.md" || fail "direct command suggestion not documented"
 
 printf 'PASS: dev-studio umbrella skill and forwarders\n'

--- a/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+++ b/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
@@ -22,7 +22,7 @@ jq -e '.["$schema"] and .type == "object"' "$SCHEMA" >/dev/null || fail "schema 
 }
 grep -Fq 'v2-role-contract: ok' "$TMPROOT/validate.err" || fail "validation did not report success"
 
-for role in planner worker reviewer qa-engineer flow-tester perf release-manager; do
+for role in manager planner worker reviewer qa-engineer flow-tester perf release-manager; do
   "$CMD" --resolve --role "$role" | grep -Fxq "core/v2/roles/$role.yaml" || fail "canonical role did not resolve: $role"
   "$CMD" --resolve --role "$role" --format json | jq -e --arg role "$role" '.role == $role and .contract_file == ("core/v2/roles/" + $role + ".yaml")' >/dev/null || fail "json resolution invalid for $role"
   if command -v check-jsonschema >/dev/null 2>&1; then
@@ -31,6 +31,7 @@ for role in planner worker reviewer qa-engineer flow-tester perf release-manager
   fi
 done
 
+[ "$("$CMD" --resolve --role chanakya)" = "core/v2/roles/manager.yaml" ] || fail "chanakya alias did not resolve to manager contract"
 [ "$("$CMD" --resolve --role architect)" = "core/v2/roles/planner.yaml" ] || fail "architect alias did not resolve to planner contract"
 [ "$("$CMD" --resolve --role achilles)" = "core/v2/roles/worker.yaml" ] || fail "achilles alias did not resolve to worker contract"
 [ "$("$CMD" --resolve --role argus)" = "core/v2/roles/reviewer.yaml" ] || fail "argus alias did not resolve to reviewer contract"
@@ -39,13 +40,9 @@ done
 [ "$("$CMD" --resolve --role apollo)" = "core/v2/roles/perf.yaml" ] || fail "apollo alias did not resolve to perf contract"
 [ "$("$CMD" --resolve --role shipper)" = "core/v2/roles/release-manager.yaml" ] || fail "shipper alias did not resolve to release-manager contract"
 
-if "$CMD" --resolve --role manager >"$TMPROOT/manager.out" 2>"$TMPROOT/manager.err"; then
-  fail "manager unexpectedly resolved to a migrated contract"
-fi
-grep -Fq 'role has no migrated contract: manager' "$TMPROOT/manager.err" || fail "manager error was not explicit"
-
 BAD="$TMPROOT/bad-contracts"
 mkdir -p "$BAD"
+cp "$ROOT/core/v2/roles/manager.yaml" "$BAD/manager.yaml"
 cp "$ROOT/core/v2/roles/planner.yaml" "$BAD/planner.yaml"
 cp "$ROOT/core/v2/roles/worker.yaml" "$BAD/worker.yaml"
 cp "$ROOT/core/v2/roles/reviewer.yaml" "$BAD/reviewer.yaml"

--- a/scripts/test-fixtures/527-cutover/test-v2-cutover.sh
+++ b/scripts/test-fixtures/527-cutover/test-v2-cutover.sh
@@ -45,7 +45,7 @@ grep -Fq 'v2-cutover: ok' /tmp/v2-cutover-validate.err || fail "validation did n
 [ "$(yq -r '.traffic_switch.compatibility_forwarders | length' "$MANIFEST")" = "0" ] || fail "A10 should remove compatibility forwarders"
 [ "$(yq -r '[.archive.surfaces[] | select(.status != "deleted")] | length' "$MANIFEST")" = "0" ] || fail "A10 should mark every v1 surface deleted"
 
-for evidence in core/v2/manager/proof-of-life.yaml core/v2/roles/worker.yaml core/v2/roles/reviewer.yaml core/v2/roles/perf.yaml; do
+for evidence in core/v2/roles/manager.yaml core/v2/roles/worker.yaml core/v2/roles/reviewer.yaml core/v2/roles/perf.yaml; do
   yq -e ".parity.golden_scenarios[].evidence | select(. == \"$evidence\")" "$MANIFEST" >/dev/null || fail "missing parity evidence: $evidence"
 done
 

--- a/scripts/v2-cutover.sh
+++ b/scripts/v2-cutover.sh
@@ -115,7 +115,7 @@ validate_cutover() {
   while IFS= read -r evidence; do
     [ -n "$evidence" ] || continue
     case "$evidence" in
-      core/v2/manager/proof-of-life.yaml|core/v2/roles/worker.yaml|core/v2/roles/reviewer.yaml|core/v2/roles/perf.yaml)
+      core/v2/manager/proof-of-life.yaml|core/v2/roles/manager.yaml|core/v2/roles/worker.yaml|core/v2/roles/reviewer.yaml|core/v2/roles/perf.yaml)
         ;;
       *) printf 'v2-cutover: unexpected parity evidence path: %s\n' "$evidence" >&2; return 1 ;;
     esac

--- a/scripts/v2-role-contract.sh
+++ b/scripts/v2-role-contract.sh
@@ -40,6 +40,7 @@ role_for_file() {
 
 expected_leaf_issue_for_role() {
   case "$1" in
+    manager) printf '564\n' ;;
     worker|reviewer|perf) printf '526\n' ;;
     planner) printf '540\n' ;;
     qa-engineer) printf '541\n' ;;
@@ -111,7 +112,7 @@ validate_contracts() {
     roles="${roles}${role}"$'\n'
   done < <(contract_files)
 
-  for role in planner worker reviewer qa-engineer flow-tester perf release-manager; do
+  for role in manager planner worker reviewer qa-engineer flow-tester perf release-manager; do
     printf '%s' "$roles" | grep -Fxq "$role" || {
       printf 'v2-role-contract: missing migrated role contract: %s\n' "$role" >&2
       exit 3


### PR DESCRIPTION
## Summary

- Add a manager role contract so bare manager routing is contract-backed.
- Document bare role landings for manager, reviewer, and release-manager across the router skill, command wrapper, README, and HTML docs.
- Teach role-contract validation that manager is now a migrated role and update cutover/context evidence.

Closes #564

## Verification

- scripts/test-fixtures/516-dev-studio-skill/test-dev-studio-skill.sh
- scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
- scripts/test-fixtures/527-cutover/test-v2-cutover.sh
- scripts/lint-v2-bootstrap.sh --full
- scripts/lint-v2-enforcement.sh --full
- scripts/test-fixtures/552-context-budget/test-context-budget-report.sh
- scripts/v2-role-contract.sh --validate
- scripts/lint-skill-prose.sh core/v2/skills/dev-studio/SKILL.md
- scripts/lint-host-agnostic.sh --staged (0 errors; existing .codex/capabilities.yaml Argus secret-scope warning)

portable: yes
