### PR TITLE
Fix chain resume worktree detection

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T13:23:28Z",
+  "generated_at": "2026-05-04T13:33:40Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T13:23:28Z",
+  "generated_at": "2026-05-04T13:33:40Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -2442,6 +2442,11 @@ wait_for_all_issue_jobs() {
   ISSUE_PIDS=()
 }
 
+git_checkout_exists() {
+  local worktree="$1"
+  git -C "$worktree" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
 integrate_issue_result() {
   local chain_name="$1" branch="$2" chain_worktree="$3" issue="$4" git_metadata_strategy="$5" result_file="$6" chain_run_id="$7" issue_run_id="$8"
   local issue_branch issue_worktree result_commit_after
@@ -2526,9 +2531,9 @@ for ((idx = 0; idx < chain_count; idx++)); do
   run with_login_home_for_github git -C "$REPO_ROOT" fetch origin --prune
   if [ "$DRY_RUN" -eq 0 ]; then
     mkdir -p "$chain_results_dir"
-    if [ -n "$RESUME_ID" ] && [ -d "$chain_worktree/.git" ]; then
+    if [ -n "$RESUME_ID" ] && git_checkout_exists "$chain_worktree"; then
       git -C "$chain_worktree" checkout "$branch"
-    elif [ ! -d "$chain_worktree/.git" ]; then
+    elif ! git_checkout_exists "$chain_worktree"; then
       git -C "$REPO_ROOT" worktree add -B "$branch" "$chain_worktree" "origin/$base"
       git -C "$chain_worktree" checkout "$branch"
       git -C "$chain_worktree" reset --hard "origin/$base"

--- a/scripts/test-fixtures/582-chain-resume-worktree/test-chain-resume-worktree.sh
+++ b/scripts/test-fixtures/582-chain-resume-worktree/test-chain-resume-worktree.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Verifies chain resume detection accepts standard git worktree .git files.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-resume-worktree.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+REPO="$TMPROOT/repo"
+CHAIN_WORKTREE="$TMPROOT/chain-worktree"
+
+git init -q "$REPO"
+git -C "$REPO" config user.name "Fixture"
+git -C "$REPO" config user.email "fixture@example.com"
+printf 'base\n' > "$REPO/base.txt"
+git -C "$REPO" add base.txt
+git -C "$REPO" commit -q -m "base"
+git -C "$REPO" branch -M main
+git -C "$REPO" worktree add -q -B feature/chain "$CHAIN_WORKTREE" main
+
+[ -f "$CHAIN_WORKTREE/.git" ] || fail "fixture did not create a linked worktree with .git as a file"
+git -C "$CHAIN_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || fail "git-native checkout probe does not recognize linked worktree"
+
+grep -q '^git_checkout_exists()' "$ROOT/scripts/studio-chain-runner.sh" \
+  || fail "runner is missing git checkout detection helper"
+
+if grep -Fq '[ -d "$chain_worktree/.git" ]' "$ROOT/scripts/studio-chain-runner.sh"; then
+  fail "runner still uses .git directory shape to detect chain worktrees"
+fi
+
+printf 'PASS: chain resume worktree detection\n'


### PR DESCRIPTION
## Summary

- detect existing chain worktrees with `git rev-parse --is-inside-work-tree` instead of `.git` directory shape
- add a regression for linked worktrees where `.git` is a file
- preserve #580 sequential integration behavior

Closes #582

## Verification

- bash scripts/test-fixtures/582-chain-resume-worktree/test-chain-resume-worktree.sh
- bash scripts/test-fixtures/580-chain-sequential-integration/test-chain-sequential-integration.sh
- bash scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh
- bash -n scripts/studio-chain-runner.sh scripts/test-fixtures/582-chain-resume-worktree/test-chain-resume-worktree.sh
- git diff --check
- scripts/lint-host-agnostic.sh --staged (pre-existing W_ARGUS_SECRET_SCOPE warning)