### PR TITLE
Handle string refactoring items in chain outcomes

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-04T20:46:18Z",
+  "generated_at": "2026-05-05T01:53:13Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-04T20:46:17Z",
+  "generated_at": "2026-05-05T01:53:13Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -2444,10 +2444,16 @@ write_issue_phase_outcome_artifact() {
     ' "$summary_file"
     printf '\n## Refactoring Pressure\n\n'
     jq -r '
+      def text_item($x):
+        if ($x | type) == "object" then
+          "\($x.affected_area // "unknown area") - \($x.reason // "no reason supplied") (risk: \($x.risk // "unknown")\(if $x.suggested_timing then ", timing: \($x.suggested_timing)" else "" end))"
+        else
+          ($x | tostring)
+        end;
       def rows($label; $items):
         ($items // []) as $xs |
         if ($xs | length) == 0 then ["- \($label): none"]
-        else [ $xs[] | "- \($label): \(.affected_area // "unknown area") - \(.reason // "no reason supplied") (risk: \(.risk // "unknown")\(if .suggested_timing then ", timing: \(.suggested_timing)" else "" end))" ]
+        else [ $xs[] | "- \($label): \(text_item(.))" ]
         end;
       rows("needed now"; .refactoring_needed_now)[],
       rows("follow-up proposed"; .refactoring_follow_ups)[]


### PR DESCRIPTION
## Summary\n- allow chain outcome artifact generation to render string refactoring items as plain text\n- keeps object-shaped refactoring items unchanged\n- fixes the report-generation crash observed after #537 parent finalization\n\n## Verification\n- bash -n scripts/studio-chain-runner.sh\n- jq formatter check against the #537 worker summary that previously crashed