### PR TITLE
Polish Argus verdict and investigation brief guidance (#22 #23)

### DIFF
--- a/_shared/contracts/brief-formats/impl-brief.md
+++ b/_shared/contracts/brief-formats/impl-brief.md
@@ -108,6 +108,12 @@ Before starting, load these skills for guidance:
 - Inspect each unit against the same acceptance criteria and record findings in one structured report shape.
 - Keep the execution in one worker session; if the scope is too large, split the work into child executable tasks before dispatch.
 
+### Investigation-Shaped Task Recipe
+<!-- Optional. Include when the observed evidence is compatible with multiple causes. -->
+- Before committing to one diagnosis, enumerate at least two independent mechanisms that could produce the observed evidence.
+- For each mechanism, name one distinguishing evidence check that would separate it from the others.
+- Run or document the cheapest distinguishing check before editing; if it cannot be run, keep the diagnosis provisional in the debrief.
+
 ## Testability Requirements
 
 ### Architecture & SOLID

--- a/_shared/rules/review-rules.md
+++ b/_shared/rules/review-rules.md
@@ -26,7 +26,7 @@ Argus's narrow v1 review catalog. These are the checks Achilles cannot do well f
 | Verdict | Meaning | Action |
 |---|---|---|
 | **Block** | Cannot merge safely | Argus returns `blocked`; Achilles loops back to revise |
-| **Flag** | Suboptimal; mergeable with user approval | Argus records findings in `review_<task-id>.md`; autonomous Achilles defers merge until the user fixes first or explicitly overrides |
+| **Flag** | Suboptimal; mergeable with user approval | Argus records findings in `plans/reviews/<review-id>.yaml`; autonomous Achilles defers merge until the user fixes first or explicitly overrides |
 | **Approve** | Nothing notable | Silent; merge proceeds |
 
 ---
@@ -235,13 +235,44 @@ When the task brief has `Type: test-tdd`:
 
 ## Review File Format
 
-Argus writes findings to `<project-memory>/reviews/review_<task-id>.md`:
+Argus writes the source-of-truth review artifact to
+`~/.dev-studio/<project>/plans/reviews/<review-id>.yaml`. The canonical verdict
+line is the lowercase YAML field `verdict: <approved|flagged|blocked>`. Legacy
+compatibility markdown, when dual-written, must place the same lowercase field
+in YAML frontmatter; a human-readable bold verdict in the body is optional and
+never authoritative.
+
+```yaml
+schema_version: {name: review, version: 1.3.0, min_reader: 1.0.0, deprecated_at: null}
+id: <review-id>
+subject: {kind: task, id: <task-uuid>}
+reviewer: argus
+stage: spec | quality
+state: approved | flagged | blocked
+requested_at: <ISO8601 timestamp>
+completed_at: <ISO8601 timestamp>
+verdict: approved | flagged | blocked
+findings:
+  - rule: <rule-id>
+    tier: block | auto-fix | ask | warn
+    message: <finding summary>
+checks_run: []
+scope: {context_scopes: [diff-only], diff_size: <lines>, file_count: <count>, caps_triggered: []}
+idempotency_key: <key>
+```
+
+Optional legacy markdown uses the same verdict key:
 
 ```markdown
-# Argus Review: <task-id>
+---
+review_id: <review-id>
+stage: spec | quality
+verdict: approved | flagged | blocked
+review_artifact: plans/reviews/<review-id>.yaml
+---
+
+# Argus Review (<stage>): <task-id>
 Reviewed: <ISO8601 timestamp>
-Task size: <XS|S|M|L>
-Verdict: approved | flagged | blocked
 Block reason: <if blocked>
 
 ## Checks Run

--- a/scripts/analyze-collect.sh
+++ b/scripts/analyze-collect.sh
@@ -240,11 +240,10 @@ count_verdict_events() {
        | wc -l | tr -d ' '
 }
 
-# File-scan cross-check. Hardened regex accepts plain `Verdict: x`, bold
-# `**Verdict:** x`, and lowercase variants (#21). Approved files are usually
-# absent (argus skips them), so the approved cross-check is expected to lag.
-# Two anchored alternatives rather than one loose pattern — keeps the match
-# tight (requires a colon) while accepting both styles we see in practice.
+# File-scan cross-check. New Argus markdown uses lowercase YAML frontmatter
+# (`verdict: x`) as the canonical line; the bold/plain alternatives are
+# historical compatibility from #21. Approved files are usually absent (argus
+# skips them), so the approved cross-check is expected to lag.
 count_verdict_files() {
   local verdict="$1"
   [ -d "$REVIEW_DIR" ] || { echo 0; return; }

--- a/scripts/argus-emit-verdict.sh
+++ b/scripts/argus-emit-verdict.sh
@@ -104,10 +104,14 @@ if [ -n "$LEGACY_REVIEW_FILE" ]; then
   finding_count=$(printf '%s' "$FINDINGS_JSON" | jq 'length' 2>/dev/null || echo 0)
   ts=$(iso_ts_now)
   {
+    printf -- '---\n'
+    printf 'review_id: %s\n' "$REVIEW_ID"
+    printf 'stage: %s\n' "$STAGE"
+    printf 'verdict: %s\n' "$VERDICT"
+    printf 'review_artifact: plans/reviews/%s.yaml\n' "$REVIEW_ID"
+    printf -- '---\n\n'
     printf '# Argus Review (%s): %s\n' "$STAGE" "$TASK_ID"
     printf 'Reviewed: %s\n' "$ts"
-    printf 'Stage: %s\n' "$STAGE"
-    printf 'Verdict: %s\n' "$VERDICT"
     [ -n "$BLOCK_REASON" ] && printf 'Block reason: %s\n' "$BLOCK_REASON"
     printf 'Review UUID: %s\n\n' "$REVIEW_ID"
     printf '## Findings (%s)\n\n' "$finding_count"

--- a/scripts/test-fixtures/022-argus-verdict-format/test-argus-verdict-format.sh
+++ b/scripts/test-fixtures/022-argus-verdict-format/test-argus-verdict-format.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t argus-verdict-format-022.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+export HOME="$TMPROOT/home"
+export ACHILLES_PROJECT="argus-verdict-format-022"
+TASK_UUID="0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11"
+PROJECT_ROOT="$HOME/.dev-studio/$ACHILLES_PROJECT"
+LEGACY_REVIEW="$TMPROOT/review_T022_quality.md"
+
+mkdir -p "$PROJECT_ROOT/plans/tasks"
+cat > "$PROJECT_ROOT/plans/tasks/$TASK_UUID.yaml" <<'YAML'
+schema_version: {name: task, version: 1.0.0, min_reader: 1.0.0, deprecated_at: null}
+id: 0190f52a-6e0c-7b3c-9a1d-0d4e9b7f6a11
+legacy_task_id: "T022"
+state: in-review
+updated_at: 2026-05-05T00:00:00Z
+links: {reviews: []}
+YAML
+
+DRY_RUN=1 "$ROOT/scripts/argus-emit-verdict.sh" T022 approved '[]' \
+  --task-uuid "$TASK_UUID" \
+  --review-file-legacy "$LEGACY_REVIEW" \
+  >/dev/null
+
+grep -q '^verdict: approved$' "$LEGACY_REVIEW" \
+  || fail "legacy review did not use canonical lowercase verdict line"
+
+sed -n '1,5p' "$LEGACY_REVIEW" | grep -q '^verdict: approved$' \
+  || fail "canonical verdict was not in YAML frontmatter"
+
+if grep -qE '^(Verdict:|\\*\\*Verdict:\\*\\*)' "$LEGACY_REVIEW"; then
+  fail "legacy review emitted a non-canonical verdict line"
+fi
+
+printf 'PASS: argus verdict format\n'


### PR DESCRIPTION
Closes #22\nCloses #23\n\n## Summary\n- make Argus legacy markdown emit YAML frontmatter with canonical lowercase verdict\n- document plans/reviews YAML as the source-of-truth review artifact and legacy markdown as compatibility output\n- add an investigation-shaped recipe to the implementation brief template to enumerate plausible mechanisms and distinguishing evidence\n\n## Verification\n- scripts/test-fixtures/022-argus-verdict-format/test-argus-verdict-format.sh\n- bash scripts/test-fixtures/223-argus-contract-hardening/test-argus-contract-hardening.sh\n- scripts/test-fixtures/606-review-rubric/test-review-rubric.sh\n- scripts/test-fixtures/analyze-collect/test-brief-dispatch-latency.sh\n- scripts/test-fixtures/323-brief-quality/test-brief-quality.sh\n- git diff --check\n- phase outcome reviews clean for #22 and #23