### PR TITLE
Fix parent-finalize warning eligibility

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T13:33:40Z",
+  "generated_at": "2026-05-04T19:11:02Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T13:33:40Z",
+  "generated_at": "2026-05-04T19:11:02Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -69,12 +69,17 @@ chain_git_parent_finalize_summary_eligible() {
     def clean_outcome($v):
       (($v.outcome // $v.status // "") | ascii_downcase)
       | test("^(pass|passed|passed_with_warning|ok|success|succeeded|skipped)$");
+    def unsafe_parent_finalize_note:
+      ascii_downcase as $line
+      | (($line | test("destructive|unrelated issue|scope cannot|review failed"))
+         or (($line | test("secret"))
+             and (($line | test("w_argus_secret_scope|secret-scope|secret_scope")) | not)));
     (((.status // "") | ascii_downcase) | test("^(blocked|failed)$"))
     and ((.commit_after // null) == null or (.commit_after // "") == "" or (.commit_after == .commit_before))
     and ((.blocked_reason // "") | ascii_downcase
       | (test("git|\\.git|index\\.lock|stage|staging|commit")
          and test("operation not permitted|permission denied|unwritable|denies writes|cannot write|failed creating")))
-    and ((text(.carryover) + "\n" + text(.lessons)) | ascii_downcase | test("secret|destructive|unrelated issue|scope cannot|review failed") | not)
+    and all(((text(.carryover) + "\n" + text(.lessons)) | split("\n")[]?); (unsafe_parent_finalize_note | not))
     and ((checks | length) > 0)
     and all(checks[]; clean_outcome(.))
   ' "$summary_file" >/dev/null 2>&1

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -36,8 +36,21 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
   "commit_after": null,
   "blocked_reason": "Unable to stage or commit: filesystem denies writes inside .git creating .git/index.lock with Operation not permitted.",
   "tests": [{"command": "fixture", "outcome": "passed"}],
-  "lints": [{"command": "git diff --check", "outcome": "passed_with_warning"}],
-  "builds": []
+  "lints": [
+    {"command": "git diff --check", "outcome": "passed_with_warning"},
+    {
+      "command": "scripts/lint-host-agnostic.sh",
+      "outcome": "passed_with_warning",
+      "warning": "W_ARGUS_SECRET_SCOPE:.codex/capabilities.yaml:secret_scope=cwd-only"
+    }
+  ],
+  "builds": [],
+  "carryover": [
+    "Existing W_ARGUS_SECRET_SCOPE lint warning was captured; no implementation scope blocker."
+  ],
+  "lessons": [
+    "A benign secret-scope lint warning must not block parent finalization by itself."
+  ]
 }
 JSON
 printf 'base\nchange\n' > "$REPO/README.md"
@@ -97,6 +110,21 @@ cat > "$TMPROOT/failing/.studio/chain-worker-summary.json" <<'JSON'
 JSON
 if chain_git_parent_finalize_summary_eligible "$TMPROOT/failing/.studio/chain-worker-summary.json"; then
   fail "failing checks were eligible"
+fi
+
+mkdir -p "$TMPROOT/secret/.studio"
+cat > "$TMPROOT/secret/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "blocked_reason": "Unable to stage or commit: .git/index.lock Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "passed"}],
+  "carryover": ["Potential secret exposure needs review before commit."]
+}
+JSON
+if chain_git_parent_finalize_summary_eligible "$TMPROOT/secret/.studio/chain-worker-summary.json"; then
+  fail "real secret blocker was eligible"
 fi
 
 printf 'PASS: chain parent-finalize commit fallback\n'


### PR DESCRIPTION
## Summary\n- keep parent-finalize conservative for real safety/scope/review blockers\n- allow known benign W_ARGUS_SECRET_SCOPE warning text when checks passed_with_warning\n- extend #584 fixture with benign-warning and real-secret-blocker cases\n\n## Verification\n- scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh\n- bash -n scripts/lib-chain-git.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh\n- scripts/lint-host-agnostic.sh --staged (0 errors, existing W_ARGUS_SECRET_SCOPE warning)\n\nCloses #586