### PR TITLE
Fix chain sequential issue integration

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T12:49:32Z",
+  "generated_at": "2026-05-04T13:23:28Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T12:49:32Z",
+  "generated_at": "2026-05-04T13:23:28Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -2442,6 +2442,60 @@ wait_for_all_issue_jobs() {
   ISSUE_PIDS=()
 }
 
+integrate_issue_result() {
+  local chain_name="$1" branch="$2" chain_worktree="$3" issue="$4" git_metadata_strategy="$5" result_file="$6" chain_run_id="$7" issue_run_id="$8"
+  local issue_branch issue_worktree result_commit_after
+
+  issue_branch=$(jq -r '.issue_branch' "$result_file")
+  issue_worktree=$(jq -r '.issue_worktree' "$result_file")
+  result_commit_after=$(jq -r '.commit_after // ""' "$result_file")
+
+  if [ "$DRY_RUN" -eq 0 ]; then
+    if [ "$(jq -r '.resumed // false' "$result_file")" = "true" ]; then
+      case "$git_metadata_strategy" in
+        linked-worktree)
+          if ! git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$issue_branch"; then
+            log "resume assumes completed issue #$issue already integrated; issue branch missing"
+            return 0
+          fi
+          ;;
+        local-clone)
+          if [ ! -d "$issue_worktree/.git" ]; then
+            if [ -n "$result_commit_after" ] \
+              && git -C "$chain_worktree" cat-file -e "$result_commit_after^{commit}" 2>/dev/null \
+              && git -C "$chain_worktree" merge-base --is-ancestor "$result_commit_after" HEAD 2>/dev/null; then
+              log "resume confirms completed issue #$issue already integrated"
+              return 0
+            fi
+            abort_run "completed issue #$issue local clone missing before integration"
+          fi
+          ;;
+      esac
+    fi
+    git -C "$chain_worktree" checkout "$branch"
+    chain_git_integrate_issue_workspace "$REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
+    emit_chain_event chain_issue_merged "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" completed 0 \
+      "$(jq -cn --arg chain "$chain_name" --arg branch "$branch" --arg issue_branch "$issue_branch" --arg commit_after "$result_commit_after" '{chain:$chain, branch:$branch, issue_branch:$issue_branch, commit_after:(if $commit_after == "" then null else $commit_after end)}')"
+  else
+    printf 'DRY-RUN git -C %q checkout %q\n' "$chain_worktree" "$branch"
+    case "$git_metadata_strategy" in
+      linked-worktree)
+        printf 'DRY-RUN git -C %q rebase %q\n' "$issue_worktree" "$branch"
+        printf 'DRY-RUN git -C %q merge --ff-only %q\n' "$chain_worktree" "$issue_branch"
+        printf 'DRY-RUN git -C %q worktree remove %q\n' "$REPO_ROOT" "$issue_worktree"
+        printf 'DRY-RUN git -C %q branch -D %q\n' "$REPO_ROOT" "$issue_branch"
+        ;;
+      local-clone)
+        printf 'DRY-RUN git -C %q fetch %q %q\n' "$issue_worktree" "$chain_worktree" "$branch"
+        printf 'DRY-RUN git -C %q rebase FETCH_HEAD\n' "$issue_worktree"
+        printf 'DRY-RUN git -C %q fetch %q %q\n' "$chain_worktree" "$issue_worktree" "$issue_branch"
+        printf 'DRY-RUN git -C %q merge --ff-only FETCH_HEAD\n' "$chain_worktree"
+        printf 'DRY-RUN rm -rf %q\n' "$issue_worktree"
+        ;;
+    esac
+  fi
+}
+
 for ((idx = 0; idx < chain_count; idx++)); do
   name=$(jq -r ".chains[$idx].name" "$PLAN_JSON")
   base=$(jq -r ".chains[$idx].base" "$PLAN_JSON")
@@ -2505,6 +2559,7 @@ for ((idx = 0; idx < chain_count; idx++)); do
         --arg worktree "$issue_worktree" \
         --arg commit_after "$issue_commit_after" \
         '{status:"completed", issue:($issue|tonumber), issue_branch:$branch, issue_worktree:$worktree, commit_after:(if $commit_after == "" then null else $commit_after end), resumed:true}' > "$result_file"
+      integrate_issue_result "$name" "$branch" "$chain_worktree" "$issue" "$git_metadata_strategy" "$result_file" "$chain_run_id" "$issue_run_id"
       continue
     fi
 
@@ -2514,64 +2569,7 @@ for ((idx = 0; idx < chain_count; idx++)); do
       result_reason=$(jq -r '.reason // "issue failed"' "$result_file")
       abort_run "$result_reason"
     fi
-  done
-
-  for ((i = 0; i < issue_count; i++)); do
-    issue=$(jq -r ".chains[$idx].issues[$i].number" "$PLAN_JSON")
-    result_file=$(find "$chain_results_dir" -maxdepth 1 -name "issue-$issue-*.json" -print -quit 2>/dev/null || true)
-    if [ -z "$result_file" ] || [ ! -r "$result_file" ]; then
-      abort_run "issue #$issue produced no runner result"
-    fi
-    result_status=$(jq -r '.status // "failed"' "$result_file")
-    if [ "$result_status" != "completed" ]; then
-      result_reason=$(jq -r '.reason // "issue failed"' "$result_file")
-      abort_run "$result_reason"
-    fi
-    issue_branch=$(jq -r '.issue_branch' "$result_file")
-    issue_worktree=$(jq -r '.issue_worktree' "$result_file")
-    result_commit_after=$(jq -r '.commit_after // ""' "$result_file")
-    if [ "$DRY_RUN" -eq 0 ]; then
-      if [ "$(jq -r '.resumed // false' "$result_file")" = "true" ]; then
-        case "$git_metadata_strategy" in
-          linked-worktree)
-            if ! git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$issue_branch"; then
-              log "resume assumes completed issue #$issue already integrated; issue branch missing"
-              continue
-            fi
-            ;;
-          local-clone)
-            if [ ! -d "$issue_worktree/.git" ]; then
-              if [ -n "$result_commit_after" ] \
-                && git -C "$chain_worktree" cat-file -e "$result_commit_after^{commit}" 2>/dev/null \
-                && git -C "$chain_worktree" merge-base --is-ancestor "$result_commit_after" HEAD 2>/dev/null; then
-                log "resume confirms completed issue #$issue already integrated"
-                continue
-              fi
-              abort_run "completed issue #$issue local clone missing before integration"
-            fi
-            ;;
-        esac
-      fi
-      git -C "$chain_worktree" checkout "$branch"
-      chain_git_integrate_issue_workspace "$REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
-    else
-      printf 'DRY-RUN git -C %q checkout %q\n' "$chain_worktree" "$branch"
-      case "$git_metadata_strategy" in
-        linked-worktree)
-          printf 'DRY-RUN git -C %q rebase %q\n' "$issue_worktree" "$branch"
-          printf 'DRY-RUN git -C %q merge --ff-only %q\n' "$chain_worktree" "$issue_branch"
-          printf 'DRY-RUN git -C %q worktree remove %q\n' "$REPO_ROOT" "$issue_worktree"
-          printf 'DRY-RUN git -C %q branch -D %q\n' "$REPO_ROOT" "$issue_branch"
-          ;;
-        local-clone)
-          printf 'DRY-RUN git -C %q fetch %q %q\n' "$issue_worktree" "$chain_worktree" "$branch"
-          printf 'DRY-RUN git -C %q rebase FETCH_HEAD\n' "$issue_worktree"
-          printf 'DRY-RUN git -C %q fetch %q %q\n' "$chain_worktree" "$issue_worktree" "$issue_branch"
-          printf 'DRY-RUN git -C %q merge --ff-only FETCH_HEAD\n' "$chain_worktree"
-          printf 'DRY-RUN rm -rf %q\n' "$issue_worktree"
-          ;;
-      esac
-    fi
+    integrate_issue_result "$name" "$branch" "$chain_worktree" "$issue" "$git_metadata_strategy" "$result_file" "$chain_run_id" "$issue_run_id"
   done
 
   finalize_chain_pr "$name" "$branch" "$chain_worktree" "$base" "$chain_run_id" "$host"

--- a/scripts/test-fixtures/580-chain-sequential-integration/test-chain-sequential-integration.sh
+++ b/scripts/test-fixtures/580-chain-sequential-integration/test-chain-sequential-integration.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Verifies sequential chain leaves carry completed commits into later leaves.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-sequential-integration.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+. "$ROOT/scripts/lib-chain-git.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+REPO="$TMPROOT/repo"
+CHAIN_WORKTREE="$TMPROOT/chain"
+ISSUE_ONE="$TMPROOT/issue-one"
+ISSUE_TWO="$TMPROOT/issue-two"
+
+git init -q "$REPO"
+git -C "$REPO" config user.name "Fixture"
+git -C "$REPO" config user.email "fixture@example.com"
+printf 'base\n' > "$REPO/base.txt"
+git -C "$REPO" add base.txt
+git -C "$REPO" commit -q -m "base"
+git -C "$REPO" branch -M main
+git -C "$REPO" worktree add -q -B feature/chain "$CHAIN_WORKTREE" main
+
+chain_git_prepare_issue_workspace "$REPO" "$CHAIN_WORKTREE" feature/chain "$ISSUE_ONE" feature/chain-issue-one local-clone
+git -C "$ISSUE_ONE" config user.name "Fixture"
+git -C "$ISSUE_ONE" config user.email "fixture@example.com"
+printf 'from first issue\n' > "$ISSUE_ONE/first.txt"
+git -C "$ISSUE_ONE" add first.txt
+git -C "$ISSUE_ONE" commit -q -m "Closes #580 first leaf"
+chain_git_integrate_issue_workspace "$REPO" "$CHAIN_WORKTREE" feature/chain "$ISSUE_ONE" feature/chain-issue-one local-clone
+
+chain_git_prepare_issue_workspace "$REPO" "$CHAIN_WORKTREE" feature/chain "$ISSUE_TWO" feature/chain-issue-two local-clone
+[ -f "$ISSUE_TWO/first.txt" ] || fail "second local-clone issue did not inherit first issue commit"
+
+BIN="$TMPROOT/bin"
+HOME_DIR="$TMPROOT/home"
+mkdir -p "$BIN" "$HOME_DIR"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  issue="$3"
+  cat <<JSON
+{
+  "number": $issue,
+  "title": "Sequential fixture $issue",
+  "body": "Exercise sequential chain integration.",
+  "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/$issue",
+  "state": "OPEN"
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "$BIN/gh"
+
+manifest="$TMPROOT/chain.yaml"
+cat > "$manifest" <<'YAML'
+schema_version: 1
+chains:
+  - name: sequential-fixture
+    base: main
+    branch: feature/sequential-fixture
+    host: codex
+    phase_review: off
+    issues: [580, 581]
+YAML
+
+PATH="$BIN:$PATH" HOME="$HOME_DIR" "$ROOT/scripts/studio-chain-runner.sh" "$manifest" --dry-run > "$TMPROOT/out" 2>&1
+
+awk '
+  /studio-chain-runner: issue #580 ->/ { issue_one=NR }
+  /DRY-RUN git -C .*merge --ff-only FETCH_HEAD/ && issue_one && !merge_one { merge_one=NR }
+  /studio-chain-runner: issue #581 ->/ { issue_two=NR }
+  END { exit !(issue_one && merge_one && issue_two && issue_one < merge_one && merge_one < issue_two) }
+' "$TMPROOT/out" || {
+  cat "$TMPROOT/out" >&2
+  fail "dry-run did not integrate first issue before launching second issue"
+}
+
+awk '
+  /if \[ "\$issue_status" = "completed" \]/ { completed_block=1 }
+  /integrate_issue_result "\$name" "\$branch" "\$chain_worktree" "\$issue"/ && completed_block { integrated=1 }
+  /continue/ && completed_block && integrated { ok=1 }
+  END { exit !ok }
+' "$ROOT/scripts/studio-chain-runner.sh" || fail "resume completed-issue path does not integrate before continuing"
+
+printf 'PASS: chain sequential integration\n'


### PR DESCRIPTION
## Summary

- integrate each completed chain issue into the chain branch before launching the next issue
- carry resumed completed issue commits forward before retrying pending leaves
- add regression coverage for local-clone sequential integration and dry-run ordering

Closes #580

## Verification

- bash scripts/test-fixtures/580-chain-sequential-integration/test-chain-sequential-integration.sh
- bash scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh
- bash -n scripts/studio-chain-runner.sh scripts/lib-chain-git.sh scripts/test-fixtures/580-chain-sequential-integration/test-chain-sequential-integration.sh
- git diff --cached --check
- scripts/lint-host-agnostic.sh --staged (pre-existing W_ARGUS_SECRET_SCOPE warning)