### PR TITLE
Honor summary failures for parent finalize

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T19:25:08Z",
+  "generated_at": "2026-05-04T19:37:33Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T19:25:08Z",
+  "generated_at": "2026-05-04T19:37:32Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -85,6 +85,34 @@ chain_git_parent_finalize_summary_eligible() {
   ' "$summary_file" >/dev/null 2>&1
 }
 
+chain_git_parent_finalize_summary_reports_failure() {
+  local summary_file="${1:?usage: chain_git_parent_finalize_summary_reports_failure <summary-file>}"
+  [ -f "$summary_file" ] || return 1
+  jq -e '
+    (((.exit_code // 0) | tonumber? // 0) != 0)
+    or (((.status // "") | ascii_downcase) | test("^(blocked|failed)$"))
+  ' "$summary_file" >/dev/null 2>&1
+}
+
+chain_git_parent_finalize_effective_worker_rc() {
+  local worker_rc="${1:?usage: chain_git_parent_finalize_effective_worker_rc <worker-rc> <summary-file>}"
+  local summary_file="${2:?summary file required}" summary_rc
+  if [ "$worker_rc" -ne 0 ]; then
+    printf '%s\n' "$worker_rc"
+    return 0
+  fi
+  summary_rc=$(jq -r '((.exit_code // 0) | tonumber? // 0)' "$summary_file" 2>/dev/null || printf '0')
+  if [ "$summary_rc" -ne 0 ] 2>/dev/null; then
+    printf '%s\n' "$summary_rc"
+    return 0
+  fi
+  if chain_git_parent_finalize_summary_reports_failure "$summary_file"; then
+    printf '1\n'
+    return 0
+  fi
+  printf '0\n'
+}
+
 chain_git_parent_finalize_has_public_diff() {
   local issue_worktree="${1:?usage: chain_git_parent_finalize_has_public_diff <issue-worktree>}"
   git -C "$issue_worktree" status --porcelain --untracked-files=all -- \

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -2292,7 +2292,7 @@ write_issue_phase_outcome_artifact() {
 
 run_issue_job() {
   local name="$1" branch="$2" chain_worktree="$3" issue="$4" host="$5" git_metadata_strategy="$6" issue_worktree="$7" issue_branch="$8" chain_run_id="$9" issue_run_id="${10}" result_file="${11}" phase_review_mode="${12:-auto}" issue_count_for_review="${13:-1}"
-  local before after worker_rc child_worker_rc summary_file issue_duration summary_payload issue_started_at child_reason_id child_blocked_reason parent_finalized
+  local before after worker_rc child_worker_rc summary_file issue_duration summary_payload issue_started_at child_reason_id child_blocked_reason parent_finalized effective_worker_rc
   local phase_context boundary_id phase_plan_artifact phase_outcome_artifact phase_review_rc phase_review_reason
   issue_started_at=$(now_epoch)
   parent_finalized=false
@@ -2364,6 +2364,7 @@ run_issue_job() {
 
   after=$(git -C "$issue_worktree" rev-parse HEAD)
   summary_file=$(ingest_worker_summary "$name" "$issue" "$host" "$issue_worktree" "$before" "$after" "$worker_rc" "$issue_started_at" "$chain_run_id" "$issue_run_id")
+  effective_worker_rc=$(chain_git_parent_finalize_effective_worker_rc "$worker_rc" "$summary_file")
   write_decision_escrows_from_summary "$summary_file" || log "decision escrow extraction failed for $summary_file"
   issue_duration=$(duration_since "$issue_started_at")
 
@@ -2377,7 +2378,7 @@ run_issue_job() {
   fi
 
   rm -rf "$issue_worktree/.studio"
-  if [ "$worker_rc" -ne 0 ] && [ "$after" = "$before" ] \
+  if [ "$effective_worker_rc" -ne 0 ] && [ "$after" = "$before" ] \
     && chain_git_parent_finalize_summary_eligible "$summary_file" \
     && chain_git_parent_finalize_has_public_diff "$issue_worktree"; then
     log "issue #$issue worker could not write git metadata; parent finalizing commit"
@@ -2391,6 +2392,10 @@ run_issue_job() {
     else
       log "issue #$issue parent finalize declined; preserving worker failure path"
     fi
+  fi
+
+  if [ "$worker_rc" -eq 0 ] && [ "$effective_worker_rc" -ne 0 ]; then
+    worker_rc="$effective_worker_rc"
   fi
 
   summary_payload=$(jq -c \

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -78,6 +78,13 @@ printf 'node_modules/\n' > "$REPO/.gitignore"
 
 chain_git_parent_finalize_summary_eligible "$REPO/.studio/chain-worker-summary.json" \
   || fail "git metadata summary was not eligible"
+chain_git_parent_finalize_summary_reports_failure "$REPO/.studio/chain-worker-summary.json" \
+  || fail "blocked summary was not reported as failure"
+[ "$(chain_git_parent_finalize_effective_worker_rc 0 "$REPO/.studio/chain-worker-summary.json")" = "1" ] \
+  || fail "summary-reported failure did not override zero host rc"
+cat "$REPO/.studio/chain-worker-summary.json" | jq '.exit_code = 0' > "$TMPROOT/status-only-summary.json"
+[ "$(chain_git_parent_finalize_effective_worker_rc 0 "$TMPROOT/status-only-summary.json")" = "1" ] \
+  || fail "blocked status did not override zero host rc"
 chain_git_parent_finalize_has_public_diff "$REPO" \
   || fail "public diff was not detected"
 chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-summary.json" \


### PR DESCRIPTION
## Summary
- let parent-finalize use a worker summary's blocked/failed status or nonzero exit_code when the host process exits zero
- preserve the existing eligible-summary plus public-diff gate before any parent commit
- add fixture coverage for summary-reported git metadata failures

## Verification
- scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- bash -n scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- scripts/lint-host-agnostic.sh
- scripts/lint-host-agnostic.sh --staged
- git diff --check

Closes #592