### PR TITLE
Fix chain parent commit finalization

### DIFF
--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -54,3 +54,78 @@ chain_git_integrate_issue_workspace() {
       ;;
   esac
 }
+
+chain_git_parent_finalize_summary_eligible() {
+  local summary_file="${1:?usage: chain_git_parent_finalize_summary_eligible <summary-file>}"
+  [ -f "$summary_file" ] || return 1
+  jq -e '
+    def text($v):
+      if $v == null then ""
+      elif ($v | type) == "array" then ($v | map(tostring) | join("\n"))
+      elif ($v | type) == "object" then ($v | tojson)
+      else ($v | tostring)
+      end;
+    def checks: ((.tests // []) + (.lints // []) + (.builds // []));
+    def clean_outcome($v):
+      (($v.outcome // $v.status // "") | ascii_downcase)
+      | test("^(pass|passed|passed_with_warning|ok|success|succeeded|skipped)$");
+    (((.status // "") | ascii_downcase) | test("^(blocked|failed)$"))
+    and ((.commit_after // null) == null or (.commit_after // "") == "" or (.commit_after == .commit_before))
+    and ((.blocked_reason // "") | ascii_downcase
+      | (test("git|\\.git|index\\.lock|stage|staging|commit")
+         and test("operation not permitted|permission denied|unwritable|denies writes|cannot write|failed creating")))
+    and ((text(.carryover) + "\n" + text(.lessons)) | ascii_downcase | test("secret|destructive|unrelated issue|scope cannot|review failed") | not)
+    and ((checks | length) > 0)
+    and all(checks[]; clean_outcome(.))
+  ' "$summary_file" >/dev/null 2>&1
+}
+
+chain_git_parent_finalize_has_public_diff() {
+  local issue_worktree="${1:?usage: chain_git_parent_finalize_has_public_diff <issue-worktree>}"
+  git -C "$issue_worktree" status --porcelain --untracked-files=all -- . ':!.studio' | grep -q .
+}
+
+chain_git_parent_finalize_issue_commit() {
+  local issue_worktree="${1:?usage: chain_git_parent_finalize_issue_commit <issue-worktree> <issue-number> <summary-file>}"
+  local issue="${2:?issue number required}"
+  local summary_file="${3:?summary file required}"
+  local issue_title subject
+
+  chain_git_parent_finalize_summary_eligible "$summary_file" || return 1
+  chain_git_parent_finalize_has_public_diff "$issue_worktree" || return 1
+  issue_title=$(jq -r '.issue_title // empty' "$summary_file" 2>/dev/null || true)
+
+  git -C "$issue_worktree" reset -q -- .studio 2>/dev/null || true
+  rm -rf "$issue_worktree/.studio"
+  git -C "$issue_worktree" add --all -- . ':!.studio'
+
+  if git -C "$issue_worktree" diff --cached --quiet --exit-code; then
+    return 1
+  fi
+  git -C "$issue_worktree" diff --cached --check
+  if git -C "$issue_worktree" diff --cached --name-only -- .studio | grep -q .; then
+    git -C "$issue_worktree" reset -q -- .studio 2>/dev/null || true
+    return 1
+  fi
+
+  if [ -n "$issue_title" ]; then
+    subject="$issue_title (#$issue)"
+  else
+    subject="Implement #$issue"
+  fi
+  git -C "$issue_worktree" commit -m "$subject" -m "Closes #$issue"
+}
+
+chain_git_parent_finalize_event_payload() {
+  local summary_file="${1:?usage: chain_git_parent_finalize_event_payload <summary> <before> <after> <host>}"
+  local before="${2:?before commit required}"
+  local after="${3:?after commit required}"
+  local host="${4:?host required}"
+  jq -cn \
+    --arg summary "$summary_file" \
+    --arg before "$before" \
+    --arg after "$after" \
+    --arg host "$host" \
+    --arg reason "worker_git_metadata_unwritable" \
+    '{summary:$summary, commit_before:$before, commit_after:$after, worker_host:$host, reason:$reason}'
+}

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -231,7 +231,7 @@ event_stage() {
   case "$1" in
     chain_run_started|chain_plan_prepared|chain_phase_review_completed) printf 'plan\n' ;;
     chain_auth_normalized|chain_host_preflight_*|chain_artifact_validation_failed) printf 'preflight\n' ;;
-    chain_started|chain_issue_started|chain_issue_completed|chain_issue_validated) printf 'execute\n' ;;
+    chain_started|chain_issue_started|chain_issue_completed|chain_issue_validated|chain_parent_commit_finalized) printf 'execute\n' ;;
     chain_worker_summary_ingested|chain_telemetry_gap) printf 'ingest\n' ;;
     chain_pr_opened|chain_review_completed) printf 'review\n' ;;
     chain_completed|chain_issue_merged) printf 'merge\n' ;;
@@ -851,6 +851,33 @@ diff_stats_json() {
 changed_artifacts_json() {
   local worktree="$1" before="$2" after="$3"
   git -C "$worktree" diff --name-only "$before" "$after" 2>/dev/null | jq -R -s -c 'split("\n")[:-1]'
+}
+
+refresh_summary_commit_metrics() {
+  local summary_file="$1" worktree="$2" before="$3" after="$4" parent_finalized="${5:-false}"
+  local stats changed_artifacts tmp
+  [ -f "$summary_file" ] || return 0
+  stats=$(diff_stats_json "$worktree" "$before" "$after")
+  changed_artifacts=$(changed_artifacts_json "$worktree" "$before" "$after")
+  tmp="$summary_file.tmp.$$"
+  jq \
+    --arg after "$after" \
+    --argjson stats "$stats" \
+    --argjson changed_artifacts "$changed_artifacts" \
+    --argjson parent_finalized "$parent_finalized" \
+    '.commit_after = $after
+     | .commit_or_pr_references.commit_after = $after
+     | .files_changed = $stats.files_changed
+     | .additions = $stats.additions
+     | .deletions = $stats.deletions
+     | .generated_file_count = $stats.generated_file_count
+     | .changed_artifacts = $changed_artifacts
+     | if $parent_finalized then
+         .parent_finalized_commit = true
+         | .parent_finalized_by = "parent-runner"
+       else . end' \
+    "$summary_file" > "$tmp"
+  mv "$tmp" "$summary_file"
 }
 
 emit_summary_telemetry_gaps() {
@@ -1953,6 +1980,7 @@ explain_plan() {
     "- Worktree: `\(.chain_worktree)`\n" +
     "- Host: `\(.host)`\n" +
     "- Git metadata strategy: `\(.git_metadata_strategy // "linked-worktree")`\n" +
+    "- Parent finalize: `git-metadata-only worker blocks can be committed by the parent runner after summary/check validation`\n" +
     "- Phase review: `\(.phase_review // "auto")`\n" +
     "- Worker pool: `\(.worker_pool)`\n" +
     "- Planned PR: base `\(.base)`, head `\(.branch)`, title `studio chain: \(.name)`\n\n" +
@@ -2264,9 +2292,10 @@ write_issue_phase_outcome_artifact() {
 
 run_issue_job() {
   local name="$1" branch="$2" chain_worktree="$3" issue="$4" host="$5" git_metadata_strategy="$6" issue_worktree="$7" issue_branch="$8" chain_run_id="$9" issue_run_id="${10}" result_file="${11}" phase_review_mode="${12:-auto}" issue_count_for_review="${13:-1}"
-  local before after worker_rc summary_file issue_duration summary_payload issue_started_at child_reason_id child_blocked_reason
+  local before after worker_rc child_worker_rc summary_file issue_duration summary_payload issue_started_at child_reason_id child_blocked_reason parent_finalized
   local phase_context boundary_id phase_plan_artifact phase_outcome_artifact phase_review_rc phase_review_reason
   issue_started_at=$(now_epoch)
+  parent_finalized=false
 
   log "issue #$issue -> $issue_branch"
   if [ "$DRY_RUN" -eq 0 ]; then
@@ -2322,6 +2351,7 @@ run_issue_job() {
   execute_issue_session "$name" "$branch" "$issue" "$host" "$git_metadata_strategy" "$issue_worktree" "$issue_branch" "$chain_run_id" "$issue_run_id" "$before" "$phase_context"
   worker_rc=$?
   set -e
+  child_worker_rc=$worker_rc
 
   if [ "$DRY_RUN" -eq 1 ]; then
     jq -n \
@@ -2336,8 +2366,6 @@ run_issue_job() {
   summary_file=$(ingest_worker_summary "$name" "$issue" "$host" "$issue_worktree" "$before" "$after" "$worker_rc" "$issue_started_at" "$chain_run_id" "$issue_run_id")
   write_decision_escrows_from_summary "$summary_file" || log "decision escrow extraction failed for $summary_file"
   issue_duration=$(duration_since "$issue_started_at")
-  summary_payload=$(jq -c --arg summary "$summary_file" --arg after "$after" --argjson exit_code "$worker_rc" --argjson duration_s "$issue_duration" \
-    '{summary:$summary, commit_after:$after, exit_code:$exit_code, worker_duration_s:$duration_s, telemetry_gaps:(.telemetry_gaps // [])}' "$summary_file")
 
   if worker_summary_tracked "$issue_worktree"; then
     emit_chain_event chain_issue_completed "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" failed "$issue_duration" \
@@ -2349,6 +2377,31 @@ run_issue_job() {
   fi
 
   rm -rf "$issue_worktree/.studio"
+  if [ "$worker_rc" -ne 0 ] && [ "$after" = "$before" ] \
+    && chain_git_parent_finalize_summary_eligible "$summary_file" \
+    && chain_git_parent_finalize_has_public_diff "$issue_worktree"; then
+    log "issue #$issue worker could not write git metadata; parent finalizing commit"
+    if chain_git_parent_finalize_issue_commit "$issue_worktree" "$issue" "$summary_file"; then
+      after=$(git -C "$issue_worktree" rev-parse HEAD)
+      refresh_summary_commit_metrics "$summary_file" "$issue_worktree" "$before" "$after" true
+      parent_finalized=true
+      worker_rc=0
+      emit_chain_event chain_parent_commit_finalized "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" completed 0 \
+        "$(chain_git_parent_finalize_event_payload "$summary_file" "$before" "$after" "$host")"
+    else
+      log "issue #$issue parent finalize declined; preserving worker failure path"
+    fi
+  fi
+
+  summary_payload=$(jq -c \
+    --arg summary "$summary_file" \
+    --arg after "$after" \
+    --argjson exit_code "$worker_rc" \
+    --argjson child_exit_code "$child_worker_rc" \
+    --argjson duration_s "$issue_duration" \
+    --argjson parent_finalized "$parent_finalized" \
+    '{summary:$summary, commit_after:$after, exit_code:$exit_code, child_exit_code:$child_exit_code, worker_duration_s:$duration_s, parent_finalized:$parent_finalized, telemetry_gaps:(.telemetry_gaps // [])}' "$summary_file")
+
   if [ "$worker_rc" -ne 0 ]; then
     child_reason_id=$(jq -r '.halt_reason_id // empty' "$summary_file")
     if [ -z "$child_reason_id" ]; then

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-parent-finalize-584.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+# shellcheck source=../../../lib-chain-git.sh
+. "$ROOT/scripts/lib-chain-git.sh"
+
+REPO="$TMPROOT/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email studio@example.invalid
+git -C "$REPO" config user.name "Studio Test"
+printf 'base\n' > "$REPO/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit -q -m "base"
+
+mkdir -p "$REPO/.studio"
+cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "issue_number": 584,
+  "issue_title": "Parent finalize fixture",
+  "commit_before": "base",
+  "commit_after": null,
+  "blocked_reason": "Unable to stage or commit: filesystem denies writes inside .git creating .git/index.lock with Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "passed"}],
+  "lints": [{"command": "git diff --check", "outcome": "passed_with_warning"}],
+  "builds": []
+}
+JSON
+printf 'base\nchange\n' > "$REPO/README.md"
+printf 'new\n' > "$REPO/runtime.sh"
+
+chain_git_parent_finalize_summary_eligible "$REPO/.studio/chain-worker-summary.json" \
+  || fail "git metadata summary was not eligible"
+chain_git_parent_finalize_has_public_diff "$REPO" \
+  || fail "public diff was not detected"
+chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-summary.json" \
+  || fail "parent finalize did not commit"
+
+git -C "$REPO" log -1 --format=%B | grep -q 'Closes #584' \
+  || fail "parent commit did not close issue"
+git -C "$REPO" log -1 --format=%s | grep -qx 'Parent finalize fixture (#584)' \
+  || fail "parent commit subject did not use issue title"
+git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'README.md' \
+  || fail "README diff missing from parent commit"
+git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'runtime.sh' \
+  || fail "new file missing from parent commit"
+if git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -q '^.studio/'; then
+  fail "private .studio artifact was committed"
+fi
+
+PAYLOAD=$(chain_git_parent_finalize_event_payload "$REPO/.studio/chain-worker-summary.json" base "$(git -C "$REPO" rev-parse HEAD)" codex)
+printf '%s\n' "$PAYLOAD" | jq -e '
+  .summary
+  and .commit_before == "base"
+  and (.commit_after | length == 40)
+  and .worker_host == "codex"
+  and .reason == "worker_git_metadata_unwritable"
+' >/dev/null || fail "parent finalize event payload malformed"
+
+mkdir -p "$TMPROOT/bad/.studio"
+cat > "$TMPROOT/bad/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "blocked_reason": "Required review failed.",
+  "tests": [{"command": "fixture", "outcome": "passed"}]
+}
+JSON
+if chain_git_parent_finalize_summary_eligible "$TMPROOT/bad/.studio/chain-worker-summary.json"; then
+  fail "non-git blocker was eligible"
+fi
+
+mkdir -p "$TMPROOT/failing/.studio"
+cat > "$TMPROOT/failing/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "blocked_reason": "Unable to stage or commit: .git/index.lock Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "failed"}]
+}
+JSON
+if chain_git_parent_finalize_summary_eligible "$TMPROOT/failing/.studio/chain-worker-summary.json"; then
+  fail "failing checks were eligible"
+fi
+
+printf 'PASS: chain parent-finalize commit fallback\n'


### PR DESCRIPTION
## Summary

- Add a host-agnostic parent-finalize path for worker patches blocked only by git metadata writes.
- Keep worker summaries private and authoritative while parent runner creates the issue commit after summary/check validation.
- Add fixture coverage for commit finalization, private artifact exclusion, event payload shape, and refusal cases.

## Verification

- bash -n scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- bash scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- bash scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh
- bash scripts/test-fixtures/580-chain-sequential-integration/test-chain-sequential-integration.sh
- bash scripts/test-fixtures/582-chain-resume-worktree/test-chain-resume-worktree.sh
- git diff --check
- scripts/lint-v2-enforcement.sh --staged
- scripts/lint-host-agnostic.sh --staged (pre-existing W_ARGUS_SECRET_SCOPE warning)
- zsh -c 'source scripts/lib-chain-git.sh'
- phase-review plan: clean
- phase-review outcome: clean after one blocker fix