### PR TITLE
Treat successful parent finalize as issue success

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T19:51:04Z",
+  "generated_at": "2026-05-04T20:04:33Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T19:51:04Z",
+  "generated_at": "2026-05-04T20:04:32Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -113,6 +113,21 @@ chain_git_parent_finalize_effective_worker_rc() {
   printf '0\n'
 }
 
+chain_git_parent_finalize_reconciled_worker_rc() {
+  local worker_rc="${1:?usage: chain_git_parent_finalize_reconciled_worker_rc <worker-rc> <effective-worker-rc> <parent-finalized>}"
+  local effective_worker_rc="${2:?effective worker rc required}"
+  local parent_finalized="${3:-false}"
+  if [ "$parent_finalized" = true ]; then
+    printf '0\n'
+    return 0
+  fi
+  if [ "$worker_rc" -eq 0 ] && [ "$effective_worker_rc" -ne 0 ]; then
+    printf '%s\n' "$effective_worker_rc"
+    return 0
+  fi
+  printf '%s\n' "$worker_rc"
+}
+
 chain_git_parent_finalize_has_public_diff() {
   local issue_worktree="${1:?usage: chain_git_parent_finalize_has_public_diff <issue-worktree>}"
   git -C "$issue_worktree" status --porcelain --untracked-files=all -- \

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -2394,9 +2394,7 @@ run_issue_job() {
     fi
   fi
 
-  if [ "$worker_rc" -eq 0 ] && [ "$effective_worker_rc" -ne 0 ]; then
-    worker_rc="$effective_worker_rc"
-  fi
+  worker_rc=$(chain_git_parent_finalize_reconciled_worker_rc "$worker_rc" "$effective_worker_rc" "$parent_finalized")
 
   summary_payload=$(jq -c \
     --arg summary "$summary_file" \

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -83,6 +83,12 @@ chain_git_parent_finalize_summary_reports_failure "$REPO/.studio/chain-worker-su
   || fail "blocked summary was not reported as failure"
 [ "$(chain_git_parent_finalize_effective_worker_rc 0 "$REPO/.studio/chain-worker-summary.json")" = "1" ] \
   || fail "summary-reported failure did not override zero host rc"
+[ "$(chain_git_parent_finalize_reconciled_worker_rc 0 1 false)" = "1" ] \
+  || fail "effective worker rc was not preserved before parent finalize"
+[ "$(chain_git_parent_finalize_reconciled_worker_rc 0 1 true)" = "0" ] \
+  || fail "effective worker rc was reapplied after parent finalize"
+[ "$(chain_git_parent_finalize_reconciled_worker_rc 1 1 true)" = "0" ] \
+  || fail "child worker rc was not cleared after parent finalize"
 cat "$REPO/.studio/chain-worker-summary.json" | jq '.exit_code = 0' > "$TMPROOT/status-only-summary.json"
 [ "$(chain_git_parent_finalize_effective_worker_rc 0 "$TMPROOT/status-only-summary.json")" = "1" ] \
   || fail "blocked status did not override zero host rc"


### PR DESCRIPTION
## Summary
- add a testable rc reconciliation helper for parent-finalize
- keep effective worker failures only when parent-finalize did not commit
- cover the successful parent-finalize path in the parent-finalize fixture

## Verification
- `scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `bash -n scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `scripts/lint-host-agnostic.sh` (existing W_ARGUS_SECRET_SCOPE warning)
- `scripts/lint-host-agnostic.sh --staged` (existing W_ARGUS_SECRET_SCOPE warning)
- `git diff --check` / `git diff --cached --check`

Closes #596