### PR TITLE
Default reviews to cross-host wrappers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ The `dev-studio` router is shipped at `core/v2/skills/dev-studio/` and exposed t
 | User intent | Trigger phrases | Dispatch |
 |---|---|---|
 | Resume in-flight arc / "where were we" | "where were we", "pick up from", "resume", `/resume-plan` | `/dev-studio manager resume-plan` |
-| Review a studio-repo diff | "review this", "check this", "any issues", "self-review", `/simplify` *on a studio-repo diff* | `/dev-studio reviewer review` plus `REVIEW.md` |
+| Review a studio-repo diff | "review this", "check this", "any issues", "self-review", `/simplify` *on a studio-repo diff* | Cross-host reviewer wrapper by default plus `REVIEW.md`; `/dev-studio reviewer review` only for conversational triage |
 | Draft release notes / evaluate tagging | "what's new", "draft release notes", "should we tag", "release" | `/dev-studio release-manager` plus `RELEASES.md` |
 | Studio-level capture (patterns, analysis, parking-lot, rule tweaks) | "add to parking lot", "file a pattern", "capture this for the studio" | `/dev-studio manager ingest` |
 | Arc-coherence audit (plan ↔ memory ↔ commits drift) | `/studio audit`, "audit the arc", "check plan drift" — also auto-runs silently on SessionStart | `/dev-studio manager audit` |
@@ -71,6 +71,17 @@ The rulebook sections below (**Reviews**, **Releases**, **Docs sync**, **Backlog
 When the user asks to review a diff (any phrasing — "review", "self-review", "check this", "any issues", or invoking `/simplify`), **read `REVIEW.md` at the repo root first** and walk its rules against the diff. Auto-fix the `block + auto-fix` tier silently; surface `ask` tier before changing; note `warn` tier either way.
 
 Do not wait for the user to name REVIEW.md. The file is authoritative for this repo.
+
+**Default to cross-host review.** For any non-trivial review target with a PR,
+diff, plan, outcome, or worker/perf artifact, invoke the smoke-gated
+cross-host reviewer wrapper rather than only switching the current session into
+`/dev-studio reviewer review`. Use `scripts/pr-headless-review.sh` for PRs,
+`scripts/phase-review.sh` for plan/outcome artifacts, and
+`scripts/task-invoke-argus.sh` for worker task diffs. The inline reviewer role
+is for lightweight conversational triage, explaining a wrapper verdict, or
+cases where no reviewable artifact exists yet. If the user asks for review from
+inside an existing worker or perf session, create or name the review artifact
+and run the wrapper unless they explicitly ask for inline-only feedback.
 
 Skip review for single-line doc fixes. Trigger it for: any `scripts/*.sh` change, any `SKILL.md` change, any `_shared/*` change, or diffs >100 lines.
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T11:29:05Z",
+  "generated_at": "2026-05-04T12:18:18Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T11:29:04Z",
+  "generated_at": "2026-05-04T12:18:17Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/hosts/ADAPTER-SPEC.md
+++ b/hosts/ADAPTER-SPEC.md
@@ -102,6 +102,12 @@ are centralized. Emergency/debug-only override is
 recorded in the review artifact. See `CLAUDE.md` §Cross-host phase review for
 the workflow rule that consumes this adapter contract.
 
+Cross-host review is the default for non-trivial review requests from worker,
+perf, planner, QA, flow-test, release, and manager sessions whenever a PR,
+diff, plan, outcome, or role artifact exists. Inline reviewer-role discussion is
+reserved for triage, explaining a wrapper verdict, or shaping the artifact that
+the wrapper will review.
+
 ### Env-scrub at reviewer dispatch
 
 `scripts/dispatch-review.sh` enforces the reviewer floor at spawn time by env-scrubbing the subprocess. Only PATH/HOME/LANG/USER, the host plugin-root, and explicit task-context vars cross the boundary; `ANTHROPIC_API_KEY`, `GH_TOKEN`/`GITHUB_TOKEN`, and arbitrary inherited env are dropped. The host CLI re-authenticates from its own keychain inside the spawned session.


### PR DESCRIPTION
## Summary
- make smoke-gated cross-host reviewer wrappers the default for non-trivial review requests
- keep inline `/dev-studio reviewer review` scoped to conversational triage, verdict explanation, or shaping a missing artifact
- document the same default in the adapter contract for worker/perf and other role sessions

## Verification
- git diff --check
- scripts/lint-host-agnostic.sh --staged (existing W_ARGUS_SECRET_SCOPE warning only)
- pre-commit staged gates passed during commit
