### PR TITLE
Close stdin for Codex phase reviews (#619)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T01:53:13Z",
+  "generated_at": "2026-05-05T03:11:48Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T01:53:13Z",
+  "generated_at": "2026-05-05T03:11:48Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -233,10 +233,7 @@ case "$review_host" in
     ;;
 esac
 
-if ! ( cd "$REPO_ROOT" && case "$review_host" in
-    codex*|*codex*) "${review_cmd[@]}" > "$output" 2>"$err_output" ;;
-    *) "${review_cmd[@]}" </dev/null > "$output" 2>"$err_output" ;;
-  esac ); then
+if ! ( cd "$REPO_ROOT" && "${review_cmd[@]}" </dev/null > "$output" 2>"$err_output" ); then
   detail=$(first_line "$err_output")
   [ -n "$detail" ] || detail=$(first_line "$output")
   fail "reviewer command failed for $review_host${detail:+: $detail}"


### PR DESCRIPTION
## Summary

- Redirects stdin from `/dev/null` for all phase-review reviewer commands, including Codex reviewer commands.
- Keeps reviewer prompt construction and verdict parsing unchanged.
- Includes hook-regenerated schema surface files.

Closes #619

## Verification

- `scripts/phase-review.sh --review-host codex-reviewer --kind plan --input ... --output ...` returned `PHASE_REVIEW_VERDICT=clean`
- `git diff --check`