### PR TITLE
Add diff-scoped review budget fast path (#537)

### DIFF
--- a/scripts/dispatch-review.sh
+++ b/scripts/dispatch-review.sh
@@ -70,6 +70,8 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # shellcheck source=lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
+# shellcheck source=lib-review-budget.sh
+. "$SCRIPT_DIR/lib-review-budget.sh"
 # shellcheck source=lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh"
 
@@ -318,6 +320,28 @@ fi
 if [ -n "$CAPTURE_HANDOFF" ]; then
   mkdir -p "$(dirname "$CAPTURE_HANDOFF")" 2>/dev/null || true
   cp "$handoff_path" "$CAPTURE_HANDOFF"
+fi
+
+handoff_bytes=$(wc -c < "$handoff_path" 2>/dev/null | tr -d ' ' || printf '0')
+handoff_lines=$(wc -l < "$handoff_path" 2>/dev/null | tr -d ' ' || printf '0')
+case "$handoff_bytes" in ""|*[!0-9]*) handoff_bytes=0 ;; esac
+case "$handoff_lines" in ""|*[!0-9]*) handoff_lines=0 ;; esac
+handoff_estimated_tokens=$(((handoff_bytes + 2) / 3))
+handoff_budget_tokens=$(review_budget_payload_token_budget)
+handoff_context_status="ok"
+[ "$handoff_estimated_tokens" -le "$handoff_budget_tokens" ] || handoff_context_status="over_budget"
+if command -v jq >/dev/null 2>&1; then
+  handoff_context_json=$(jq -n \
+    --arg kind "dispatch-$STAGE" \
+    --arg mode "handoff-scoped" \
+    --arg risk_level "argus-dispatch" \
+    --argjson bytes "$handoff_bytes" \
+    --argjson lines "$handoff_lines" \
+    --argjson estimated_tokens "$handoff_estimated_tokens" \
+    --argjson payload_budget_tokens "$handoff_budget_tokens" \
+    --arg status "$handoff_context_status" \
+    '{kind:$kind,mode:$mode,risk_level:$risk_level,budget:{payload_budget_tokens:$payload_budget_tokens},payload:{bytes:$bytes,lines:$lines,estimated_tokens:$estimated_tokens,status:$status}}')
+  review_budget_emit_context_event argus "$TASK_ID" review_context_budget_resolved "$handoff_context_json" "dispatch-review-context:$IDEM_KEY"
 fi
 
 # ---- Step 5: env-scrubbed spawn -------------------------------------------

--- a/scripts/lib-review-budget.sh
+++ b/scripts/lib-review-budget.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+review_budget_positive_int() {
+  case "${1:-}" in
+    ""|*[!0-9]*) return 1 ;;
+    *) [ "$1" -gt 0 ] ;;
+  esac
+}
+
+review_budget_max_diff_lines() {
+  review_budget_positive_int "${STUDIO_REVIEW_FAST_PATH_MAX_DIFF_LINES:-}" \
+    && printf '%s\n' "$STUDIO_REVIEW_FAST_PATH_MAX_DIFF_LINES" \
+    || printf '120\n'
+}
+
+review_budget_max_files() {
+  review_budget_positive_int "${STUDIO_REVIEW_FAST_PATH_MAX_FILES:-}" \
+    && printf '%s\n' "$STUDIO_REVIEW_FAST_PATH_MAX_FILES" \
+    || printf '3\n'
+}
+
+review_budget_payload_token_budget() {
+  review_budget_positive_int "${STUDIO_REVIEW_PAYLOAD_BUDGET_TOKENS:-}" \
+    && printf '%s\n' "$STUDIO_REVIEW_PAYLOAD_BUDGET_TOKENS" \
+    || printf '9000\n'
+}
+
+review_budget_payload_line_cap() {
+  review_budget_positive_int "${STUDIO_REVIEW_PAYLOAD_MAX_DIFF_LINES:-}" \
+    && printf '%s\n' "$STUDIO_REVIEW_PAYLOAD_MAX_DIFF_LINES" \
+    || printf '800\n'
+}
+
+review_budget_estimated_tokens_for_file() {
+  local file="$1" bytes
+  bytes=$(wc -c < "$file" 2>/dev/null | tr -d ' ' || printf '0')
+  case "$bytes" in ""|*[!0-9]*) bytes=0 ;; esac
+  printf '%s\n' $(((bytes + 2) / 3))
+}
+
+review_budget_diff_line_count() {
+  local file="$1" lines
+  lines=$(wc -l < "$file" 2>/dev/null | tr -d ' ' || printf '0')
+  case "$lines" in ""|*[!0-9]*) lines=0 ;; esac
+  printf '%s\n' "$lines"
+}
+
+review_budget_changed_files() {
+  local file="$1"
+  sed -n 's/^diff --git a\/.* b\/\(.*\)$/\1/p' "$file" 2>/dev/null \
+    | sed '/^$/d' \
+    | sort -u
+}
+
+review_budget_changed_file_count() {
+  local file="$1"
+  review_budget_changed_files "$file" | wc -l | tr -d ' '
+}
+
+review_budget_risk_triggers() {
+  local diff_file="$1" diff_lines="$2" changed_files="$3" max_lines="$4" max_files="$5"
+  {
+    [ "$diff_lines" -le "$max_lines" ] || printf 'diff_lines\n'
+    [ "$changed_files" -le "$max_files" ] || printf 'file_count\n'
+    review_budget_changed_files "$diff_file" | while IFS= read -r path; do
+      case "$path" in
+        scripts/*.sh|core/*|_shared/*|hosts/*|.github/*|REVIEW.md|AGENTS.md|CLAUDE.md|*_schema.json|*.schema.json|*.yaml|*.yml)
+          printf 'path:%s\n' "$path"
+          ;;
+      esac
+    done
+  } | awk 'NF && !seen[$0]++'
+}
+
+review_budget_policy_json() {
+  local kind="$1" diff_file="$2" requested_mode="${3:-auto}"
+  local diff_lines changed_files max_lines max_files risk_file risk_count mode risk_level
+  local payload_budget line_cap estimated_diff_tokens
+
+  diff_lines=$(review_budget_diff_line_count "$diff_file")
+  changed_files=$(review_budget_changed_file_count "$diff_file")
+  max_lines=$(review_budget_max_diff_lines)
+  max_files=$(review_budget_max_files)
+  payload_budget=$(review_budget_payload_token_budget)
+  line_cap=$(review_budget_payload_line_cap)
+  estimated_diff_tokens=$(review_budget_estimated_tokens_for_file "$diff_file")
+  risk_file=$(mktemp -t review-budget-risk.XXXXXX) || return 1
+  review_budget_risk_triggers "$diff_file" "$diff_lines" "$changed_files" "$max_lines" "$max_files" > "$risk_file"
+  risk_count=$(wc -l < "$risk_file" 2>/dev/null | tr -d ' ')
+  case "$risk_count" in ""|*[!0-9]*) risk_count=0 ;; esac
+
+  mode="diff-scoped"
+  risk_level="low"
+  if [ "$risk_count" -gt 0 ]; then
+    mode="expanded"
+    risk_level="triggered"
+  fi
+  case "$requested_mode" in
+    diff-scoped|minimal|fast) mode="diff-scoped"; risk_level="low" ;;
+    expanded|full) mode="expanded"; [ "$risk_count" -gt 0 ] || risk_level="manual" ;;
+    summarized|summary) mode="summarized"; [ "$risk_count" -gt 0 ] || risk_level="budget" ;;
+    auto|"") ;;
+    *) mode="diff-scoped"; risk_level="low" ;;
+  esac
+  if [ "$diff_lines" -gt "$line_cap" ] && [ "$mode" != "expanded" ]; then
+    mode="summarized"
+    risk_level="budget"
+  fi
+
+  jq -n \
+    --arg kind "$kind" \
+    --arg mode "$mode" \
+    --arg requested_mode "$requested_mode" \
+    --arg risk_level "$risk_level" \
+    --argjson diff_lines "$diff_lines" \
+    --argjson changed_files "$changed_files" \
+    --argjson max_fast_path_diff_lines "$max_lines" \
+    --argjson max_fast_path_files "$max_files" \
+    --argjson payload_budget_tokens "$payload_budget" \
+    --argjson payload_diff_line_cap "$line_cap" \
+    --argjson estimated_diff_tokens "$estimated_diff_tokens" \
+    --slurpfile risk_triggers <(jq -R . "$risk_file" | jq -s '.') \
+    '{
+      kind:$kind,
+      mode:$mode,
+      requested_mode:$requested_mode,
+      risk_level:$risk_level,
+      diff_lines:$diff_lines,
+      changed_files:$changed_files,
+      fast_path:{
+        max_diff_lines:$max_fast_path_diff_lines,
+        max_files:$max_fast_path_files,
+        eligible:($risk_level == "low" and $mode == "diff-scoped")
+      },
+      risk_triggers:$risk_triggers[0],
+      budget:{
+        payload_budget_tokens:$payload_budget_tokens,
+        payload_diff_line_cap:$payload_diff_line_cap,
+        estimated_diff_tokens:$estimated_diff_tokens
+      }
+    }'
+  rm -f "$risk_file"
+}
+
+review_budget_payload_stats_json() {
+  local payload="$1" policy_json="$2" bytes lines estimated_tokens budget_tokens status
+  bytes=$(wc -c < "$payload" 2>/dev/null | tr -d ' ' || printf '0')
+  lines=$(wc -l < "$payload" 2>/dev/null | tr -d ' ' || printf '0')
+  case "$bytes" in ""|*[!0-9]*) bytes=0 ;; esac
+  case "$lines" in ""|*[!0-9]*) lines=0 ;; esac
+  estimated_tokens=$(((bytes + 2) / 3))
+  budget_tokens=$(printf '%s\n' "$policy_json" | jq -r '.budget.payload_budget_tokens // 9000')
+  status="ok"
+  [ "$estimated_tokens" -le "$budget_tokens" ] || status="over_budget"
+  jq -n \
+    --argjson policy "$policy_json" \
+    --argjson bytes "$bytes" \
+    --argjson lines "$lines" \
+    --argjson estimated_tokens "$estimated_tokens" \
+    --arg status "$status" \
+    '$policy + {payload:{bytes:$bytes, lines:$lines, estimated_tokens:$estimated_tokens, status:$status}}'
+}
+
+review_budget_emit_context_event() {
+  command -v emit_event_keyed >/dev/null 2>&1 || return 0
+  local producer="$1" subject="$2" event="$3" stats_json="$4" idem_key="${5:-}"
+  if [ -n "$idem_key" ]; then
+    emit_event_keyed "$producer" review "$event" "$subject" "$stats_json" --idem-key "$idem_key" >/dev/null 2>&1 || true
+  else
+    emit_event_keyed "$producer" review "$event" "$subject" "$stats_json" >/dev/null 2>&1 || true
+  fi
+}

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -23,6 +23,8 @@ CALLER_HOME="${HOME:-}"
 
 # shellcheck source=lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
+# shellcheck source=lib-review-budget.sh
+. "$SCRIPT_DIR/lib-review-budget.sh"
 
 usage() {
   sed -n '3,9p' "$0" >&2
@@ -157,6 +159,25 @@ esac
 spawn_argv=( $spawn_command )
 
 input_content=$(cat "$input")
+input_bytes=$(wc -c < "$input" 2>/dev/null | tr -d ' ' || printf '0')
+input_lines=$(wc -l < "$input" 2>/dev/null | tr -d ' ' || printf '0')
+case "$input_bytes" in ""|*[!0-9]*) input_bytes=0 ;; esac
+case "$input_lines" in ""|*[!0-9]*) input_lines=0 ;; esac
+input_estimated_tokens=$(((input_bytes + 2) / 3))
+phase_budget_tokens=$(review_budget_payload_token_budget)
+phase_context_status="ok"
+[ "$input_estimated_tokens" -le "$phase_budget_tokens" ] || phase_context_status="over_budget"
+phase_context_json=$(jq -n \
+  --arg kind "phase-$kind" \
+  --arg mode "artifact-scoped" \
+  --arg risk_level "phase-gate" \
+  --argjson bytes "$input_bytes" \
+  --argjson lines "$input_lines" \
+  --argjson estimated_tokens "$input_estimated_tokens" \
+  --argjson payload_budget_tokens "$phase_budget_tokens" \
+  --arg status "$phase_context_status" \
+  '{kind:$kind,mode:$mode,risk_level:$risk_level,budget:{payload_budget_tokens:$payload_budget_tokens},payload:{bytes:$bytes,lines:$lines,estimated_tokens:$estimated_tokens,status:$status}}')
+review_budget_emit_context_event studio "$input" review_context_budget_resolved "$phase_context_json" "phase-review-context:$kind:$input"
 
 prompt=$(cat <<EOF
 Read this $kind-review artifact and perform the required sibling-host review:
@@ -228,3 +249,4 @@ printf 'PHASE_REVIEW_HOST=%s\n' "$review_host"
 printf 'PHASE_REVIEW_OUTPUT=%s\n' "$output"
 printf 'PHASE_REVIEW_ERR=%s\n' "$err_output"
 printf 'PHASE_REVIEW_VERDICT=%s\n' "$verdict"
+printf 'PHASE_REVIEW_CONTEXT_TOKENS=%s\n' "$input_estimated_tokens"

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -28,6 +28,7 @@ PR_URL_FOR_EVENT=""
 PR_HEAD_SHA_FOR_EVENT=""
 PR_REVIEW_VERDICT_FOR_EVENT=""
 PR_REVIEW_TOKENS_JSON="null"
+PR_REVIEW_CONTEXT_JSON="null"
 TMPDIR_TO_CLEAN=""
 REVIEW_SESSION_SCAN_STARTED_AT=$(date +%s)
 PARENT_HOST=""
@@ -85,6 +86,8 @@ AUTOPILOT="${PR_HEADLESS_REVIEW_AUTOPILOT:-$SCRIPT_DIR/pr-autopilot.sh}"
 
 # shellcheck source=lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
+# shellcheck source=lib-review-budget.sh
+. "$SCRIPT_DIR/lib-review-budget.sh"
 # shellcheck source=lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh" 2>/dev/null || true
 
@@ -124,6 +127,7 @@ emit_pr_review_duration() {
       --argjson duration_s "$duration_s" \
       --argjson exit_code "$rc" \
       --argjson tokens "$PR_REVIEW_TOKENS_JSON" \
+      --argjson review_context "$PR_REVIEW_CONTEXT_JSON" \
       '{pr:$pr,pr_url:$pr_url,head:$head,review_host:$host,selected_review_host:$host,verdict:$verdict,method:$method,status:$status,duration_s:$duration_s,exit_code:$exit_code,
         parent_host:$parent_host,
         eligible_review_hosts:($eligible_hosts | split(",") | map(select(length > 0))),
@@ -133,7 +137,8 @@ emit_pr_review_duration() {
        + (if $fallback_failures == "" then {} else {fallback_failures:$fallback_failures} end)
        + (if $cross_host_bypass_url == "" then {} else {cross_host_bypass_url:$cross_host_bypass_url} end)
        + (if $review_model_id == "" then {} else {review_model_key:$review_model_key,review_model_id:$review_model_id,review_model_provider_family:$review_model_provider_family,review_model_reasoning_effort:$review_model_reasoning_effort} end)
-       + (if $tokens == null then {} else {tokens:$tokens} end)')
+       + (if $tokens == null then {} else {tokens:$tokens} end)
+       + (if $review_context == null then {} else {review_context:$review_context} end)')
   else
     data=$(printf '{"pr":"%s","review_host":"%s","selected_review_host":"%s","verdict":"%s","method":"%s","status":"%s","parent_host":"%s","eligible_review_hosts":"%s","cross_host":"%s","cross_host_required":"%s","fallback_from":"%s","fallback_failures":"%s","duration_s":%s,"exit_code":%s}' \
       "$PR" "$REVIEW_HOST" "$REVIEW_HOST" "$PR_REVIEW_VERDICT_FOR_EVENT" "$METHOD" "$status" "$PARENT_HOST" "$ELIGIBLE_REVIEW_HOSTS_CSV" "$CROSS_HOST_FOR_EVENT" "$CROSS_HOST_REQUIRED" "$FALLBACK_FROM_CSV" "$FALLBACK_FAILURES_TEXT" "$duration_s" "$rc")
@@ -359,6 +364,7 @@ mkdir -p "$review_tmp_root"
 tmpdir=$(mktemp -d "$review_tmp_root/run.XXXXXX")
 TMPDIR_TO_CLEAN="$tmpdir"
 payload="$tmpdir/review-payload.md"
+diff_payload="$tmpdir/pr.diff"
 summary="$tmpdir/reviewer-summary.md"
 reviewer_home="$tmpdir/reviewer-home"
 mkdir -p "$reviewer_home"
@@ -366,9 +372,15 @@ reviewer_codex_home=""
 reviewer_claude_home=""
 reviewer_claude_config_dir=""
 
-{
+with_login_home_for_github gh pr diff "$PR" --patch > "$diff_payload"
+
+write_pr_payload() {
+  local mode="$1" policy_json="$2"
+  local line_cap
+  line_cap=$(printf '%s\n' "$policy_json" | jq -r '.budget.payload_diff_line_cap')
   printf '# Studio PR Review Payload\n\n'
-  printf 'Metadata:\n\n```json\n%s\n```\n\n' "$(printf '%s' "$pr_json" | jq -c '.')"
+  printf 'Review context policy:\n\n```json\n%s\n```\n\n' "$(printf '%s' "$policy_json" | jq -c '.')"
+  printf 'Metadata:\n\n```json\n%s\n```\n\n' "$(printf '%s' "$pr_json" | jq -c '{number,title,url,baseRefName,headRefName,headRefOid,author}')"
   cat <<'PROMPT'
 Review this studio PR against REVIEW.md and the repository-specific rules.
 Grouped feature/reliability PRs are normal when the included issues share a
@@ -389,11 +401,30 @@ checks, merge conflicts, or repo-rule violations. Non-critical findings may be
 fixed by the reviewer only if the reviewer host has write permissions and the
 fix is narrow and confined to the PR branch; summarize any fixes.
 
+This payload is diff-scoped by default. If the context is insufficient for a
+safe verdict, print REVIEW_CONTEXT_FALLBACK=expanded and do not print a verdict;
+the wrapper will rerun once with expanded context.
+
 PROMPT
+  if [ "$mode" = "expanded" ]; then
+    printf '\nExpanded repo review rules:\n\n```md\n'
+    sed -n '1,260p' "$REPO_ROOT/REVIEW.md"
+    printf '\n```\n'
+  fi
   printf '\nPR diff:\n\n```diff\n'
-  with_login_home_for_github gh pr diff "$PR" --patch
+  if [ "$mode" = "summarized" ]; then
+    sed -n "1,${line_cap}p" "$diff_payload"
+    printf '\n--- diff summarized at %s lines; rerun with STUDIO_REVIEW_PAYLOAD_MODE=expanded for full context ---\n' "$line_cap"
+  else
+    cat "$diff_payload"
+  fi
   printf '\n```\n'
-} > "$payload"
+}
+
+policy_json=$(review_budget_policy_json pr "$diff_payload" "${STUDIO_REVIEW_PAYLOAD_MODE:-auto}")
+write_pr_payload "$(printf '%s\n' "$policy_json" | jq -r '.mode')" "$policy_json" > "$payload"
+PR_REVIEW_CONTEXT_JSON=$(review_budget_payload_stats_json "$payload" "$policy_json")
+review_budget_emit_context_event studio "$PR" review_context_budget_resolved "$PR_REVIEW_CONTEXT_JSON" "pr-review-context:$pr_num:$head_sha"
 
 run_review_candidate() {
   local candidate="$1" eligibility spawn_command verdict_count model_resolution
@@ -425,7 +456,6 @@ run_review_candidate() {
   reviewer_codex_home=""
   reviewer_claude_home=""
   reviewer_claude_config_dir=""
-  set +e
   case "$REVIEW_HOST" in
     codex*|*codex*)
       reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-}}"
@@ -474,11 +504,11 @@ run_review_candidate() {
       spawn_argv+=(--model "$REVIEWER_MODEL_ID")
       ;;
   esac
-  review_prompt="Read $payload, review PR $pr_url at HEAD $head_sha, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
+  review_prompt="Read $payload, review PR $pr_url at HEAD $head_sha, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>. If context is insufficient, print REVIEW_CONTEXT_FALLBACK=expanded instead."
 
   case "$REVIEW_HOST" in
     codex*|*codex*)
-      ( cd "$REPO_ROOT" && env -i \
+      if ( cd "$REPO_ROOT" && env -i \
         PATH="$PATH" \
         HOME="$reviewer_home" \
         LANG="${LANG:-C.UTF-8}" \
@@ -491,11 +521,14 @@ run_review_candidate() {
         REVIEW_PAYLOAD="$payload" \
         PR_URL="$pr_url" \
         PR_HEAD_SHA="$head_sha" \
-        "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err" )
-      review_rc=$?
+        "${spawn_argv[@]}" "$review_prompt" > "$summary" 2>"$summary.err" ); then
+        review_rc=0
+      else
+        review_rc=$?
+      fi
       ;;
     *)
-      ( cd "$REPO_ROOT" && env -i \
+      if ( cd "$REPO_ROOT" && env -i \
         PATH="$PATH" \
         HOME="$reviewer_claude_home" \
         LANG="${LANG:-C.UTF-8}" \
@@ -509,11 +542,13 @@ run_review_candidate() {
         REVIEW_PAYLOAD="$payload" \
         PR_URL="$pr_url" \
         PR_HEAD_SHA="$head_sha" \
-        "${spawn_argv[@]}" "$review_prompt" </dev/null > "$summary" 2>"$summary.err" )
-      review_rc=$?
+        "${spawn_argv[@]}" "$review_prompt" </dev/null > "$summary" 2>"$summary.err" ); then
+        review_rc=0
+      else
+        review_rc=$?
+      fi
       ;;
   esac
-  set -e
   if [ "$review_rc" -ne 0 ]; then
     append_failure "$REVIEW_HOST" "$summary" "$summary.err"
     return 1
@@ -521,6 +556,15 @@ run_review_candidate() {
 
   verdict_count=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary" | wc -l | tr -d ' ')
   verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary")
+  if [ "$verdict_count" = "0" ] \
+      && grep -Eq '^REVIEW_CONTEXT_FALLBACK=expanded|INSUFFICIENT_CONTEXT' "$summary" \
+      && [ "$(printf '%s\n' "$PR_REVIEW_CONTEXT_JSON" | jq -r '.mode')" != "expanded" ]; then
+    policy_json=$(review_budget_policy_json pr "$diff_payload" expanded)
+    write_pr_payload expanded "$policy_json" > "$payload"
+    PR_REVIEW_CONTEXT_JSON=$(review_budget_payload_stats_json "$payload" "$policy_json")
+    review_budget_emit_context_event studio "$PR" review_context_budget_resolved "$PR_REVIEW_CONTEXT_JSON" "pr-review-context-expanded:$pr_num:$head_sha"
+    return 2
+  fi
   if [ "$verdict_count" != "1" ]; then
     printf 'pr-headless-review: reviewer must emit exactly one STUDIO_REVIEW_VERDICT line (found %s)\n' "$verdict_count" > "$summary.err"
     append_failure "$REVIEW_HOST" "$summary" "$summary.err"
@@ -569,7 +613,17 @@ fi
 selected=0
 failed_hosts=()
 for candidate in "${candidates[@]}"; do
-  if run_review_candidate "$candidate"; then
+  set +e
+  run_review_candidate "$candidate"
+  candidate_rc=$?
+  set -e
+  if [ "$candidate_rc" -eq 2 ]; then
+    set +e
+    run_review_candidate "$candidate"
+    candidate_rc=$?
+    set -e
+  fi
+  if [ "$candidate_rc" -eq 0 ]; then
     selected=1
     break
   fi

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -19,6 +19,7 @@ REVIEW_HOST="${STUDIO_REVIEW_HOST:-}"
 BYPASS_REVIEW=0
 CALLER_HOME="${HOME:-}"
 REVIEW_STARTED_AT=$(date +%s)
+REVIEW_CONTEXT_JSON="null"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -33,6 +34,8 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # shellcheck source=lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
+# shellcheck source=lib-review-budget.sh
+. "$SCRIPT_DIR/lib-review-budget.sh"
 # shellcheck source=lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh" 2>/dev/null || true
 
@@ -77,8 +80,10 @@ emit_gate_event() {
       --arg patch_id "$patch_id" \
       --arg bypass_source "$bypass_source" \
       --arg duration_s "$duration_s" \
+      --argjson review_context "$REVIEW_CONTEXT_JSON" \
       '{verdict:$verdict,review_host:$host,branch:$branch,head:$head,patch_id:$patch_id,bypass_source:$bypass_source}
-       + (if $duration_s == "" then {} else {duration_s:($duration_s|tonumber)} end)')
+       + (if $duration_s == "" then {} else {duration_s:($duration_s|tonumber)} end)
+       + (if $review_context == null then {} else {review_context:$review_context} end)')
   else
     data="{\"verdict\":\"$verdict\",\"review_host\":\"$host\",\"patch_id\":\"$patch_id\",\"bypass_source\":\"$bypass_source\""
     [ -n "$duration_s" ] && data="$data,\"duration_s\":$duration_s"
@@ -119,6 +124,7 @@ if [ "${STUDIO_BYPASS_REVIEW:-0}" = "1" ] || [ "$BYPASS_REVIEW" -eq 1 ]; then
 fi
 
 command -v yq >/dev/null 2>&1 || { printf 'pre-commit-review: yq is required\n' >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { printf 'pre-commit-review: jq is required\n' >&2; exit 1; }
 
 if [ -z "$REVIEW_HOST" ]; then
   hosts=()
@@ -145,6 +151,7 @@ spawn_command=$(printf '%s\n' "$eligibility" | sed -n 's/^SPAWN_COMMAND=//p' | h
 tmpdir=$(mktemp -d -t pre-commit-review.XXXXXX)
 trap 'rm -rf "$tmpdir"' EXIT
 payload="$tmpdir/review-payload.md"
+diff_payload="$tmpdir/staged.diff"
 summary="$tmpdir/reviewer-summary.md"
 reviewer_home="$tmpdir/reviewer-home"
 mkdir -p "$reviewer_home"
@@ -186,8 +193,14 @@ case "$REVIEW_HOST" in
     ;;
 esac
 
-{
+git diff --cached --patch > "$diff_payload"
+
+write_precommit_payload() {
+  local mode="$1" policy_json="$2"
+  local line_cap
+  line_cap=$(printf '%s\n' "$policy_json" | jq -r '.budget.payload_diff_line_cap')
   printf '# Studio Pre-Commit Review Payload\n\n'
+  printf 'Review context policy:\n\n```json\n%s\n```\n\n' "$(printf '%s' "$policy_json" | jq -c '.')"
   printf 'Metadata:\n\n'
   printf '%s\n' "- repository: $(basename "$REPO_ROOT")"
   printf '%s\n' "- branch: $(git symbolic-ref --quiet --short HEAD 2>/dev/null || printf unknown)"
@@ -208,15 +221,34 @@ checks, merge conflicts, or repo-rule violations. This is a pre-commit review:
 do not edit files, do not stage files, do not commit, and do not bypass this
 gate.
 
+This payload is diff-scoped by default. If the context is insufficient for a
+safe verdict, print REVIEW_CONTEXT_FALLBACK=expanded and do not print a verdict;
+the wrapper will rerun once with expanded context.
+
 PROMPT
+  if [ "$mode" = "expanded" ]; then
+    printf '\nExpanded repo review rules:\n\n```md\n'
+    sed -n '1,260p' "$REPO_ROOT/REVIEW.md"
+    printf '\n```\n'
+  fi
   printf '\nStaged diff:\n\n```diff\n'
-  git diff --cached --patch
+  if [ "$mode" = "summarized" ]; then
+    sed -n "1,${line_cap}p" "$diff_payload"
+    printf '\n--- diff summarized at %s lines; rerun with STUDIO_REVIEW_PAYLOAD_MODE=expanded for full context ---\n' "$line_cap"
+  else
+    cat "$diff_payload"
+  fi
   printf '\n```\n'
-} > "$payload"
+}
+
+policy_json=$(review_budget_policy_json precommit "$diff_payload" "${STUDIO_REVIEW_PAYLOAD_MODE:-auto}")
+write_precommit_payload "$(printf '%s\n' "$policy_json" | jq -r '.mode')" "$policy_json" > "$payload"
+REVIEW_CONTEXT_JSON=$(review_budget_payload_stats_json "$payload" "$policy_json")
+review_budget_emit_context_event studio "$patch_id" review_context_budget_resolved "$REVIEW_CONTEXT_JSON" "precommit-review-context:$patch_id"
 
 # shellcheck disable=SC2206
 spawn_argv=( $spawn_command )
-review_prompt="Read $payload, review the staged studio diff, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>."
+review_prompt="Read $payload, review the staged studio diff, and print STUDIO_REVIEW_VERDICT=<approved|approved_with_fixes|blocked>. If context is insufficient, print REVIEW_CONTEXT_FALLBACK=expanded instead."
 
 case "$REVIEW_HOST" in
   codex*|*codex*)
@@ -246,16 +278,34 @@ case "$REVIEW_HOST" in
     ;;
 esac
 
-if ! ( cd "$REPO_ROOT" && case "$REVIEW_HOST" in
+run_precommit_reviewer() {
+  ( cd "$REPO_ROOT" && case "$REVIEW_HOST" in
     codex*|*codex*) "${review_cmd[@]}" > "$summary" 2>"$summary.err" ;;
     *) "${review_cmd[@]}" </dev/null > "$summary" 2>"$summary.err" ;;
-  esac ); then
+  esac )
+}
+
+if ! run_precommit_reviewer; then
   print_reviewer_failure "$summary" "$summary.err"
   exit 1
 fi
 
 verdict_count=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary" | wc -l | tr -d ' ')
 verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary")
+if [ "$verdict_count" = "0" ] \
+    && grep -Eq '^REVIEW_CONTEXT_FALLBACK=expanded|INSUFFICIENT_CONTEXT' "$summary" \
+    && [ "$(printf '%s\n' "$REVIEW_CONTEXT_JSON" | jq -r '.mode')" != "expanded" ]; then
+  policy_json=$(review_budget_policy_json precommit "$diff_payload" expanded)
+  write_precommit_payload expanded "$policy_json" > "$payload"
+  REVIEW_CONTEXT_JSON=$(review_budget_payload_stats_json "$payload" "$policy_json")
+  review_budget_emit_context_event studio "$patch_id" review_context_budget_resolved "$REVIEW_CONTEXT_JSON" "precommit-review-context-expanded:$patch_id"
+  if ! run_precommit_reviewer; then
+    print_reviewer_failure "$summary" "$summary.err"
+    exit 1
+  fi
+  verdict_count=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary" | wc -l | tr -d ' ')
+  verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary")
+fi
 if [ "$verdict_count" != "1" ]; then
   printf 'pre-commit-review: reviewer must emit exactly one STUDIO_REVIEW_VERDICT line (found %s)\n' "$verdict_count" >&2
   sed -n '1,120p' "$summary" >&2 || true

--- a/scripts/test-fixtures/537-review-budget/test-review-budget.sh
+++ b/scripts/test-fixtures/537-review-budget/test-review-budget.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t review-budget.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# shellcheck source=scripts/lib-review-budget.sh
+. "$ROOT/scripts/lib-review-budget.sh"
+
+low_diff="$TMPROOT/low.diff"
+printf 'diff --git a/docs/readme.md b/docs/readme.md\n+ok\n' > "$low_diff"
+review_budget_policy_json pr "$low_diff" auto | jq -e '
+  .mode == "diff-scoped" and .fast_path.eligible == true and .risk_triggers == []
+' >/dev/null
+
+risky_diff="$TMPROOT/risky.diff"
+printf 'diff --git a/scripts/new.sh b/scripts/new.sh\n+ok\n' > "$risky_diff"
+review_budget_policy_json pr "$risky_diff" auto | jq -e '
+  .mode == "expanded" and (.risk_triggers | index("path:scripts/new.sh"))
+' >/dev/null
+
+large_diff="$TMPROOT/large.diff"
+{
+  printf 'diff --git a/docs/large.md b/docs/large.md\n'
+  seq 1 10 | sed 's/^/+line /'
+} > "$large_diff"
+STUDIO_REVIEW_PAYLOAD_MAX_DIFF_LINES=3 review_budget_policy_json pr "$large_diff" auto | jq -e '
+  .mode == "summarized" and .risk_level == "budget"
+' >/dev/null
+
+BIN="$TMPROOT/bin"
+REPO="$TMPROOT/repo"
+mkdir -p "$BIN" "$REPO"
+
+cat > "$BIN/yq" <<'SH'
+#!/usr/bin/env bash
+expr="$2"
+case "$expr" in
+  *detect_binary*) printf 'codex\n' ;;
+  *capabilities_path*) printf '.codex-reviewer/capabilities.yaml\n' ;;
+  *) printf 'unexpected yq expression: %s\n' "$expr" >&2; exit 2 ;;
+esac
+SH
+chmod +x "$BIN/yq"
+
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+case " $* " in
+  *" --help "*) printf 'codex fixture help\n'; exit 0 ;;
+esac
+case " $* " in
+  *"smoke test"*) printf 'STUDIO_REVIEW_VERDICT=approved\n'; exit 0 ;;
+esac
+[ -n "${REVIEW_PAYLOAD:-}" ] && [ -f "$REVIEW_PAYLOAD" ] || exit 3
+if grep -q '"mode":"diff-scoped"' "$REVIEW_PAYLOAD"; then
+  printf 'REVIEW_CONTEXT_FALLBACK=expanded\n'
+  exit 0
+fi
+grep -q '"mode":"expanded"' "$REVIEW_PAYLOAD" || exit 4
+grep -q 'Expanded repo review rules' "$REVIEW_PAYLOAD" || exit 5
+printf 'STUDIO_REVIEW_VERDICT=approved\n'
+SH
+chmod +x "$BIN/codex"
+
+export PATH="$BIN:$PATH"
+export HOME="$TMPROOT/caller-home"
+export CODEX_HOME="$HOME/.codex"
+export STUDIO_REVIEWER_SMOKE_TIMEOUT_SEC=0
+mkdir -p "$CODEX_HOME"
+
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name Test
+mkdir -p "$REPO/docs"
+printf 'one\n' > "$REPO/docs/readme.md"
+git -C "$REPO" add docs/readme.md
+git -C "$REPO" commit -qm initial
+printf 'two\n' >> "$REPO/docs/readme.md"
+git -C "$REPO" add docs/readme.md
+
+if ! (cd "$REPO" && bash "$ROOT/scripts/pre-commit-review.sh" --review-host codex-reviewer >"$TMPROOT/out" 2>"$TMPROOT/err"); then
+  sed -n '1,120p' "$TMPROOT/out" >&2 || true
+  sed -n '1,120p' "$TMPROOT/err" >&2 || true
+  exit 1
+fi
+
+grep -q 'PRECOMMIT_REVIEW_VERDICT=approved' "$TMPROOT/out"
+event_log=$(find "$HOME/.dev-studio" -type f -path '*/events/*.jsonl' | head -1)
+[ -n "$event_log" ] || { printf 'missing event log\n' >&2; exit 1; }
+jq -e 'select(.event == "precommit_review_passed" and .data.review_context.mode == "expanded" and .data.review_context.payload.estimated_tokens > 0)' "$event_log" >/dev/null
+
+printf 'PASS: review budget policy and precommit fallback\n'


### PR DESCRIPTION
Closes #537\n\n## Summary\n- add shared review payload budget helpers\n- make PR and pre-commit review payloads diff-scoped by default with risk-triggered expansion and one expanded-context fallback\n- emit review context telemetry for PR, pre-commit, phase, and dispatch review paths\n\n## Verification\n- bash scripts/test-fixtures/537-review-budget/test-review-budget.sh\n- bash scripts/test-fixtures/523-context-budget/test-context-budget.sh\n- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh\n- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh\n- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-fallback.sh\n- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-cross-host-policy.sh\n- bash scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh\n- bash scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh\n- bash scripts/test-fixtures/454-phase-review/test-phase-review.sh\n- bash -n scripts/lib-review-budget.sh scripts/pr-headless-review.sh scripts/pre-commit-review.sh scripts/phase-review.sh scripts/dispatch-review.sh scripts/test-fixtures/537-review-budget/test-review-budget.sh\n- scripts/lint-field-review-surfaces.sh\n- scripts/lint-host-agnostic.sh (existing W_ARGUS_SECRET_SCOPE warning)