### PR TITLE
Accept alternate metadata parent-finalize summaries

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T20:31:01Z",
+  "generated_at": "2026-05-04T20:46:18Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T20:31:01Z",
+  "generated_at": "2026-05-04T20:46:17Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -74,16 +74,25 @@ chain_git_parent_finalize_summary_eligible() {
       [($v.command // ""), ($v.outcome // $v.status // ""), ($v.warning // ""), ($v.notes // "")]
       | map(tostring)
       | join(" ");
+    def primary_commit_after:
+      (.commit_or_pr_references.commit_after // .primary_commit_after // .primary_git_commit_after // "");
+    def alternate_metadata_note:
+      (text(.blocked_reason) + "\n" + text(.carryover) + "\n" + text(.lessons))
+      | ascii_downcase
+      | test("alternate|copied git|writable copied|\\.git\\.codex|primary metadata|primary \\.git|original \\.git|primary.*head.*remain");
+    def no_primary_commit:
+      ((.commit_after // null) == null or (.commit_after // "") == "" or (.commit_after == .commit_before))
+      or (primary_commit_after == .commit_before and alternate_metadata_note);
     def unsafe_parent_finalize_note:
       ascii_downcase as $line
       | (($line | test("destructive|unrelated issue|scope cannot|review failed"))
          or (($line | test("secret"))
              and (($line | test("w_argus_secret_scope|secret-scope|secret_scope")) | not)));
     (((.status // "") | ascii_downcase) | test("^(blocked|failed)$"))
-    and ((.commit_after // null) == null or (.commit_after // "") == "" or (.commit_after == .commit_before))
+    and no_primary_commit
     and ((.blocked_reason // "") | ascii_downcase
       | (test("git|\\.git|index\\.lock|stage|staging|commit")
-         and test("operation not permitted|permission denied|unwritable|denies writes|cannot write|failed creating")))
+         and test("operation not permitted|permission denied|unwritable|not writable|denies writes|cannot write|failed creating")))
     and all((((text(.carryover) + "\n" + text(.lessons)) | split("\n")) + [checks[]? | check_note(.)])[]?; (unsafe_parent_finalize_note | not))
     and ((checks | length) > 0)
     and all(checks[]; clean_outcome(.))

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -91,6 +91,17 @@ chain_git_parent_finalize_summary_reports_failure "$REPO/.studio/chain-worker-su
 cat "$REPO/.studio/chain-worker-summary.json" | jq '.exit_code = 0' > "$TMPROOT/status-only-summary.json"
 [ "$(chain_git_parent_finalize_effective_worker_rc 0 "$TMPROOT/status-only-summary.json")" = "1" ] \
   || fail "blocked status did not override zero host rc"
+cat "$REPO/.studio/chain-worker-summary.json" | jq '
+  .commit_after = "alternate-meta-commit"
+  | .commit_or_pr_references = {commit_after: .commit_before}
+  | .blocked_reason = "Committed to .git.codex-meta, but primary .git HEAD remains at commit_before because primary metadata is not writable."
+' > "$TMPROOT/alternate-meta-summary.json"
+chain_git_parent_finalize_summary_eligible "$TMPROOT/alternate-meta-summary.json" \
+  || fail "alternate metadata commit summary was not eligible"
+cat "$TMPROOT/alternate-meta-summary.json" | jq '.commit_or_pr_references.commit_after = "primary-advanced"' > "$TMPROOT/primary-advanced-summary.json"
+if chain_git_parent_finalize_summary_eligible "$TMPROOT/primary-advanced-summary.json"; then
+  fail "primary-advanced alternate metadata summary was eligible"
+fi
 chain_git_parent_finalize_has_public_diff "$REPO" \
   || fail "public diff was not detected"
 chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-summary.json" \


### PR DESCRIPTION
## Summary

- Treat alternate/copied git metadata commits as parent-finalize eligible only when the primary commit reference remains at `commit_before`.
- Extend git-unwritable matching for `not writable` summaries.
- Add fixture coverage for eligible alternate metadata summaries and rejected primary-advanced summaries.

## Verification

- `bash scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `bash -n scripts/lib-chain-git.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `scripts/lint-host-agnostic.sh --staged` (existing `W_ARGUS_SECRET_SCOPE` warning)
- `git diff --cached --check`

Closes #601