### PR TITLE
Review quality follow-ups: evidence and self-review gates

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -127,6 +127,8 @@ Every completion-style claim in a debrief (YAML or prose) must cite a specific, 
 
 When a reviewer accepts worker evidence instead of rerunning, the verdict must say `verified_by_worker_evidence` and cite the evidence. When a reviewer reruns, the verdict must say `independently_rerun_by_reviewer` and include the command, timestamp, and result. Do not collapse both into "tests pass"; downstream sessions need the confidence level and cost model. Gates that mandate independent reruns must document why the added latency is worth it, what failure mode it catches, and when the rerun can be skipped or made async.
 
+**Same-host self-review gate (issue #605).** Worker outputs must show `self_review_performed`, `self_review_findings`, `self_review_fixes`, and `final_verification_evidence`; planner outputs must show `self_review_performed`, `self_review_findings`, and `self_review_fixes` before cross-host plan review. Reviewers inspect those fields before requesting extra reruns. Missing self-review is a workflow defect: flag as `warn` when risk is low and block when the target is non-trivial, risky, or final verification claims depend on the missing review.
+
 ### R11 — No studio-initiated pushes to base branches (tier: **block + auto-fix**)
 
 Scripts and mode prose must never run `git push origin main` (or `master`, or any equivalent integration/base branch) against a project or studio repo. Remote base branches advance **only** through PR merges. Studio-initiated pushes may target feature branches (`push -u origin HEAD`, `push origin <feature-branch>`) or tags (`push origin <tag>`). Integration happens via `gh pr create` / `gh pr merge`, never direct ref advancement.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -116,6 +116,17 @@ Every completion-style claim in a debrief (YAML or prose) must cite a specific, 
 
 **Gate taxonomy (issue #84).** The `brief_completed.gate` event field distinguishes four outcomes: `verified` (build green + tests ran + Argus approved), `build-only` (build green, suite disabled), `waived` (build green, Argus skipped on a non-exempt path), `lsp-only` (LSP gate). Use this vocabulary in reviews + debriefs — "full-green" is legacy and ambiguous. A debrief reading `gate: build-only` or `gate: waived` without a matching explanation in `key_learnings` / `decisions` is an R10 hit: the structural signal is present but the WHY is missing. See `_shared/contracts/events.md` → `brief_completed.gate` taxonomy for source-signal rules.
 
+**Reviewer test rerun policy (issue #604).** R10 requires trustworthy, fresh verification evidence; it does not require reviewers to blindly repeat a worker's test command. Reviewers inspect the worker evidence first: exact command, timestamp, exit status or pass/fail output, environment, commit or diff covered, and whether the suite reaches the changed surface. A reviewer reruns tests only when one of these is true:
+
+- Evidence is missing, stale, incomplete, or not tied to the reviewed diff.
+- The diff changed after the worker's verification run.
+- The worker ran only a narrow suite and the changed surface needs broader coverage.
+- The command is cheap and high-value for the reviewed risk.
+- The change is risky enough that independent reproduction materially changes confidence.
+- The reviewer needs to reproduce a suspicious pass, failure, flake, or environment-dependent result.
+
+When a reviewer accepts worker evidence instead of rerunning, the verdict must say `verified_by_worker_evidence` and cite the evidence. When a reviewer reruns, the verdict must say `independently_rerun_by_reviewer` and include the command, timestamp, and result. Do not collapse both into "tests pass"; downstream sessions need the confidence level and cost model. Gates that mandate independent reruns must document why the added latency is worth it, what failure mode it catches, and when the rerun can be skipped or made async.
+
 ### R11 — No studio-initiated pushes to base branches (tier: **block + auto-fix**)
 
 Scripts and mode prose must never run `git push origin main` (or `master`, or any equivalent integration/base branch) against a project or studio repo. Remote base branches advance **only** through PR merges. Studio-initiated pushes may target feature branches (`push -u origin HEAD`, `push origin <feature-branch>`) or tags (`push origin <tag>`). Integration happens via `gh pr create` / `gh pr merge`, never direct ref advancement.

--- a/_shared/contracts/debrief.schema.json
+++ b/_shared/contracts/debrief.schema.json
@@ -333,6 +333,27 @@
         "$ref": "worker-report.schema.json#/$defs/reviewResponse"
       }
     },
+    "self_review_performed": {
+      "type": "boolean"
+    },
+    "self_review_findings": {
+      "type": "array",
+      "items": {
+        "$ref": "worker-report.schema.json#/$defs/selfReviewFinding"
+      }
+    },
+    "self_review_fixes": {
+      "type": "array",
+      "items": {
+        "$ref": "worker-report.schema.json#/$defs/selfReviewFix"
+      }
+    },
+    "final_verification_evidence": {
+      "type": "array",
+      "items": {
+        "$ref": "worker-report.schema.json#/$defs/finalVerificationEvidence"
+      }
+    },
     "refactoring_pressure": {
       "$ref": "worker-report.schema.json#/$defs/refactoringPressure"
     }

--- a/_shared/contracts/review-verdict.schema.json
+++ b/_shared/contracts/review-verdict.schema.json
@@ -201,6 +201,59 @@
         }
       }
     },
+    "evidence_reviewed": {
+      "type": "array",
+      "description": "Evidence inspected for the verdict. Test/build entries distinguish worker evidence from independent reviewer reruns.",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "verification_source",
+          "command",
+          "result",
+          "timestamp"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "build",
+              "tests",
+              "lint",
+              "runtime",
+              "review-artifact",
+              "other"
+            ]
+          },
+          "verification_source": {
+            "enum": [
+              "verified_by_worker_evidence",
+              "independently_rerun_by_reviewer",
+              "reviewed_non_test_evidence"
+            ]
+          },
+          "command": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "result": {
+            "type": "string",
+            "minLength": 1
+          },
+          "timestamp": {
+            "$ref": "debrief.schema.json#/$defs/rfc3339"
+          },
+          "note": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "maxLength": 500
+          }
+        }
+      }
+    },
     "scope": {
       "type": "object",
       "required": [

--- a/_shared/contracts/review-verdict.schema.json
+++ b/_shared/contracts/review-verdict.schema.json
@@ -254,6 +254,91 @@
         }
       }
     },
+    "self_review_checked": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Reviewer inspection of the producer's same-host self-review gate. Required by role contract for worker and planner targets.",
+      "required": [
+        "applicable",
+        "self_review_performed",
+        "artifact_refs",
+        "findings_reviewed",
+        "fixes_reviewed",
+        "absence_disposition"
+      ],
+      "properties": {
+        "applicable": {
+          "type": "boolean"
+        },
+        "self_review_performed": {
+          "type": "boolean"
+        },
+        "artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "findings_reviewed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fixes_reviewed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "absence_disposition": {
+          "enum": [
+            "not_applicable",
+            "none",
+            "warn",
+            "block"
+          ]
+        },
+        "note": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 500
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "applicable": { "const": false }
+            },
+            "required": ["applicable"]
+          },
+          "then": {
+            "properties": {
+              "absence_disposition": { "const": "not_applicable" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "applicable": { "const": true },
+              "self_review_performed": { "const": false }
+            },
+            "required": ["applicable", "self_review_performed"]
+          },
+          "then": {
+            "properties": {
+              "absence_disposition": {
+                "enum": [
+                  "warn",
+                  "block"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
     "scope": {
       "type": "object",
       "required": [
@@ -482,6 +567,17 @@
           "result": "pass"
         }
       ],
+      "self_review_checked": {
+        "applicable": true,
+        "self_review_performed": true,
+        "artifact_refs": [
+          "plans/self-reviews/0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11.yaml"
+        ],
+        "findings_reviewed": 0,
+        "fixes_reviewed": 0,
+        "absence_disposition": "none",
+        "note": null
+      },
       "scope": {
         "context_scopes": ["diff-only", "task-context"],
         "diff_size": 187,

--- a/_shared/contracts/worker-report.md
+++ b/_shared/contracts/worker-report.md
@@ -63,6 +63,33 @@ review_loop:
 
 Budget is two fix cycles per bounded task. A third review attempt, conflicting findings, or repeated high-risk uncertain findings sets `escalation_required: true` with `escalation_reason` and routes to manager/planner arbitration. This preserves blockers for real correctness, contract, and regression risks while preventing local review churn from rewriting the original plan.
 
+## Same-host self-review gate
+
+Workers run same-host self-review after implementation and before final verification. The review is a reasoning gate, not a second test pass: it checks missed edge cases, possible bugs, regressions, scope drift, and test adequacy. Material findings are fixed or recorded as blocked before final verification starts, so the final test/build/lint evidence is captured once after the reviewed fixes.
+
+Worker summaries and debriefs distinguish the gate from external reviewer responses:
+
+```yaml
+self_review_performed: true
+self_review_findings:
+  - id: SR1
+    focus: edge_case
+    finding: "Empty input path was not covered by the first implementation."
+    severity: material
+    disposition: fixed
+self_review_fixes:
+  - finding_id: SR1
+    action: fixed
+    summary: "Added the empty-input guard before final verification."
+final_verification_evidence:
+  - command: "scripts/test-fixtures/605-self-review-gate/test-self-review-gate.sh"
+    outcome: pass
+    timestamp: 2026-05-05T01:30:00Z
+    after_self_review_fixes: true
+```
+
+External reviewers inspect these fields before deciding whether to rerun tests. Missing same-host self-review is a workflow defect; reviewers record it as a warn or block depending on the review target and risk.
+
 ## Refactoring pressure protocol
 
 Worker self-review records refactoring pressure without turning every task into a cleanup task:

--- a/_shared/contracts/worker-report.schema.json
+++ b/_shared/contracts/worker-report.schema.json
@@ -21,6 +21,31 @@
         "$ref": "#/$defs/reviewResponse"
       }
     },
+    "self_review_performed": {
+      "type": "boolean",
+      "description": "True when the same-host self-review gate ran after implementation and before final verification."
+    },
+    "self_review_findings": {
+      "type": "array",
+      "description": "Same-host self-review findings focused on missed edge cases, possible bugs, regressions, scope drift, and test adequacy.",
+      "items": {
+        "$ref": "#/$defs/selfReviewFinding"
+      }
+    },
+    "self_review_fixes": {
+      "type": "array",
+      "description": "Fixes made because of same-host self-review findings, or recorded non-fix dispositions.",
+      "items": {
+        "$ref": "#/$defs/selfReviewFix"
+      }
+    },
+    "final_verification_evidence": {
+      "type": "array",
+      "description": "Final verification run after same-host self-review fixes. This is the evidence reviewers inspect before deciding whether to rerun anything.",
+      "items": {
+        "$ref": "#/$defs/finalVerificationEvidence"
+      }
+    },
     "refactoring_pressure": {
       "$ref": "#/$defs/refactoringPressure"
     }
@@ -195,6 +220,126 @@
           }
         }
       ]
+    },
+    "selfReviewFinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "focus",
+        "finding",
+        "severity",
+        "disposition"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "focus": {
+          "enum": [
+            "edge_case",
+            "possible_bug",
+            "regression",
+            "scope_drift",
+            "test_adequacy",
+            "acceptance_criteria",
+            "hidden_dependency",
+            "other"
+          ]
+        },
+        "finding": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "enum": [
+            "material",
+            "minor",
+            "none"
+          ]
+        },
+        "disposition": {
+          "enum": [
+            "fixed",
+            "not_applicable",
+            "deferred_follow_up",
+            "blocked"
+          ]
+        },
+        "evidence_ref": {
+          "type": "string"
+        }
+      }
+    },
+    "selfReviewFix": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "finding_id",
+        "action",
+        "summary"
+      ],
+      "properties": {
+        "finding_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "enum": [
+            "fixed",
+            "not_applicable",
+            "deferred_follow_up",
+            "blocked"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "commit": {
+          "type": "string"
+        },
+        "follow_up_ref": {
+          "type": "string"
+        }
+      }
+    },
+    "finalVerificationEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command",
+        "outcome",
+        "timestamp",
+        "after_self_review_fixes"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcome": {
+          "enum": [
+            "pass",
+            "fail",
+            "skipped",
+            "blocked"
+          ]
+        },
+        "timestamp": {
+          "$ref": "debrief.schema.json#/$defs/rfc3339"
+        },
+        "after_self_review_fixes": {
+          "const": true
+        },
+        "evidence_ref": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        }
+      }
     },
     "refactoringPressure": {
       "type": "object",

--- a/_shared/rules/review-rules.md
+++ b/_shared/rules/review-rules.md
@@ -119,6 +119,8 @@ To promote a flag check to block: edit the `Block?` column in the check tables b
 3. Evaluate **path coverage**: does the test reach the changed lines, or does it call a wrapper that bypasses them?
 4. Flag tests that call changed functions but assert on unrelated outcomes (marker: false sense of coverage).
 
+**Rerun policy:** inspect worker verification evidence before running tests yourself. Accept fresh worker evidence when it names the command, timestamp, result, environment, covered commit or diff, and suite scope. Rerun only when evidence is missing, stale, diff-stale, too narrow for the changed surface, cheap/high-value, risky enough to justify independent reproduction, or suspicious. Record `verified_by_worker_evidence` or `independently_rerun_by_reviewer` in the verdict so later sessions do not treat both confidence levels as identical.
+
 **Verdict:** Inadequate tests → **flag** with specific test names and what's missing.
 
 | Check | Block? | Notes |

--- a/_shared/rules/review-rules.md
+++ b/_shared/rules/review-rules.md
@@ -79,6 +79,8 @@ To promote a flag check to block: edit the `Block?` column in the check tables b
 
 **Goal:** actively enumerate edge cases the implementation may not handle, then verify test coverage.
 
+**Self-review prerequisite:** before external worker or planner review, inspect the producer's same-host self-review fields. Worker artifacts expose `self_review_performed`, `self_review_findings`, `self_review_fixes`, and `final_verification_evidence`; planner artifacts expose `self_review_performed`, `self_review_findings`, and `self_review_fixes`. Missing self-review is a workflow defect, not a substitute edge-case finding: warn for low-risk targets and block when the target is non-trivial or final verification confidence depends on the missing reasoning gate.
+
 **Procedure:**
 
 1. For each changed function or method in the diff, enumerate candidate edge cases:

--- a/_shared/schemas/debrief.md
+++ b/_shared/schemas/debrief.md
@@ -4,7 +4,7 @@ description: YAML shape for Achilles-authored debriefs under plans/debriefs/<deb
 type: reference
 ---
 
-# Debrief Schema (`debrief@2.6.0`)
+# Debrief Schema (`debrief@2.7.0`)
 
 Per-debrief artifact written to `~/.dev-studio/<project>/plans/debriefs/<debrief-id>.yaml`. Replaces the markdown debriefs that previously landed at `plans/chanakya-inbox/<task-id>-debrief.md`. Authored by Achilles in `task` mode (paired with a brief), Achilles in `debrief` mode (direct-debrief, no brief), or Apollo in any perf-mode (`metrics:` block populated, `executed_with.host` reflects Apollo's surface).
 
@@ -15,7 +15,7 @@ Version 2.0.0 was a breaking change from the legacy markdown format (`contracts/
 ```yaml
 schema_version:
   name: debrief
-  version: 2.6.0
+  version: 2.7.0
   min_reader: 2.0.0
   deprecated_at: null
 id: 0190f52a-79aa-7d02-8b88-33ce5fe65e66        # UUIDv7
@@ -88,6 +88,22 @@ argus_review:
 report_state: done                                # done | done_with_concerns | blocked | needs_context — see contracts/worker-report.md
 review_loop: null                                # optional {attempt, budget, escalation_required, escalation_reason?}
 review_responses: []                             # optional worker dispositions for reviewer findings; see contracts/worker-report.md
+self_review_performed: true                      # optional same-host self-review gate result; required by current worker role contract
+self_review_findings:
+  - id: SR1
+    focus: edge_case                              # edge_case | possible_bug | regression | scope_drift | test_adequacy | acceptance_criteria | hidden_dependency | other
+    finding: "Empty input path was not covered by the first implementation."
+    severity: material                            # material | minor | none
+    disposition: fixed                            # fixed | not_applicable | deferred_follow_up | blocked
+self_review_fixes:
+  - finding_id: SR1
+    action: fixed
+    summary: "Added the empty-input guard before final verification."
+final_verification_evidence:
+  - command: "scripts/test-fixtures/605-self-review-gate/test-self-review-gate.sh"
+    outcome: pass                                 # pass | fail | skipped | blocked
+    timestamp: 2026-05-05T01:30:00Z
+    after_self_review_fixes: true
 refactoring_pressure:                            # optional; see contracts/worker-report.md
   needed_now:
     - kind: localized_cleanup
@@ -163,6 +179,10 @@ metrics: null                                     # 2.2.0; Apollo perf-mode only
 | `report_state` | enum \| absent | no | `done` \| `done_with_concerns` \| `blocked` \| `needs_context`. Worker-report contract — see `contracts/worker-report.md`. Absent in pre-2.0.2 debriefs; readers infer from other fields for back-compat. |
 | `review_loop` | object \| null \| absent | no | Optional review/fix loop budget: `{attempt, budget, escalation_required, escalation_reason?}`. Budget is two fix cycles; attempt ≥3 escalates. |
 | `review_responses` | array \| absent | no | Optional per-finding worker responses: accepted/fixed, modified fix, rejected, escalated, or deferred. Entries consume reviewer risk metadata and include the mandatory worker self-check. |
+| `self_review_performed` | boolean \| absent | no | Optional schema field, required by the current worker role contract for fresh task-mode emits. True only when same-host self-review ran after implementation and before final verification. |
+| `self_review_findings` | array \| absent | no | Same-host self-review findings focused on missed edge cases, possible bugs, regressions, scope drift, and test adequacy. |
+| `self_review_fixes` | array \| absent | no | Fixes or dispositions made from same-host self-review findings before final verification. |
+| `final_verification_evidence` | array \| absent | no | Final test/build/lint evidence captured after self-review fixes. Reviewers inspect this before deciding whether to rerun tests; do not duplicate test reruns by default. |
 | `refactoring_pressure` | object \| absent | no | Optional split between `needed_now[]` refactors the worker performed to keep the current change correct/maintainable and `deferred_follow_ups[]` design-debt opportunities. Deferred entries carry reason, affected area, risk, and suggested timing so the manager can mint explicit follow-up work instead of parsing prose. |
 | `executed_with` | object \| absent | no | 2.1.0; `{model_id, host, session_id, duration_s}`. Producer identity for multi-model accountability. Absent in pre-2.1.0 debriefs; readers MUST tolerate absence and either join `events/<date>.jsonl` `agent_boot` records by `task_id` to fill the gap or treat the executor as unknown. Three of the four fields (`model_id`, `host`, `session_id`) are already produced by `scripts/emit-agent-boot.sh`; `duration_s` is computed from the matching `agent_session_completed` event timestamp delta. |
 | `metrics` | object \| null | yes | 2.2.0; Apollo perf-mode only. Null for Achilles task / direct-debrief debriefs. Populated by Apollo when emitting a perf-mode debrief — carries strict-9 evidence (cohort, baseline, observed, delta, verdict) so Chanakya's ingest path can render perf outcomes without re-reading the underlying `.trace` / MXMetric artifact. Sub-shape documented inline with the example above; refusal subobject populated only when `verdict: refused`. |
@@ -208,6 +228,7 @@ The 141 processed debriefs in `chanakya-inbox/processed/` are **copied as-is** t
 
 | Version | Landed | Changes |
 |---|---|---|
+| 2.7.0 | 2026-05-05 | Non-breaking: optional same-host self-review fields and final verification evidence for #605. The worker role contract requires them for fresh task-mode output before external review. |
 | 2.6.0 | 2026-05-05 | Non-breaking: optional `refactoring_pressure` plus structured refactoring follow-up metadata so worker/planner cleanup concerns can be captured as explicit manager follow-up work (#607). |
 | 2.5.0 | 2026-05-05 | Non-breaking: optional `review_loop` and `review_responses` fields for #606 worker disposition of structured reviewer findings. |
 | 2.4.0 | 2026-05-02 | Non-breaking: `tests.added[]` / `tests.modified[]` items may now be `{title, preconditions?, steps?, expected?}` objects. Legacy string form remains accepted; new task-mode emits use objects as the canonical source for test-manifest/test-flow generation (#335). |

--- a/_shared/schemas/review.md
+++ b/_shared/schemas/review.md
@@ -36,6 +36,13 @@ checks_run:
     result: pass
   - name: edge_case_coverage
     result: pass
+evidence_reviewed:
+  - kind: tests
+    verification_source: verified_by_worker_evidence  # verified_by_worker_evidence | independently_rerun_by_reviewer
+    command: "scripts/test-fixtures/604-reviewer-test-rerun-policy/test.sh"
+    result: pass
+    timestamp: 2026-05-05T01:10:00Z
+    note: "Fresh worker evidence covered the reviewed diff; reviewer did not rerun."
 scope:
   context_scopes: [diff-only, task-context]       # diff-only | task-context | plan-context | architecture-context | runtime/evidence-context
   diff_size: 187
@@ -59,6 +66,7 @@ notes: null
 | `verdict` | enum \| null | yes | `approved` \| `flagged` \| `blocked` \| null (while pre-terminal). Redundant with `state` for terminal verdicts; separates intent (state) from ruling (verdict). |
 | `findings` | array | yes | Per-finding `{rule, tier, message, severity, likelihood, impact, change_risk, confidence, basis, recommended_action, path?}`. See §Findings. |
 | `checks_run` | array | yes | Per-check `{name, result}`. `result ∈ {pass, fail, skip, warn}`. |
+| `evidence_reviewed` | array | no | Evidence inspected for the verdict. For test/build evidence, set `verification_source` to `verified_by_worker_evidence` or `independently_rerun_by_reviewer`; include command, timestamp, result, and a short note when reruns are skipped for cost. |
 | `scope` | object | yes | `{context_scopes, diff_size, file_count, caps_triggered}`. Records what Argus saw — useful for dashboards and rule-effectiveness analysis. |
 | `notes` | string \| null | yes | Optional reviewer commentary. |
 

--- a/_shared/schemas/review.md
+++ b/_shared/schemas/review.md
@@ -4,7 +4,7 @@ description: YAML shape for Argus and user verdicts under plans/reviews/<review-
 type: reference
 ---
 
-# Review Schema (`review@1.2.0`)
+# Review Schema (`review@1.3.0`)
 
 Per-review artifact written to `~/.dev-studio/<project>/plans/reviews/<review-id>.yaml`. Each review targets a subject (a task, a round, a release) and carries a verdict + findings list. Argus emits reviews on task merges; Chanakya emits them on round aggregates; the user emits them via `/chanakya review-feedback`.
 
@@ -13,7 +13,7 @@ Per-review artifact written to `~/.dev-studio/<project>/plans/reviews/<review-id
 ```yaml
 schema_version:
   name: review
-  version: 1.2.0
+  version: 1.3.0
   min_reader: 1.0.0
   deprecated_at: null
 id: 0190f52a-7a11-7e03-8c99-44df6fd77a77        # UUIDv7
@@ -43,6 +43,15 @@ evidence_reviewed:
     result: pass
     timestamp: 2026-05-05T01:10:00Z
     note: "Fresh worker evidence covered the reviewed diff; reviewer did not rerun."
+self_review_checked:
+  applicable: true
+  self_review_performed: true
+  artifact_refs:
+    - "plans/self-reviews/0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11.yaml"
+  findings_reviewed: 1
+  fixes_reviewed: 1
+  absence_disposition: none                       # not_applicable | none | warn | block
+  note: null
 scope:
   context_scopes: [diff-only, task-context]       # diff-only | task-context | plan-context | architecture-context | runtime/evidence-context
   diff_size: 187
@@ -55,7 +64,7 @@ notes: null
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `schema_version` | object | yes | Per `contracts/schema-version.md`. Version 1.2.0 adds structured review context and risk metadata for non-trivial findings. |
+| `schema_version` | object | yes | Per `contracts/schema-version.md`. Version 1.3.0 adds reviewer-visible same-host self-review inspection for #605. |
 | `id` | string (UUIDv7) | yes | |
 | `stage` | enum \| absent | no | `spec` \| `quality`. Set for Argus two-stage reviews (see `argus/modes/{spec-compliance,code-quality}.md`). Absent for user/chanakya reviewers. Missing in pre-1.1.0 reviews is read as `quality` for back-compat. |
 | `subject` | object | yes | `{kind, id}`. `kind ∈ {task, round, release}`. `id` must resolve to an artifact of that kind. |
@@ -66,7 +75,8 @@ notes: null
 | `verdict` | enum \| null | yes | `approved` \| `flagged` \| `blocked` \| null (while pre-terminal). Redundant with `state` for terminal verdicts; separates intent (state) from ruling (verdict). |
 | `findings` | array | yes | Per-finding `{rule, tier, message, severity, likelihood, impact, change_risk, confidence, basis, recommended_action, path?}`. See §Findings. |
 | `checks_run` | array | yes | Per-check `{name, result}`. `result ∈ {pass, fail, skip, warn}`. |
-| `evidence_reviewed` | array | no | Evidence inspected for the verdict. For test/build evidence, set `verification_source` to `verified_by_worker_evidence` or `independently_rerun_by_reviewer`; include command, timestamp, result, and a short note when reruns are skipped for cost. |
+| `evidence_reviewed` | array | no | Evidence inspected for the verdict. For test/build evidence, set `verification_source` to `verified_by_worker_evidence` or `independently_rerun_by_reviewer`; include command, timestamp, result, and a short note when reruns are skipped for cost. The schema permits omission for old artifacts; the reviewer role contract requires it for fresh verdicts. |
+| `self_review_checked` | object | no | Reviewer inspection of same-host self-review. The schema permits omission for old artifacts; the reviewer role contract requires it for fresh worker and planner reviews. For worker and planner targets, missing self-review sets `absence_disposition: warn` or `block`; other review kinds set `applicable: false` and `absence_disposition: not_applicable`. |
 | `scope` | object | yes | `{context_scopes, diff_size, file_count, caps_triggered}`. Records what Argus saw — useful for dashboards and rule-effectiveness analysis. |
 | `notes` | string \| null | yes | Optional reviewer commentary. |
 
@@ -152,6 +162,8 @@ User-emitted reviews (from `/chanakya review-feedback`) set verdict directly —
 
 Risk metadata does not weaken blocks. It explains why the finding is blocking, warning-only, or escalation-worthy. Reviewers keep true correctness, contract, or regression blockers as `tier: block`.
 
+Missing same-host self-review for worker or planner targets is a workflow defect. Reviewers encode it in `self_review_checked.absence_disposition` and add a finding when it affects the verdict: `warn` maps to `flagged`, and `block` maps to `blocked`.
+
 ## Lifecycle
 
 Per `state-machines/review-lifecycle.md`:
@@ -178,6 +190,7 @@ Pre-2.6 Argus review output lived in free-form markdown under the worktree (`.ar
 
 | Version | Landed | Changes |
 |---|---|---|
+| 1.3.0 | 2026-05-05 | Adds optional schema field `self_review_checked`; the reviewer role contract requires it for fresh worker/planner verdicts so reviewers can warn or block when same-host self-review is absent before external review (#605). |
 | 1.2.0 | 2026-05-05 | Adds `scope.context_scopes` and per-finding `severity`, `likelihood`, `impact`, `change_risk`, `confidence`, `basis`, and `recommended_action` for #606. Cross-references #537 review scope, #604 test evidence, and #605 same-host self-review. |
 | 1.0.0 | 2026-04-22 | Initial Phase 2.6 landing. |
 

--- a/_shared/schemas/self-review.md
+++ b/_shared/schemas/self-review.md
@@ -4,7 +4,7 @@ description: YAML shape for Achilles self-review artifacts under plans/self-revi
 type: reference
 ---
 
-# Self-Review Schema (`self-review@1.1.0`)
+# Self-Review Schema (`self-review@1.2.0`)
 
 Per-task artifact written to `~/.dev-studio/<project>/plans/self-reviews/<task-id>.yaml` at Step 5 completion. Read by Argus Stage 2 to cross-check skill verdicts and coverage gates without re-deriving from debrief prose.
 
@@ -13,12 +13,23 @@ Per-task artifact written to `~/.dev-studio/<project>/plans/self-reviews/<task-i
 ```yaml
 schema_version:
   name: self-review
-  version: 1.1.0
+  version: 1.2.0
   min_reader: 1.0.0
 task_id: T123
 completed_at: 2026-04-27T12:00:00Z
 iteration: 1           # 1 = no fix-rerun; 2 = one fix-rerun occurred (cap)
 converged: true        # false if iteration cap hit with material findings still present
+self_review_performed: true
+self_review_findings:
+  - id: SR1
+    focus: edge_case
+    finding: "Empty input path was not covered by the first implementation."
+    severity: material
+    disposition: fixed
+self_review_fixes:
+  - finding_id: SR1
+    action: fixed
+    summary: "Added the empty-input guard before final verification."
 skill_verdicts:        # keyed by skill name; value: clean | minor | material
   simplify: clean
   swiftui-pro: minor
@@ -61,6 +72,8 @@ Argus Stage 2 (`argus/modes/review.md`): reads `skill_verdicts` and `findings` v
 ## Interaction with external reviews
 
 Self-review is not a substitute for structured reviewer findings. When same-host self-review overlaps with external review (#605), the worker still records external reviewer finding dispositions in `contracts/worker-report.md` / `schemas/debrief.md`. Use self-review to expose local skill verdicts; use review verdict metadata (#537 context scope, #604 test/runtime evidence, #606 finding rubric) to decide whether to fix, modify, reject, escalate, or defer external findings.
+
+The same-host self-review gate runs before final verification. External reviewers inspect `self_review_performed`, `self_review_findings`, `self_review_fixes`, and final verification evidence before requesting independent reruns. Missing self-review is a warn or block workflow defect in the reviewer verdict.
 
 ## Refactoring pressure
 

--- a/core/v2/handoffs/planner-output.yaml
+++ b/core/v2/handoffs/planner-output.yaml
@@ -54,6 +54,11 @@ payload:
       risk: medium
       suggested_timing: After the role-contract migration completes.
       manager_follow_up_title: Extract shared role-handoff boundary guidance after migration.
+  self_review_performed: true
+  self_review_findings:
+    - "Checked planner contract scope against worker and reviewer role boundaries."
+  self_review_fixes:
+    - "Kept qa-engineer, flow-tester, and release-manager role contracts out of this leaf."
   review_ask: Verify the planner contract preserves manager escalation and the handoff fixture validates without broadening adjacent role scope.
   escalation:
     required: false

--- a/core/v2/roles/planner.yaml
+++ b/core/v2/roles/planner.yaml
@@ -56,4 +56,7 @@ verification_floor:
   - Planner output names scope, non-goals, dependencies, risks, reusable API findings, acceptance criteria, and explicit review ask.
   - Each worker contract produced by the planner has bounded ownership, required checks, stop conditions, and a private summary artifact path.
   - Planner output distinguishes dispatch-blocking refactors from deferred refactoring follow-ups that the manager can capture as separate work.
+  - Same-host plan self-review runs before cross-host plan review; it checks edge cases, likely bugs or regressions, hidden dependencies, acceptance-criteria gaps, and scope mistakes.
+  - Planner output distinguishes self_review_performed, self_review_findings, and self_review_fixes before it is sent to a reviewer.
+  - Cross-host plan review starts only after self-review fixes are integrated or the plan is marked blocked for manager decision.
   - Irreducible conflicts are escalated to manager before worker dispatch.

--- a/core/v2/roles/reviewer.yaml
+++ b/core/v2/roles/reviewer.yaml
@@ -52,6 +52,8 @@ failure_semantics:
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
 verification_floor:
   - Evidence reviewed is listed in the verdict.
+  - Test or build confidence distinguishes verified_by_worker_evidence from independently_rerun_by_reviewer.
+  - Reviewers inspect worker command evidence before rerunning tests and rerun only when evidence is missing, stale, too narrow, diff-stale, cheap/high-value, risky, or suspicious.
   - Context scope is declared as diff-only, task-context, plan-context, architecture-context, or runtime/evidence-context.
   - Non-trivial findings include severity, likelihood, impact, change_risk, confidence, basis, and recommended_action.
   - Refactoring findings distinguish required current-task cleanup from deferred design debt and recommend manager/planner follow-up when broad cleanup is not justified.

--- a/core/v2/roles/reviewer.yaml
+++ b/core/v2/roles/reviewer.yaml
@@ -12,6 +12,9 @@ inputs:
   - kind: worker-contract
     required: false
     description: Bounded task contract to review before dispatch or after completion.
+  - kind: worker-summary
+    required: false
+    description: Worker completion artifact with same-host self-review notes, fixes from that review, and final verification evidence.
   - kind: diff-or-outcome
     required: false
     description: Changed files, outcome summary, verification evidence, or release packet under review.
@@ -52,6 +55,8 @@ failure_semantics:
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
 verification_floor:
   - Evidence reviewed is listed in the verdict.
+  - Worker or planner review targets record self_review_checked in the verdict; missing same-host self-review is a warn or block workflow defect, not a weak-summary note.
+  - Reviewers inspect self_review_findings, self_review_fixes, and final_verification_evidence before requesting extra test reruns.
   - Test or build confidence distinguishes verified_by_worker_evidence from independently_rerun_by_reviewer.
   - Reviewers inspect worker command evidence before rerunning tests and rerun only when evidence is missing, stale, too narrow, diff-stale, cheap/high-value, risky, or suspicious.
   - Context scope is declared as diff-only, task-context, plan-context, architecture-context, or runtime/evidence-context.

--- a/core/v2/roles/worker.yaml
+++ b/core/v2/roles/worker.yaml
@@ -52,9 +52,12 @@ failure_semantics:
   - Preserve partial output details and the stable idempotency key if a failure happens after writes.
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
 verification_floor:
+  - Same-host self-review runs after implementation and before final verification; it checks missed edge cases, possible bugs, regressions, scope drift, and test adequacy.
+  - Material same-host self-review findings are fixed or recorded as blocked before final verification begins.
+  - Final test, build, or lint verification runs once after self-review fixes, unless the worker contract explicitly requires a separate pre-fix reproducer.
   - Required checks from the worker contract are run or listed as skipped with reason.
   - Reviewer-requested changes include a worker self-check and per-finding response state before implementation.
-  - The private worker-summary artifact is valid JSON and names the final commit when changes are made.
+  - The private worker-summary artifact is valid JSON, names the final commit when changes are made, and distinguishes self_review_performed, self_review_findings, self_review_fixes, and final_verification_evidence.
   - Worker artifacts distinguish refactoring needed now from refactoring follow-up proposed, and deferred refactoring concerns are copied into carryover or follow_ups for manager ingestion.
   - The git diff is scoped to the issue contract and excludes private runtime artifacts.
   - Worker checkpoint use is optional and is reported separately from required worker-summary and debrief evidence.

--- a/core/v2/schemas/handoff.schema.json
+++ b/core/v2/schemas/handoff.schema.json
@@ -180,6 +180,9 @@
         "risks",
         "acceptance_criteria",
         "decomposition",
+        "self_review_performed",
+        "self_review_findings",
+        "self_review_fixes",
         "review_ask",
         "escalation"
       ],
@@ -199,6 +202,9 @@
           "type": "array",
           "items": {"$ref": "#/$defs/refactoringFollowUp"}
         },
+        "self_review_performed": {"type": "boolean"},
+        "self_review_findings": {"$ref": "#/$defs/optionalTextArray"},
+        "self_review_fixes": {"$ref": "#/$defs/optionalTextArray"},
         "review_ask": {"type": "string", "minLength": 1},
         "escalation": {"$ref": "#/$defs/escalation"}
       }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -164,6 +164,7 @@ scripts/node-parity.sh [--fix|--dry-run]                # probe + cache toolchai
 scripts/check-xcode-parity.sh m1mini                    # pre-dispatch guard; exit 1 = MAJOR Xcode drift; STUDIO_IGNORE_XCODE_DRIFT=1 overrides (#136)
 scripts/node-warmup.sh m1mini [project]                 # async-safe pre-dispatch source sync + package cache warm-up (#138)
 scripts/task-write-test-cases.sh T001 '[{...}]'         # stdout debrief `tests.added` payload; no standalone sidecar write
+scripts/task-write-self-review.sh T001 '{...}'          # writes plans/self-reviews/T001.yaml with same-host findings/fixes before final verification
 scripts/task-invoke-argus.sh T001 /wt main S            # emits review_requested with reviewed base SHA (reviewer invoked through dispatch wrapper)
 scripts/task-merge.sh T001 /wt feature-branch --require-approved  # merge lock + approved-only policy + post-review base re-check
 scripts/node-janitor.sh [--days N] [--dry-run]          # periodic node-side sweep of stale derived-data + worktrees + dispatch logs/registry (#129, #272); LaunchAgent-driven

--- a/scripts/lib-ledger.sh
+++ b/scripts/lib-ledger.sh
@@ -1032,7 +1032,7 @@ write_review_artifact() {
 
   local payload
   payload=$({
-    printf 'schema_version: {name: review, version: 1.1.0, min_reader: 1.0.0, deprecated_at: null}\n'
+    printf 'schema_version: {name: review, version: 1.3.0, min_reader: 1.0.0, deprecated_at: null}\n'
     printf 'id: %s\n' "$uuid"
     printf 'subject: {kind: %s, id: %s}\n' "$subject_kind" "$subject_uuid"
     printf 'reviewer: argus\n'
@@ -1043,6 +1043,7 @@ write_review_artifact() {
     printf 'verdict: %s\n' "$verdict"
     printf 'findings: %s\n' "$findings_json"
     printf 'checks_run: []\n'
+    printf 'self_review_checked: {applicable: false, self_review_performed: false, artifact_refs: [], findings_reviewed: 0, fixes_reviewed: 0, absence_disposition: not_applicable, note: "Legacy writer did not receive self-review artifacts."}\n'
     printf 'scope: {context_scopes: [diff-only], diff_size: 0, file_count: 0, caps_triggered: []}\n'
     printf 'notes: null\n'
     printf 'idempotency_key: "%s"\n' "$idem"

--- a/scripts/task-write-self-review.sh
+++ b/scripts/task-write-self-review.sh
@@ -12,6 +12,11 @@
 #   {
 #     "iteration": 1,
 #     "converged": true,
+#     "self_review_performed": true,
+#     "self_review_findings": [{"id": "SR1", "focus": "edge_case",
+#       "finding": "...", "severity": "material", "disposition": "fixed"}],
+#     "self_review_fixes": [{"finding_id": "SR1", "action": "fixed",
+#       "summary": "..."}],
 #     "skill_verdicts": {"simplify": "clean", "swiftui-pro": "minor"},
 #     "diff_stats": {"files": 4, "added_lines": 187, "removed_lines": 12,
 #                    "public_api_changed": false},
@@ -50,6 +55,7 @@ NOW=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 ITERATION=$(printf '%s' "$FIELDS_JSON" | jq -r '.iteration // 1')
 # Use explicit null-check for booleans — jq's // treats false as falsy.
 CONVERGED=$(printf '%s' "$FIELDS_JSON" | jq -r 'if .converged == null then "true" else (.converged | tostring) end')
+SELF_REVIEW_PERFORMED=$(printf '%s' "$FIELDS_JSON" | jq -r 'if .self_review_performed == null then "true" else (.self_review_performed | tostring) end')
 FILES=$(printf '%s' "$FIELDS_JSON" | jq -r '.diff_stats.files // 0')
 ADDED=$(printf '%s' "$FIELDS_JSON" | jq -r '.diff_stats.added_lines // 0')
 REMOVED=$(printf '%s' "$FIELDS_JSON" | jq -r '.diff_stats.removed_lines // 0')
@@ -67,6 +73,8 @@ SKILL_BLOCK=$(printf '%s' "$FIELDS_JSON" | jq -r '
 
 # Render findings block.
 HAS_FINDINGS=$(printf '%s' "$FIELDS_JSON" | jq -e '(.findings // []) | length > 0' >/dev/null 2>&1 && printf 'yes' || printf 'no')
+HAS_SELF_REVIEW_FINDINGS=$(printf '%s' "$FIELDS_JSON" | jq -e '(.self_review_findings // []) | length > 0' >/dev/null 2>&1 && printf 'yes' || printf 'no')
+HAS_SELF_REVIEW_FIXES=$(printf '%s' "$FIELDS_JSON" | jq -e '(.self_review_fixes // []) | length > 0' >/dev/null 2>&1 && printf 'yes' || printf 'no')
 
 if [ "$HAS_FINDINGS" = "yes" ]; then
   FINDINGS_BLOCK=$(printf '%s' "$FIELDS_JSON" | jq -r '
@@ -76,12 +84,42 @@ if [ "$HAS_FINDINGS" = "yes" ]; then
   ')
 fi
 
+if [ "$HAS_SELF_REVIEW_FINDINGS" = "yes" ]; then
+  SELF_REVIEW_FINDINGS_BLOCK=$(printf '%s' "$FIELDS_JSON" | jq -r '
+    .self_review_findings | map(
+      "  - id: \(.id)\n    focus: \(.focus)\n    finding: \(.finding | @json)\n    severity: \(.severity)\n    disposition: \(.disposition)"
+      + (if .evidence_ref then "\n    evidence_ref: \(.evidence_ref | @json)" else "" end)
+    ) | join("\n")
+  ')
+fi
+
+if [ "$HAS_SELF_REVIEW_FIXES" = "yes" ]; then
+  SELF_REVIEW_FIXES_BLOCK=$(printf '%s' "$FIELDS_JSON" | jq -r '
+    .self_review_fixes | map(
+      "  - finding_id: \(.finding_id)\n    action: \(.action)\n    summary: \(.summary | @json)"
+      + (if .commit then "\n    commit: \(.commit | @json)" else "" end)
+      + (if .follow_up_ref then "\n    follow_up_ref: \(.follow_up_ref | @json)" else "" end)
+    ) | join("\n")
+  ')
+fi
+
 {
-  printf 'schema_version:\n  name: self-review\n  version: 1.0.0\n  min_reader: 1.0.0\n'
+  printf 'schema_version:\n  name: self-review\n  version: 1.2.0\n  min_reader: 1.0.0\n'
   printf 'task_id: %s\n' "$TASK_ID"
   printf 'completed_at: %s\n' "$NOW"
   printf 'iteration: %s\n' "$ITERATION"
   printf 'converged: %s\n' "$CONVERGED"
+  printf 'self_review_performed: %s\n' "$SELF_REVIEW_PERFORMED"
+  if [ "$HAS_SELF_REVIEW_FINDINGS" = "yes" ]; then
+    printf 'self_review_findings:\n%s\n' "$SELF_REVIEW_FINDINGS_BLOCK"
+  else
+    printf 'self_review_findings: []\n'
+  fi
+  if [ "$HAS_SELF_REVIEW_FIXES" = "yes" ]; then
+    printf 'self_review_fixes:\n%s\n' "$SELF_REVIEW_FIXES_BLOCK"
+  else
+    printf 'self_review_fixes: []\n'
+  fi
   printf 'skill_verdicts:\n%s\n' "$SKILL_BLOCK"
   printf 'diff_stats:\n  files: %s\n  added_lines: %s\n  removed_lines: %s\n  public_api_changed: %s\n' \
     "$FILES" "$ADDED" "$REMOVED" "$PUBLIC_API"

--- a/scripts/test-fixtures/605-self-review-gate/test-self-review-gate.sh
+++ b/scripts/test-fixtures/605-self-review-gate/test-self-review-gate.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t self-review-gate-605.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v check-jsonschema >/dev/null 2>&1 || fail "check-jsonschema is required"
+
+cat > "$TMPROOT/worker-valid.yaml" <<'YAML'
+report_state: done
+branch: {merge_sha: abc123}
+argus_review: {status: approved}
+debt: {build: false, test_unit: false, test_ui: false}
+self_review_performed: true
+self_review_findings:
+  - id: SR1
+    focus: edge_case
+    finding: "Empty input path needed an explicit guard."
+    severity: material
+    disposition: fixed
+self_review_fixes:
+  - finding_id: SR1
+    action: fixed
+    summary: "Added the empty-input guard before final verification."
+final_verification_evidence:
+  - command: "scripts/test-fixtures/605-self-review-gate/test-self-review-gate.sh"
+    outcome: pass
+    timestamp: 2026-05-05T01:30:00Z
+    after_self_review_fixes: true
+YAML
+
+"$ROOT/scripts/validate-contract.sh" worker-report "$TMPROOT/worker-valid.yaml" >/dev/null \
+  || fail "valid worker self-review fields were rejected"
+
+writer_out=$(
+  HOME="$TMPROOT/home" ACHILLES_PROJECT=self-review-test \
+    "$ROOT/scripts/task-write-self-review.sh" T605 \
+      '{"self_review_findings":[{"id":"SR1","focus":"edge_case","finding":"Empty path was missed.","severity":"material","disposition":"fixed"}],"self_review_fixes":[{"finding_id":"SR1","action":"fixed","summary":"Added the guard."}],"skill_verdicts":{"simplify":"clean"},"diff_stats":{"files":1,"added_lines":2,"removed_lines":0,"public_api_changed":false}}'
+)
+grep -q '^self_review_performed: true$' "$writer_out" \
+  || fail "self-review writer omitted self_review_performed"
+grep -q '^self_review_findings:' "$writer_out" \
+  || fail "self-review writer omitted self_review_findings"
+grep -q '^self_review_fixes:' "$writer_out" \
+  || fail "self-review writer omitted self_review_fixes"
+grep -q 'version: 1.2.0' "$writer_out" \
+  || fail "self-review writer did not emit self-review@1.2.0"
+
+cat > "$TMPROOT/worker-invalid.yaml" <<'YAML'
+report_state: done
+branch: {merge_sha: abc123}
+argus_review: {status: approved}
+debt: {build: false, test_unit: false, test_ui: false}
+self_review_performed: true
+final_verification_evidence:
+  - command: "scripts/test-fixtures/605-self-review-gate/test-self-review-gate.sh"
+    outcome: pass
+    timestamp: 2026-05-05T01:30:00Z
+    after_self_review_fixes: false
+YAML
+
+if "$ROOT/scripts/validate-contract.sh" worker-report "$TMPROOT/worker-invalid.yaml" >/dev/null 2>"$TMPROOT/worker-invalid.err"; then
+  fail "worker final verification before self-review fixes was accepted"
+fi
+
+cat > "$TMPROOT/review-missing-self-review.yaml" <<'YAML'
+schema_version: {name: review, version: 1.3.0, min_reader: 1.0.0, deprecated_at: null}
+id: 0190f52a-7a11-7e03-8c99-44df6fd77a77
+stage: quality
+subject: {kind: task, id: 0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11}
+reviewer: argus
+state: flagged
+requested_at: 2026-05-05T00:00:00Z
+completed_at: 2026-05-05T00:01:00Z
+verdict: flagged
+findings:
+  - rule: R605_missing_same_host_self_review
+    tier: warn
+    severity: medium
+    likelihood: confirmed
+    impact: medium
+    change_risk: low
+    confidence: high
+    basis: runtime/evidence-context
+    recommended_action: fix_now
+    message: "Worker summary omitted same-host self-review before final verification."
+checks_run: []
+self_review_checked:
+  applicable: true
+  self_review_performed: false
+  artifact_refs: []
+  findings_reviewed: 0
+  fixes_reviewed: 0
+  absence_disposition: warn
+  note: "Missing same-host self-review was treated as a workflow defect."
+scope:
+  context_scopes: [diff-only, runtime/evidence-context]
+  diff_size: 12
+  file_count: 1
+  caps_triggered: []
+notes: null
+idempotency_key: "argus:review:0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11:quality:605"
+YAML
+
+"$ROOT/scripts/validate-contract.sh" review-verdict "$TMPROOT/review-missing-self-review.yaml" >/dev/null \
+  || fail "review verdict warning for missing same-host self-review was rejected"
+
+cat > "$TMPROOT/review-invalid.yaml" <<'YAML'
+schema_version: {name: review, version: 1.3.0, min_reader: 1.0.0, deprecated_at: null}
+id: 0190f52a-7a11-7e03-8c99-44df6fd77a77
+stage: quality
+subject: {kind: task, id: 0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11}
+reviewer: argus
+state: approved
+requested_at: 2026-05-05T00:00:00Z
+completed_at: 2026-05-05T00:01:00Z
+verdict: approved
+findings: []
+checks_run: []
+self_review_checked:
+  applicable: true
+  self_review_performed: false
+  artifact_refs: []
+  findings_reviewed: 0
+  fixes_reviewed: 0
+  absence_disposition: none
+  note: null
+scope:
+  context_scopes: [diff-only]
+  diff_size: 12
+  file_count: 1
+  caps_triggered: []
+notes: null
+idempotency_key: "argus:review:0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11:quality:605-invalid"
+YAML
+
+if "$ROOT/scripts/validate-contract.sh" review-verdict "$TMPROOT/review-invalid.yaml" >/dev/null 2>"$TMPROOT/review-invalid.err"; then
+  fail "missing same-host self-review with absence_disposition none was accepted"
+fi
+
+cp "$ROOT/core/v2/handoffs/planner-output.yaml" "$TMPROOT/planner-valid.yaml"
+PYTHONWARNINGS=ignore check-jsonschema --force-filetype yaml \
+  --schemafile "$ROOT/core/v2/schemas/handoff.schema.json" \
+  "$TMPROOT/planner-valid.yaml" >/dev/null \
+  || fail "planner output with self-review fields was rejected"
+
+printf 'PASS: same-host self-review gate\n'

--- a/scripts/test-fixtures/606-review-rubric/test-review-rubric.sh
+++ b/scripts/test-fixtures/606-review-rubric/test-review-rubric.sh
@@ -35,6 +35,14 @@ findings:
     message: "Finding needs worker disposition instead of direct application."
     path: "_shared/schemas/review.md"
 checks_run: []
+self_review_checked:
+  applicable: true
+  self_review_performed: true
+  artifact_refs: ["plans/self-reviews/0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11.yaml"]
+  findings_reviewed: 0
+  fixes_reviewed: 0
+  absence_disposition: none
+  note: null
 scope:
   context_scopes: [diff-only, task-context]
   diff_size: 42
@@ -69,6 +77,14 @@ findings:
     recommended_action: fix_now
     message: "This must escalate or defer instead of forcing a direct fix."
 checks_run: []
+self_review_checked:
+  applicable: true
+  self_review_performed: true
+  artifact_refs: ["plans/self-reviews/0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11.yaml"]
+  findings_reviewed: 0
+  fixes_reviewed: 0
+  absence_disposition: none
+  note: null
 scope:
   context_scopes: [diff-only]
   diff_size: 12

--- a/scripts/test-fixtures/607-refactoring-pressure/test-refactoring-pressure.sh
+++ b/scripts/test-fixtures/607-refactoring-pressure/test-refactoring-pressure.sh
@@ -134,6 +134,14 @@ findings:
     message: "Broad cleanup is real but not justified as required for this bounded task."
     path: "core/v2/roles/worker.yaml"
 checks_run: []
+self_review_checked:
+  applicable: true
+  self_review_performed: true
+  artifact_refs: ["plans/self-reviews/0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11.yaml"]
+  findings_reviewed: 0
+  fixes_reviewed: 0
+  absence_disposition: none
+  note: null
 scope:
   context_scopes: [diff-only, task-context]
   diff_size: 42


### PR DESCRIPTION
Implements #604 and #605 from the open-issues easy-target chain.\n\n- Clarifies reviewer test rerun policy and records worker-evidence vs reviewer-rerun provenance.\n- Adds same-host self-review fields and reviewer checks for worker/planner outputs.\n- Adds focused fixtures for review evidence and self-review gate contracts.\n\nChain run: 019df5a8-9f66-72d8-ac46-9c4c6fcceb81.\n\nCloses #604.\nCloses #605.