### PR TITLE
Accept alternate-git clean outcomes for parent finalize

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T19:37:33Z",
+  "generated_at": "2026-05-04T19:51:04Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T19:37:32Z",
+  "generated_at": "2026-05-04T19:51:04Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -68,7 +68,7 @@ chain_git_parent_finalize_summary_eligible() {
     def checks: ((.tests // []) + (.lints // []) + (.builds // []));
     def clean_outcome($v):
       (($v.outcome // $v.status // "") | ascii_downcase)
-      | test("^(pass|passed|passed_with_warning|ok|success|succeeded|skipped)$");
+      | test("^(pass|passed|passed_with_warning|passed_before_alternate_commit|ok|success|succeeded|skipped)$");
     def unsafe_parent_finalize_note:
       ascii_downcase as $line
       | (($line | test("destructive|unrelated issue|scope cannot|review failed"))

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -54,6 +54,7 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
   "tests": [{"command": "fixture", "outcome": "passed"}],
   "lints": [
     {"command": "git diff --check", "outcome": "passed_with_warning"},
+    {"command": "git diff --cached --check in alternate git dir", "outcome": "passed_before_alternate_commit"},
     {
       "command": "scripts/lint-host-agnostic.sh",
       "outcome": "passed_with_warning",
@@ -142,6 +143,20 @@ cat > "$TMPROOT/failing/.studio/chain-worker-summary.json" <<'JSON'
 JSON
 if chain_git_parent_finalize_summary_eligible "$TMPROOT/failing/.studio/chain-worker-summary.json"; then
   fail "failing checks were eligible"
+fi
+
+mkdir -p "$TMPROOT/unknown-outcome/.studio"
+cat > "$TMPROOT/unknown-outcome/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "blocked_reason": "Unable to stage or commit: .git/index.lock Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "passed_after_retry"}]
+}
+JSON
+if chain_git_parent_finalize_summary_eligible "$TMPROOT/unknown-outcome/.studio/chain-worker-summary.json"; then
+  fail "unknown passed_* outcome was eligible"
 fi
 
 mkdir -p "$TMPROOT/secret/.studio"


### PR DESCRIPTION
## Summary
- admit the explicit `passed_before_alternate_commit` check outcome for parent-finalize eligibility
- extend the parent-finalize fixture to cover this summary shape and reject unknown `passed_*` variants

## Verification
- `scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `bash -n scripts/lib-chain-git.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `scripts/lint-host-agnostic.sh` (existing W_ARGUS_SECRET_SCOPE warning)
- `scripts/lint-host-agnostic.sh --staged` (existing W_ARGUS_SECRET_SCOPE warning)
- `git diff --check` / `git diff --cached --check`

Closes #594