### PR TITLE
Accept detailed parent-finalize warning outcomes

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T20:04:33Z",
+  "generated_at": "2026-05-04T20:31:01Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T20:04:32Z",
+  "generated_at": "2026-05-04T20:31:01Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -68,7 +68,12 @@ chain_git_parent_finalize_summary_eligible() {
     def checks: ((.tests // []) + (.lints // []) + (.builds // []));
     def clean_outcome($v):
       (($v.outcome // $v.status // "") | ascii_downcase)
+      | sub(":.*$"; "")
       | test("^(pass|passed|passed_with_warning|passed_before_alternate_commit|ok|success|succeeded|skipped)$");
+    def check_note($v):
+      [($v.command // ""), ($v.outcome // $v.status // ""), ($v.warning // ""), ($v.notes // "")]
+      | map(tostring)
+      | join(" ");
     def unsafe_parent_finalize_note:
       ascii_downcase as $line
       | (($line | test("destructive|unrelated issue|scope cannot|review failed"))
@@ -79,7 +84,7 @@ chain_git_parent_finalize_summary_eligible() {
     and ((.blocked_reason // "") | ascii_downcase
       | (test("git|\\.git|index\\.lock|stage|staging|commit")
          and test("operation not permitted|permission denied|unwritable|denies writes|cannot write|failed creating")))
-    and all(((text(.carryover) + "\n" + text(.lessons)) | split("\n")[]?); (unsafe_parent_finalize_note | not))
+    and all((((text(.carryover) + "\n" + text(.lessons)) | split("\n")) + [checks[]? | check_note(.)])[]?; (unsafe_parent_finalize_note | not))
     and ((checks | length) > 0)
     and all(checks[]; clean_outcome(.))
   ' "$summary_file" >/dev/null 2>&1

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -57,8 +57,7 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
     {"command": "git diff --cached --check in alternate git dir", "outcome": "passed_before_alternate_commit"},
     {
       "command": "scripts/lint-host-agnostic.sh",
-      "outcome": "passed_with_warning",
-      "warning": "W_ARGUS_SECRET_SCOPE:.codex/capabilities.yaml:secret_scope=cwd-only"
+      "outcome": "passed_with_warning: W_ARGUS_SECRET_SCOPE:.codex/capabilities.yaml:secret_scope=cwd-only | Argus dispatch on this host requires secret_scope: none"
     }
   ],
   "builds": [],
@@ -178,6 +177,21 @@ cat > "$TMPROOT/secret/.studio/chain-worker-summary.json" <<'JSON'
 JSON
 if chain_git_parent_finalize_summary_eligible "$TMPROOT/secret/.studio/chain-worker-summary.json"; then
   fail "real secret blocker was eligible"
+fi
+
+mkdir -p "$TMPROOT/secret-warning/.studio"
+cat > "$TMPROOT/secret-warning/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "blocked_reason": "Unable to stage or commit: .git/index.lock Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "passed"}],
+  "lints": [{"command": "secret scan", "outcome": "passed_with_warning: potential secret exposure needs review"}]
+}
+JSON
+if chain_git_parent_finalize_summary_eligible "$TMPROOT/secret-warning/.studio/chain-worker-summary.json"; then
+  fail "secret-looking warning outcome was eligible"
 fi
 
 printf 'PASS: chain parent-finalize commit fallback\n'


### PR DESCRIPTION
## Summary

- Accept `passed_with_warning: ...` and other allow-listed detailed success outcomes during parent-finalize eligibility.
- Apply the existing unsafe-text filter to detailed check messages so secret-looking warning details still block unless they are the known secret-scope lint warning.
- Extend the parent-finalize fixture for detailed `W_ARGUS_SECRET_SCOPE` and a rejected secret-looking warning detail.

## Verification

- `bash scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `bash -n scripts/lib-chain-git.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `scripts/lint-host-agnostic.sh --staged` (existing `W_ARGUS_SECRET_SCOPE` warning)
- `git diff --cached --check`

Closes #598