### PR TITLE
Standardize completion summary contract (#340)

### DIFF
--- a/_shared/contracts/completion-summary.md
+++ b/_shared/contracts/completion-summary.md
@@ -1,0 +1,47 @@
+---
+name: Completion Summary Contract
+description: Shared user-facing completion summary shape for manager, worker, reviewer, and debrief paths.
+type: contract
+---
+
+# Completion Summary Contract
+
+When a role gives the user a task-completion conclusion, the final human note
+uses this information architecture:
+
+```text
+We fixed/implemented <truthful outcome>.
+
+Impact on user:
+Behavior before:
+Behavior after:
+New behavior:
+
+Operational closure:
+PR/merge state:
+Local sync state:
+Worktree cleanup:
+Derived data and stale artifacts:
+
+Safe to end the session.
+```
+
+Labels may be adapted to the task type, but the summary must preserve the same
+shape:
+
+- Lead with `We fixed ...`, `We implemented ...`, or the closest truthful
+  equivalent for review-only, blocked, or no-change work.
+- Split user impact into before, after, and new behavior when the task changed
+  user-visible behavior. If one field does not apply, say `Not applicable` and
+  why in a short phrase.
+- State operational closure explicitly: PR or merge status, local sync status,
+  worktree cleanup, and derived-data or stale-artifact cleanup.
+- End with `Safe to end the session.` only when merge or closure, local sync,
+  required cleanup, and required artifact writes actually completed.
+- If merge, sync, cleanup, verification, or artifact emission did not happen,
+  replace the safe-close line with `Not safe to end the session yet:` followed
+  by the remaining blocker or owner.
+
+This contract governs user-facing conclusions only. Typed artifacts such as
+worker summaries, debrief YAML, reviewer verdicts, release packets, and event
+log entries remain the source of truth for automation.

--- a/_shared/contracts/debrief-format.md
+++ b/_shared/contracts/debrief-format.md
@@ -66,6 +66,13 @@ Task-mode writers normally call `scripts/task-emit-debrief.sh`, which wraps
 `write_debrief_artifact` from `scripts/lib-ledger.sh`, validates the payload,
 sets `tasks/<uuid>.yaml` `links.debrief`, and emits `debrief_emitted`.
 
+When a debrief is also summarized back to the user, the human-facing conclusion
+follows `_shared/contracts/completion-summary.md`. The YAML debrief remains the
+automation source of truth; the visible summary must still name the user impact,
+before/after/new behavior when applicable, PR or merge state, local sync state,
+worktree cleanup, derived-data or stale-artifact cleanup, and whether it is
+actually safe to end the session.
+
 The archived pre-Phase 2.6 section-header template lives at
 `_shared/contracts/.legacy/debrief-format-md.md` for old artifact readability
 only. Active writers MUST NOT use it.

--- a/core/v2/roles/manager.yaml
+++ b/core/v2/roles/manager.yaml
@@ -79,5 +79,6 @@ verification_floor:
   - Studio-internal suggestions are shown only for the studio repo or when the user explicitly asks for studio operations.
   - Locked-in workflows report the direct command or phrasing the user can use next time.
   - Shaped intent and summaries distinguish refactoring needed now from refactoring follow-up proposed.
+  - "User-facing workflow completion summaries follow `_shared/contracts/completion-summary.md`: lead with a truthful fixed/implemented outcome, split user impact into before/after/new behavior when applicable, state PR or merge, local sync, worktree cleanup, and derived-data or stale-artifact cleanup, and use `Safe to end the session.` only when those closure facts are true."
   - Manager checkpoints contain only routing context; explicit role checkpoint content remains role-owned.
   - Manager analyze reports final feedback inbox count and every durable destination; source records move to processed/ only after a destination issue/comment exists and `feedback_ingested` records the source, destination issue, and disposition.

--- a/core/v2/roles/reviewer.yaml
+++ b/core/v2/roles/reviewer.yaml
@@ -68,4 +68,5 @@ verification_floor:
   - Refactoring findings distinguish required current-task cleanup from deferred design debt and recommend manager/planner follow-up when broad cleanup is not justified.
   - Findings are ordered by derived severity and grounded in file, artifact, or command references rather than prose tone.
   - Clean reviews say nothing_fatal explicitly and record any residual warnings or skipped evidence.
+  - "User-facing review conclusions that hand back final task status follow `_shared/contracts/completion-summary.md`: lead with a truthful reviewed/accepted/blocked equivalent, split user impact into before/after/new behavior when applicable, state PR or merge, local sync, worktree cleanup, and derived-data or stale-artifact cleanup, and use `Safe to end the session.` only when those closure facts are true."
   - Reviewer checkpoints may preserve pending review context, but the reviewer-verdict remains the only review gate artifact.

--- a/core/v2/roles/worker.yaml
+++ b/core/v2/roles/worker.yaml
@@ -63,5 +63,6 @@ verification_floor:
   - Reviewer-requested changes include a worker self-check and per-finding response state before implementation.
   - The private worker-summary artifact is valid JSON, names the final commit when changes are made, and distinguishes self_review_performed, self_review_findings, self_review_fixes, and final_verification_evidence.
   - Worker artifacts distinguish refactoring needed now from refactoring follow-up proposed, and deferred refactoring concerns are copied into carryover or follow_ups for manager ingestion.
+  - "User-facing task completion or debrief summaries follow `_shared/contracts/completion-summary.md`: lead with a truthful fixed/implemented outcome, split user impact into before/after/new behavior when applicable, state PR or merge, local sync, worktree cleanup, and derived-data or stale-artifact cleanup, and use `Safe to end the session.` only when those closure facts are true."
   - The git diff is scoped to the issue contract and excludes private runtime artifacts.
   - Worker checkpoint use is optional and is reported separately from required worker-summary and debrief evidence.

--- a/scripts/test-fixtures/340-completion-summary/test-completion-summary-contract.sh
+++ b/scripts/test-fixtures/340-completion-summary/test-completion-summary-contract.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verifies the shared completion-summary convention is wired into role contracts.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CONTRACT="$ROOT/_shared/contracts/completion-summary.md"
+
+[ -f "$CONTRACT" ] || {
+  printf 'missing completion summary contract\n' >&2
+  exit 1
+}
+
+for required in \
+  'We fixed/implemented' \
+  'Impact on user:' \
+  'Behavior before:' \
+  'Behavior after:' \
+  'New behavior:' \
+  'PR/merge state:' \
+  'Local sync state:' \
+  'Worktree cleanup:' \
+  'Derived data and stale artifacts:' \
+  'Safe to end the session.' \
+  'Not safe to end the session yet:'; do
+  grep -F "$required" "$CONTRACT" >/dev/null || {
+    printf 'completion summary contract missing required phrase: %s\n' "$required" >&2
+    exit 1
+  }
+done
+
+for role in manager worker reviewer; do
+  grep -F '_shared/contracts/completion-summary.md' "$ROOT/core/v2/roles/$role.yaml" >/dev/null || {
+    printf '%s role does not reference completion-summary contract\n' "$role" >&2
+    exit 1
+  }
+done
+
+grep -F '_shared/contracts/completion-summary.md' "$ROOT/_shared/contracts/debrief-format.md" >/dev/null || {
+  printf 'debrief format does not reference completion-summary contract\n' >&2
+  exit 1
+}
+
+printf 'PASS: completion summary contract\n'

--- a/tests/mode-packs/studio/summary.yaml
+++ b/tests/mode-packs/studio/summary.yaml
@@ -11,12 +11,16 @@ failure_signals:
   - "The task is done\\."
   - "Let me know if"
 success_signals:
-  - "Safe To End"
-  - "Done:"
-  - "Changed:"
-  - "Verified:"
-  - "Not Done:"
-  - "Command:"
+  - "We (fixed|implemented)"
+  - "Impact on user:"
+  - "Behavior before:"
+  - "Behavior after:"
+  - "New behavior:"
+  - "PR/merge state:"
+  - "Local sync state:"
+  - "Worktree cleanup:"
+  - "Derived data and stale artifacts:"
+  - "Safe to end the session\\."
 notes: |
   Catches regressions where the final response becomes a vague prose summary
-  instead of the reusable completion-report shape.
+  instead of the shared completion-summary contract.


### PR DESCRIPTION
## Summary

- Adds a shared completion-summary contract for manager, worker, reviewer, and debrief user-facing conclusions.
- Wires manager/worker/reviewer role contracts and debrief docs to the shared completion shape.
- Updates the studio summary fixture and adds a focused regression fixture.

Closes #340

## Verification

- `scripts/test-fixtures/340-completion-summary/test-completion-summary-contract.sh`
- `bash scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- `git diff --check origin/main..HEAD`

## Notes

This PR ships only #340 from the completion-and-engineering-discipline chain. Remaining chain issues #328 and #50 will restart from updated main after this lands. Pre-existing architecture lint orphan fixture failures are tracked in #617.