### PR TITLE
Fix Codex worker spawn capability

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -59,6 +59,12 @@ For unattended workers, also use the non-interactive approval policy:
 codex --sandbox workspace-write --add-dir ~/.dev-studio --ask-for-approval never
 ```
 
+Studio-launched Codex workers use `scripts/codex-worker-exec.sh` instead of
+plain `codex exec`. The wrapper resolves the login `HOME`, adds
+`$HOME/.dev-studio` as the runtime writable root, forces
+`--sandbox workspace-write`, disables transcript/session persistence with
+`--ephemeral`, and runs with `approval_policy=never`.
+
 ## GitHub Auth Parity
 
 Codex worker sessions must launch with the same login `HOME`, keychain, ssh-agent, and GitHub credential-helper surface that Claude-backed sessions use. The studio chain runner sets `HOME` to the login home before spawning Codex so `gh` and `git` see the user's normal credentials instead of a scratch home. Parent-side studio scripts that run under a synthetic Codex home also normalize GitHub operations to the login `HOME` per command; set `STUDIO_BYPASS_PARENT_HOME_FLIP=1` only when intentionally testing synthetic-home isolation.

--- a/.codex/capabilities.yaml
+++ b/.codex/capabilities.yaml
@@ -1,10 +1,10 @@
 # Codex adapter (OpenAI Codex CLI, v0.120+)
 #
-# Codex runs in a workspace-write sandbox with cwd-only secret scope,
-# satisfying the Achilles security floor defined in hosts/ADAPTER-SPEC.md.
+# Codex workers must materialize the declared workspace-write/no-persistence
+# contract through the wrapper, not by relying on user config defaults.
 # Hooks require Codex v0.120+.
 supports_hooks: true
-spawn_command: "codex exec"
+spawn_command: "scripts/codex-worker-exec.sh"
 block_for_event_strategy: tail
 tool_dialect: openai
 sandbox_profile: workspace-write

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T12:18:18Z",
+  "generated_at": "2026-05-04T12:49:32Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T12:18:17Z",
+  "generated_at": "2026-05-04T12:49:32Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/hosts/ADAPTER-SPEC.md
+++ b/hosts/ADAPTER-SPEC.md
@@ -35,7 +35,9 @@ secret_scope: <str>              # Secret visibility: "inherit-env" | "cwd-only"
 
 ### Field semantics
 
-**`sandbox_profile`** — levels form an ordered scale from least to most restrictive:
+**`sandbox_profile`** — levels form an ordered scale from least to most restrictive.
+The declared value is not enough: the adapter's effective `spawn_command` must
+materialize the matching host CLI flags or wrapper behavior.
 
 | Value | Meaning |
 |---|---|
@@ -51,6 +53,15 @@ secret_scope: <str>              # Secret visibility: "inherit-env" | "cwd-only"
 | `inherit-env` | Worker inherits the caller's full environment (including `ANTHROPIC_API_KEY`, etc.). |
 | `cwd-only` | Only secrets declared in `.env` or equivalent CWD-scoped files. |
 | `none` | No secrets injected; worker must not need them. |
+
+**`spawn_command`** — must be the source of truth for effective behavior, not a
+placeholder that relies on a user's local CLI defaults. For worker profiles,
+the command must force noninteractive execution, materialize the declared
+sandbox profile, and disable transcript/session persistence when the host CLI
+supports that mode. For Codex workers, this is handled by
+`scripts/codex-worker-exec.sh`, which passes `--sandbox workspace-write`,
+`--add-dir "$HOME/.dev-studio"`, `--ephemeral`, and
+`approval_policy=never`.
 
 ## Security floor
 
@@ -172,6 +183,11 @@ per-issue local clone made from the chain worktree; the parent runner fetches
 the resulting issue branch back into the chain worktree after the worker
 commits. Do not fix sandboxed workers by widening write access to the main
 checkout's `.git/worktrees/*` metadata or unrelated issue gitdirs.
+
+The git metadata strategy only solves where Git writes. It does not prove that
+the child host actually launched writable. The host adapter must separately
+prove that its effective spawn command materializes the declared sandbox and
+session-persistence policy.
 
 ## Conformance test
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,6 +75,7 @@ scripts/studio-chain-runner.sh --resume <run_id> --yes                     # res
 scripts/studio-chain-runner.sh --list                                      # list persisted chain runs and report paths
 scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution
 scripts/studio-chain-telemetry-digest.sh --days 7                          # v1 counters + weekly digest from private chain-run telemetry
+scripts/codex-worker-exec.sh "<prompt>"                                    # internal Codex worker launcher: workspace-write + ~/.dev-studio + ephemeral + no prompts
 # Chain dry-runs show the selected git metadata strategy; sandboxed hosts use issue-local clones so commits stay inside the worker root.
 # Chain reports include typed halt records and decision escrow when automation pauses or continues on a low-risk default.
 scripts/studio-chain-reviewed.sh v2-transition --host codex --review-host claude-reviewer  # pre-run phase review, then chain PRs reviewed by the selected reviewer

--- a/scripts/codex-worker-exec.sh
+++ b/scripts/codex-worker-exec.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Materialize the Codex worker capability manifest as real CLI flags.
+
+set -euo pipefail
+umask 022
+
+dev_studio_root="${STUDIO_CODEX_WRITABLE_ROOT:-${HOME:?HOME required}/.dev-studio}"
+
+exec codex exec \
+  --ephemeral \
+  --sandbox workspace-write \
+  --add-dir "$dev_studio_root" \
+  -c approval_policy=never \
+  "$@"

--- a/scripts/lint-host-agnostic.sh
+++ b/scripts/lint-host-agnostic.sh
@@ -135,7 +135,7 @@ yaml_field() {
 }
 
 check_capability_security_floor() {
-  local manifest host_dir sandbox secret
+  local manifest host_dir sandbox secret spawn wrapper_path
   # LINT_HOST_AGNOSTIC_EXTRA_DIR: optional comma-separated list of additional
   # adapter dirs to scan (used by tests/conformance harness).
   local extra_dirs=()
@@ -152,6 +152,7 @@ check_capability_security_floor() {
 
     sandbox=$(yaml_field "$manifest" sandbox_profile)
     secret=$(yaml_field "$manifest" secret_scope)
+    spawn=$(yaml_field "$manifest" spawn_command)
 
     # sandbox_profile: none is always a block (no isolation whatsoever).
     if [ "$sandbox" = "none" ]; then
@@ -169,6 +170,26 @@ check_capability_security_floor() {
     # a dedicated Argus-specific manifest or run Argus on a none-scoped host.
     if [ "$secret" = "cwd-only" ]; then
       emit_warn "W_ARGUS_SECRET_SCOPE:$host_dir/capabilities.yaml:secret_scope=cwd-only | Argus dispatch on this host requires secret_scope: none; add a dedicated Argus adapter or route Argus to a none-scoped host"
+    fi
+
+    if [ "$host_dir" = ".codex" ]; then
+      wrapper_path="$REPO_ROOT/$spawn"
+      if [ "$spawn" = "codex exec" ]; then
+        emit_error "E_EFFECTIVE_CAPABILITY:$host_dir/capabilities.yaml:spawn_command | Codex worker spawn must not rely on plain codex exec defaults"
+      elif [ ! -x "$wrapper_path" ]; then
+        emit_error "E_EFFECTIVE_CAPABILITY:$host_dir/capabilities.yaml:spawn_command | Codex worker spawn wrapper is missing or not executable: $spawn"
+      else
+        grep -q -- '--sandbox workspace-write' "$wrapper_path" \
+          || emit_error "E_EFFECTIVE_CAPABILITY:$spawn | Codex worker wrapper must pass --sandbox workspace-write"
+        grep -q -- '--ephemeral' "$wrapper_path" \
+          || emit_error "E_EFFECTIVE_CAPABILITY:$spawn | Codex worker wrapper must pass --ephemeral"
+        grep -q -- 'approval_policy=never' "$wrapper_path" \
+          || emit_error "E_EFFECTIVE_CAPABILITY:$spawn | Codex worker wrapper must force approval_policy=never"
+        grep -q -- '--add-dir' "$wrapper_path" \
+          || emit_error "E_EFFECTIVE_CAPABILITY:$spawn | Codex worker wrapper must add the resolved ~/.dev-studio writable root"
+        grep -Eq -- 'dangerously-bypass-approvals-and-sandbox|dangerously-skip-permissions' "$wrapper_path" \
+          && emit_error "E_EFFECTIVE_CAPABILITY:$spawn | Codex worker wrapper must not use dangerous sandbox bypass flags"
+      fi
     fi
   done < <(
     # Discover adapter dirs from registry instead of hardcoding paths.

--- a/scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh
+++ b/scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Verifies Codex worker capabilities are materialized by the effective spawn.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t codex-worker-spawn.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+WORKER_CAPS="$ROOT/.codex/capabilities.yaml"
+REVIEWER_CAPS="$ROOT/.codex-reviewer/capabilities.yaml"
+WORKER_WRAPPER="$ROOT/scripts/codex-worker-exec.sh"
+
+grep -q 'spawn_command: "scripts/codex-worker-exec.sh"' "$WORKER_CAPS" \
+  || fail "Codex worker manifest does not use the wrapper"
+grep -q -- '--sandbox workspace-write' "$WORKER_WRAPPER" \
+  || fail "Codex worker wrapper does not materialize workspace-write"
+grep -q -- '--ephemeral' "$WORKER_WRAPPER" \
+  || fail "Codex worker wrapper does not disable session persistence"
+grep -q -- 'approval_policy=never' "$WORKER_WRAPPER" \
+  || fail "Codex worker wrapper does not force noninteractive approval"
+grep -q -- '--add-dir "$dev_studio_root"' "$WORKER_WRAPPER" \
+  || fail "Codex worker wrapper does not add the resolved runtime writable root"
+if grep -Eq -- 'dangerously-bypass-approvals-and-sandbox|dangerously-skip-permissions' "$WORKER_WRAPPER"; then
+  fail "Codex worker wrapper uses a dangerous sandbox bypass"
+fi
+
+grep -q -- '--sandbox read-only' "$REVIEWER_CAPS" \
+  || fail "Codex reviewer profile is not read-only"
+grep -q -- '--ephemeral' "$REVIEWER_CAPS" \
+  || fail "Codex reviewer profile does not disable session persistence"
+grep -q -- 'approval_policy=never' "$REVIEWER_CAPS" \
+  || fail "Codex reviewer profile does not force noninteractive approval"
+grep -q '^secret_scope: none$' "$REVIEWER_CAPS" \
+  || fail "Codex reviewer profile is not no-secret"
+
+BIN="$TMPROOT/bin"
+HOME_DIR="$TMPROOT/home"
+mkdir -p "$BIN" "$HOME_DIR"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  issue="$3"
+  cat <<JSON
+{
+  "number": $issue,
+  "title": "Codex worker spawn fixture $issue",
+  "body": "Exercise effective Codex worker spawn.",
+  "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/$issue",
+  "state": "OPEN"
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "$BIN/gh"
+
+manifest="$TMPROOT/chain.yaml"
+cat > "$manifest" <<'YAML'
+schema_version: 1
+chains:
+  - name: codex-worker-spawn-fixture
+    base: main
+    branch: feature/codex-worker-spawn-fixture
+    host: codex
+    issues: [576]
+YAML
+
+PATH="$BIN:$PATH" HOME="$HOME_DIR" "$ROOT/scripts/studio-chain-runner.sh" "$manifest" --dry-run > "$TMPROOT/out" 2>&1
+
+grep -q 'Git metadata strategy: `local-clone`' "$TMPROOT/out" \
+  || fail "dry-run plan did not keep Codex on local-clone git metadata"
+grep -q 'scripts/codex-worker-exec.sh' "$TMPROOT/out" \
+  || fail "dry-run did not use the effective Codex worker wrapper"
+if grep -q 'codex exec .*Implement this studio issue' "$TMPROOT/out"; then
+  fail "dry-run still used plain codex exec for Codex worker"
+fi
+
+bash "$ROOT/scripts/lint-host-agnostic.sh" >/tmp/codex-worker-spawn-lint.out 2>/tmp/codex-worker-spawn-lint.err \
+  || {
+    cat /tmp/codex-worker-spawn-lint.out >&2
+    cat /tmp/codex-worker-spawn-lint.err >&2
+    fail "host-agnostic lint rejected effective Codex worker capability"
+  }
+
+printf 'PASS: codex worker effective spawn\n'


### PR DESCRIPTION
## Summary

Fixes #576 by making the Codex worker adapter materialize its declared capability through a real launcher instead of plain `codex exec` defaults.

## Changes

- Adds `scripts/codex-worker-exec.sh` for Codex workers.
- Updates `.codex/capabilities.yaml` to use the wrapper.
- Forces worker execution to be `workspace-write`, `--ephemeral`, and `approval_policy=never`, with `$HOME/.dev-studio` added as the runtime writable root.
- Extends host-agnostic lint to reject plain `codex exec` for the Codex worker adapter and validate the wrapper flags.
- Adds fixture coverage for effective Codex worker spawn and reviewer isolation.
- Updates adapter docs and script roster.

## Verification

- `bash scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh`
- `bash scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh`
- `bash scripts/lint-host-agnostic.sh`
- `bash scripts/test-host.sh codex --failure-modes-only`
- `bash scripts/test-host.sh codex`
- `bash -n scripts/codex-worker-exec.sh scripts/lint-host-agnostic.sh scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh scripts/studio-chain-runner.sh`
- `git diff --check`
- `scripts/lint-host-agnostic.sh --staged`
- Checkpoint dry-run from `/tmp/studio-checkpoint-flow/chains/checkpoint-workflow.yaml` showed `local-clone` and `scripts/codex-worker-exec.sh` for #567-#570.

## Review

- Sibling outcome review: clean, archived locally as `20260504T124759Z-576-direct-outcome-review.md`.
