### PR TITLE
Add context-local ingest resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The `dev-studio` router is shipped at `core/v2/skills/dev-studio/` and exposed t
 | Resume in-flight arc / "where were we" | "where were we", "pick up from", "resume", `/resume-plan` | `/dev-studio manager resume-plan` |
 | Review a studio-repo diff | "review this", "check this", "any issues", "self-review", `/simplify` *on a studio-repo diff* | Cross-host reviewer wrapper by default plus `REVIEW.md`; `/dev-studio reviewer review` only for conversational triage |
 | Draft release notes / evaluate tagging | "what's new", "draft release notes", "should we tag", "release" | `/dev-studio release-manager` plus `RELEASES.md` |
-| Studio-level capture (patterns, analysis, parking-lot, rule tweaks) | "add to parking lot", "file a pattern", "capture this for the studio" | `/dev-studio manager ingest` |
+| Context-local capture (project ideas by default; Forge/Studio only when explicitly named) | "add to parking lot", "file a pattern", "capture this for the studio" | `/dev-studio manager ingest` via `scripts/dev-studio-ingest-resolve.sh` |
 | Arc-coherence audit (plan ↔ memory ↔ commits drift) | `/studio audit`, "audit the arc", "check plan drift" — also auto-runs silently on SessionStart | `/dev-studio manager audit` |
 | Pre-work guard (already-shipped / already-tried / already-in-backlog) | `/studio guard <topic>`, "has this been done?", "are we repeating work?" | `/dev-studio manager guard` |
 | Add a skill from a git URL | `/studio add <url>`, "add this skill", "install this skill", "vendor this" | `/dev-studio manager add` |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 /dev-studio manager resume-plan  # "where were we" — load ROADMAP + ARCHITECTURE + pending memory
 /dev-studio reviewer review      # walk REVIEW.md against the pending diff
 /dev-studio release-manager      # draft release notes per RELEASES.md (never auto-tags)
-/dev-studio manager ingest       # capture a single studio-level pattern / rule-tweak proposal
+/dev-studio manager ingest       # capture one idea in the current repo context; --scope studio crosses to Forge
 /dev-studio manager analyze      # sweep studio-feedback inbox + event logs for a project
 /studio-help                     # open the v2 router docs
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements # unattended safe start/resume for one manifest
@@ -179,6 +179,7 @@ scripts/                # multi-worker fleet (BETA)
   studio-staleness-triage.sh # scheduled GitHub issue staleness labels + escalation comments for the PM surface
   host-preflight.sh    # pre-task host parity gate: gh auth + git ls-remote credential access
   studio-gh.sh          # GitHub CLI wrapper for assistant/interactive calls; normalizes synthetic Codex HOME
+  dev-studio-ingest-resolve.sh # resolves /dev-studio manager ingest destination as JSON
   ingest-feedback.sh    # auto-ingests studio-feedback records into analysis + GH issues
   detect-edits.sh       # sweep-time blind-spot detector — brief_edited + debrief_edited
   appstore-watch.sh     # polls ASC for pending submission; finalizes draft release + Slack on release

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -51,8 +51,10 @@ supplies the task context and runtime slug.
    - `planner`, `qa-engineer`, `flow-tester`, `release-manager` -> active role contracts, usually manager-mediated or approval-gated.
 
 6. Keep project state under `~/.dev-studio/$PROJECT_SLUG/` unless the user
-   explicitly names another project slug. Use studio scripts from
-   `$STUDIO_REPO/scripts/`.
+   explicitly names another project slug. For `manager ingest`, call
+   `$STUDIO_REPO/scripts/dev-studio-ingest-resolve.sh --cwd "$PROJECT_ROOT"`
+   with any explicit `--scope` or `--to` arguments and follow its JSON route.
+   Use studio scripts from `$STUDIO_REPO/scripts/`.
 
 7. For a bare-role landing:
    - In `generic-dev-studio`, include studio-internal options such as
@@ -79,3 +81,9 @@ supplies the task context and runtime slug.
 Former top-level v1 names are aliases under this command, not restored v1
 surfaces. For example, `/dev-studio apollo profile` resolves to
 `/dev-studio perf profile`.
+
+`scripts/dev-studio-ingest-resolve.sh` owns ingest destination semantics. Its
+JSON includes `destination_project`, `scope`, `artifact_kind`, `artifact_root`,
+`public_issue_repo`, `requires_privacy_scrub`, and `local_ingest_policy`.
+Project profiles decide what a project-local ingest becomes after routing:
+private artifact, GitHub issue, task, or backlog entry.

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -59,12 +59,14 @@ After the user locks in a path, continue into the selected workflow and report
 the direct one-line invocation they can use next time. Existing explicit
 invocations keep routing directly and do not show the landing.
 
-Landing suggestions are cwd/profile-aware. Studio-internal options such as
-`ingest`, `audit`, `guard`, `sync`, `nodes`, and `resume-plan` target
-`generic-dev-studio` unless the user explicitly asks for studio operations from
-another project. Project repositories should bias suggestions toward project
-task shaping, implementation, review, QA, flow testing, performance, and
-release readiness.
+Landing suggestions are cwd/profile-aware. Studio-internal options (`audit`,
+`guard`, `sync`, `nodes`, `resume-plan`) target `generic-dev-studio` unless the
+user explicitly asks for studio operations from another project. `manager
+ingest` calls `scripts/dev-studio-ingest-resolve.sh`; default ingest follows
+the current git repository, and Forge/Studio ingest requires explicit `--scope
+studio` or `--to generic-dev-studio`. Project repositories should bias
+suggestions toward project task shaping, implementation, review, QA, flow
+testing, performance, and release readiness.
 
 <!-- v2-dev-studio:intent -->
 ## Intent detection

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -608,6 +608,18 @@ core/v2/skills/dev-studio/
             </p>
           </aside>
         </div>
+        <div class="workflow-grid">
+          <section class="card">
+            <h3>Ingest Routing</h3>
+            <p>Ingest follows the current git repository by default. Cross-context Forge/Studio capture is explicit and resolved by <code>scripts/dev-studio-ingest-resolve.sh</code>.</p>
+            <code class="shell">scripts/dev-studio-ingest-resolve.sh --cwd "$PWD"
+scripts/dev-studio-ingest-resolve.sh --cwd "$PWD" --scope studio</code>
+          </section>
+          <section class="card">
+            <h3>Project Profiles</h3>
+            <p>After routing, project profiles decide whether local ingest becomes a private artifact, GitHub issue, task, or backlog entry.</p>
+          </section>
+        </div>
         <div class="table-wrap">
           <table>
             <thead>
@@ -706,7 +718,8 @@ scripts/worker-status.sh</code>
             <code class="shell">/dev-studio manager
 /dev-studio manager resume-plan
 /dev-studio manager guard "has this shipped?"
-/dev-studio manager ingest "capture this pattern"</code>
+/dev-studio manager ingest "capture this pattern"
+/dev-studio manager ingest --scope studio "capture this Forge workflow gap"</code>
           </article>
           <article class="role">
             <h3>planner</h3>

--- a/scripts/dev-studio-ingest-resolve.sh
+++ b/scripts/dev-studio-ingest-resolve.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=scripts/lib-paths.sh
+. "$ROOT/scripts/lib-paths.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: dev-studio-ingest-resolve.sh [--cwd <path>] [--message-file <path>] [--scope studio|project] [--to <project-slug>]
+
+Resolves /dev-studio manager ingest destination as structured JSON.
+EOF
+}
+
+cwd=$PWD
+message_file=
+scope=
+to_project=
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cwd)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      cwd=$2
+      shift 2
+      ;;
+    --message-file)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      message_file=$2
+      shift 2
+      ;;
+    --scope)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      scope=$2
+      shift 2
+      ;;
+    --to)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      to_project=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unknown argument: %s\n' "$1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$scope" in
+  ""|studio|project) ;;
+  *)
+    printf 'error: --scope must be studio or project\n' >&2
+    exit 2
+    ;;
+esac
+
+[ -d "$cwd" ] || {
+  printf 'error: --cwd does not exist or is not a directory: %s\n' "$cwd" >&2
+  exit 1
+}
+
+if [ -n "$message_file" ] && [ ! -r "$message_file" ]; then
+  printf 'error: --message-file is not readable: %s\n' "$message_file" >&2
+  exit 1
+fi
+
+source_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$cwd")
+source_project=$(basename "$source_root")
+destination_project=$source_project
+
+if [ -n "$to_project" ]; then
+  destination_project=$to_project
+elif [ "$scope" = "studio" ]; then
+  destination_project=generic-dev-studio
+fi
+
+resolved_scope=project
+if [ "$destination_project" = "generic-dev-studio" ]; then
+  resolved_scope=studio
+fi
+
+if [ "$scope" = "studio" ] && [ "$resolved_scope" != "studio" ]; then
+  printf 'error: --scope studio conflicts with --to %s\n' "$destination_project" >&2
+  exit 2
+fi
+
+if [ "$scope" = "project" ] && [ "$resolved_scope" = "studio" ]; then
+  printf 'error: --scope project conflicts with studio destination %s\n' "$destination_project" >&2
+  exit 2
+fi
+
+artifact_kind=project-ingest
+artifact_root="$(resolve_project_root_for "$destination_project")/ingest"
+public_issue_repo=null
+requires_privacy_scrub=false
+
+if [ "$resolved_scope" = "studio" ]; then
+  artifact_kind=studio-ingest
+  artifact_root="$(resolve_feedback_inbox_for "$source_project")"
+  public_issue_repo='"v-i-s-h-a-l/generic-dev-studio"'
+  if [ "$source_project" != "generic-dev-studio" ]; then
+    requires_privacy_scrub=true
+  fi
+fi
+
+jq -n \
+  --arg source_project "$source_project" \
+  --arg source_root "$source_root" \
+  --arg destination_project "$destination_project" \
+  --arg scope "$resolved_scope" \
+  --arg artifact_kind "$artifact_kind" \
+  --arg artifact_root "$artifact_root" \
+  --argjson public_issue_repo "$public_issue_repo" \
+  --argjson requires_privacy_scrub "$requires_privacy_scrub" \
+  --arg message_file "$message_file" \
+  '{
+    kind: "dev-studio-ingest-route",
+    schema_version: 1,
+    source_project: $source_project,
+    source_root: $source_root,
+    destination_project: $destination_project,
+    scope: $scope,
+    artifact_kind: $artifact_kind,
+    artifact_root: $artifact_root,
+    public_issue_repo: $public_issue_repo,
+    requires_privacy_scrub: $requires_privacy_scrub,
+    message_file: (if $message_file == "" then null else $message_file end),
+    local_ingest_policy: "project-profile"
+  }'

--- a/scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
+++ b/scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUN="$ROOT/scripts/dev-studio-ingest-resolve.sh"
+TMPROOT=$(mktemp -d -t ingest-resolver.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+make_repo() {
+  local path="$1"
+  mkdir -p "$path"
+  git -C "$path" init -q
+}
+
+[ -x "$RUN" ] || fail "scripts/dev-studio-ingest-resolve.sh is not executable"
+
+make_repo "$TMPROOT/generic-dev-studio"
+make_repo "$TMPROOT/sample-app"
+printf 'workflow gap\n' > "$TMPROOT/message.md"
+
+studio_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/generic-dev-studio")
+printf '%s\n' "$studio_json" | jq -e \
+  --arg home "$TMPROOT/home" \
+  '.kind == "dev-studio-ingest-route"
+   and .schema_version == 1
+   and .source_project == "generic-dev-studio"
+   and .destination_project == "generic-dev-studio"
+   and .scope == "studio"
+   and .artifact_kind == "studio-ingest"
+   and .artifact_root == ($home + "/.dev-studio/generic-dev-studio/feedback-inbox/generic-dev-studio")
+   and .public_issue_repo == "v-i-s-h-a-l/generic-dev-studio"
+   and .requires_privacy_scrub == false
+   and .local_ingest_policy == "project-profile"' >/dev/null || {
+  printf '%s\n' "$studio_json" >&2
+  fail "studio repo default route was not Forge/Studio"
+}
+
+project_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app")
+printf '%s\n' "$project_json" | jq -e \
+  --arg home "$TMPROOT/home" \
+  '.source_project == "sample-app"
+   and .destination_project == "sample-app"
+   and .scope == "project"
+   and .artifact_kind == "project-ingest"
+   and .artifact_root == ($home + "/.dev-studio/sample-app/ingest")
+   and .public_issue_repo == null
+   and .requires_privacy_scrub == false' >/dev/null || {
+  printf '%s\n' "$project_json" >&2
+  fail "project repo default route was not project-local"
+}
+
+cross_scope_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --scope studio --message-file "$TMPROOT/message.md")
+printf '%s\n' "$cross_scope_json" | jq -e \
+  --arg msg "$TMPROOT/message.md" \
+  '.source_project == "sample-app"
+   and .destination_project == "generic-dev-studio"
+   and .scope == "studio"
+   and .artifact_kind == "studio-ingest"
+   and .public_issue_repo == "v-i-s-h-a-l/generic-dev-studio"
+   and .requires_privacy_scrub == true
+   and .message_file == $msg' >/dev/null || {
+  printf '%s\n' "$cross_scope_json" >&2
+  fail "--scope studio did not route cross-context to Forge"
+}
+
+cross_to_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --to generic-dev-studio)
+printf '%s\n' "$cross_to_json" | jq -e \
+  '.destination_project == "generic-dev-studio"
+   and .scope == "studio"
+   and .requires_privacy_scrub == true' >/dev/null || {
+  printf '%s\n' "$cross_to_json" >&2
+  fail "--to generic-dev-studio did not route cross-context to Forge"
+}
+
+explicit_project_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --to other-app)
+printf '%s\n' "$explicit_project_json" | jq -e \
+  '.destination_project == "other-app"
+   and .scope == "project"
+   and .artifact_kind == "project-ingest"
+   and .requires_privacy_scrub == false' >/dev/null || {
+  printf '%s\n' "$explicit_project_json" >&2
+  fail "--to other-app did not remain project-scoped"
+}
+
+if HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --scope project --to generic-dev-studio >"$TMPROOT/ingest-conflict.out" 2>"$TMPROOT/ingest-conflict.err"; then
+  fail "conflicting project scope and studio destination should fail"
+fi
+grep -q 'conflicts with studio destination' "$TMPROOT/ingest-conflict.err" || {
+  cat "$TMPROOT/ingest-conflict.err" >&2
+  fail "conflict error was not actionable"
+}
+
+if HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/generic-dev-studio" --scope project --to generic-dev-studio >"$TMPROOT/studio-conflict.out" 2>"$TMPROOT/studio-conflict.err"; then
+  fail "explicit project scope and studio destination should fail in studio repo"
+fi
+grep -q 'conflicts with studio destination' "$TMPROOT/studio-conflict.err" || {
+  cat "$TMPROOT/studio-conflict.err" >&2
+  fail "studio conflict error was not actionable"
+}
+
+printf 'PASS: dev-studio ingest resolver\n'


### PR DESCRIPTION
## Summary

- Add `scripts/dev-studio-ingest-resolve.sh`, a JSON resolver for `/dev-studio manager ingest` destination semantics.
- Default ingest follows the current git repo; explicit `--scope studio` or `--to generic-dev-studio` routes to Forge and marks cross-project privacy scrub.
- Update router/docs surfaces to point at the resolver and document that project profiles choose the local ingest backend.

Closes #578.

## Verification

- `scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh`
- `bash -n scripts/dev-studio-ingest-resolve.sh scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh`
- `scripts/lint-skill-prose.sh core/v2/skills/dev-studio/SKILL.md`
- `scripts/lint-mode-pack.sh core/v2/skills/dev-studio/SKILL.md`
- `git diff --check`
- `scripts/pre-commit-review.sh` (approved)
- `scripts/lint-host-agnostic.sh` (0 errors; existing `W_ARGUS_SECRET_SCOPE` warning)

## Review

- REVIEW.md R1/R2/R3/R4/R5/R6/R7/R11/R12/R13/R14 checked.
- Portable: yes.
