### PR TITLE
Exclude git metadata from parent finalize

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T19:11:02Z",
+  "generated_at": "2026-05-04T19:25:08Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T19:11:02Z",
+  "generated_at": "2026-05-04T19:25:08Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -87,7 +87,12 @@ chain_git_parent_finalize_summary_eligible() {
 
 chain_git_parent_finalize_has_public_diff() {
   local issue_worktree="${1:?usage: chain_git_parent_finalize_has_public_diff <issue-worktree>}"
-  git -C "$issue_worktree" status --porcelain --untracked-files=all -- . ':!.studio' | grep -q .
+  git -C "$issue_worktree" status --porcelain --untracked-files=all -- \
+    . \
+    ':!.studio' ':!.studio/**' \
+    ':!.git[0-9]*' ':!.git[0-9]*/**' \
+    ':!.git-*' ':!.git-*/**' \
+    | grep -q .
 }
 
 chain_git_parent_finalize_issue_commit() {
@@ -100,16 +105,20 @@ chain_git_parent_finalize_issue_commit() {
   chain_git_parent_finalize_has_public_diff "$issue_worktree" || return 1
   issue_title=$(jq -r '.issue_title // empty' "$summary_file" 2>/dev/null || true)
 
-  git -C "$issue_worktree" reset -q -- .studio 2>/dev/null || true
+  git -C "$issue_worktree" reset -q -- .studio '.git[0-9]*' '.git-*' 2>/dev/null || true
   rm -rf "$issue_worktree/.studio"
-  git -C "$issue_worktree" add --all -- . ':!.studio'
+  git -C "$issue_worktree" add --all -- \
+    . \
+    ':!.studio' ':!.studio/**' \
+    ':!.git[0-9]*' ':!.git[0-9]*/**' \
+    ':!.git-*' ':!.git-*/**'
 
   if git -C "$issue_worktree" diff --cached --quiet --exit-code; then
     return 1
   fi
   git -C "$issue_worktree" diff --cached --check
-  if git -C "$issue_worktree" diff --cached --name-only -- .studio | grep -q .; then
-    git -C "$issue_worktree" reset -q -- .studio 2>/dev/null || true
+  if git -C "$issue_worktree" diff --cached --name-only | grep -Eq '^(\.studio(/|$)|\.git[0-9][^/]*(/|$)|\.git-[^/]*(/|$))'; then
+    git -C "$issue_worktree" reset -q -- .studio '.git[0-9]*' '.git-*' 2>/dev/null || true
     return 1
   fi
 

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -15,6 +15,22 @@ command -v jq >/dev/null 2>&1 || fail "jq is required"
 # shellcheck source=../../../lib-chain-git.sh
 . "$ROOT/scripts/lib-chain-git.sh"
 
+PRIVATE_REPO="$TMPROOT/private-only"
+mkdir -p "$PRIVATE_REPO"
+git -C "$PRIVATE_REPO" init -q
+git -C "$PRIVATE_REPO" config user.email studio@example.invalid
+git -C "$PRIVATE_REPO" config user.name "Studio Test"
+printf 'base\n' > "$PRIVATE_REPO/README.md"
+git -C "$PRIVATE_REPO" add README.md
+git -C "$PRIVATE_REPO" commit -q -m "base"
+mkdir -p "$PRIVATE_REPO/.studio" "$PRIVATE_REPO/.git2" "$PRIVATE_REPO/.git-protected"
+printf '{}\n' > "$PRIVATE_REPO/.studio/chain-worker-summary.json"
+printf '[core]\n' > "$PRIVATE_REPO/.git2/config"
+printf 'ref: refs/heads/main\n' > "$PRIVATE_REPO/.git-protected/HEAD"
+if chain_git_parent_finalize_has_public_diff "$PRIVATE_REPO"; then
+  fail "private checkpoint and git metadata dirs counted as public diff"
+fi
+
 REPO="$TMPROOT/repo"
 mkdir -p "$REPO"
 git -C "$REPO" init -q
@@ -55,6 +71,10 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
 JSON
 printf 'base\nchange\n' > "$REPO/README.md"
 printf 'new\n' > "$REPO/runtime.sh"
+mkdir -p "$REPO/.git2" "$REPO/.git-protected"
+printf '[core]\n' > "$REPO/.git2/config"
+printf 'ref: refs/heads/main\n' > "$REPO/.git-protected/HEAD"
+printf 'node_modules/\n' > "$REPO/.gitignore"
 
 chain_git_parent_finalize_summary_eligible "$REPO/.studio/chain-worker-summary.json" \
   || fail "git metadata summary was not eligible"
@@ -71,8 +91,13 @@ git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'README.m
   || fail "README diff missing from parent commit"
 git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'runtime.sh' \
   || fail "new file missing from parent commit"
+git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx '.gitignore' \
+  || fail ".gitignore diff missing from parent commit"
 if git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -q '^.studio/'; then
   fail "private .studio artifact was committed"
+fi
+if git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -Eq '^\.git(2|-protected)/'; then
+  fail "private git metadata dir was committed"
 fi
 
 PAYLOAD=$(chain_git_parent_finalize_event_payload "$REPO/.studio/chain-worker-summary.json" base "$(git -C "$REPO" rev-parse HEAD)" codex)


### PR DESCRIPTION
## Summary
- exclude worker-created private git metadata dirs from parent-finalize diff detection and staging
- keep normal files such as .gitignore eligible for parent commits
- extend the parent-finalize fixture for private-only and mixed public/private cases

## Verification
- scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- bash -n scripts/lib-chain-git.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- scripts/lint-host-agnostic.sh
- scripts/lint-host-agnostic.sh --staged
- git diff --check

Closes #589