### PR TITLE
Close stdin for Codex reviewer smoke (#621)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T03:11:48Z",
+  "generated_at": "2026-05-05T03:17:21Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T03:11:48Z",
+  "generated_at": "2026-05-05T03:17:21Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -123,7 +123,7 @@ run_smoke_gate() {
         ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
         STUDIO_HOST="$HOST" \
         REVIEW_PAYLOAD="$payload" \
-        "${smoke_cmd[@]}" >"$stdout_file" 2>"$stderr_file" )
+        "${smoke_cmd[@]}" </dev/null >"$stdout_file" 2>"$stderr_file" )
       smoke_rc=$?
       ;;
     *)


### PR DESCRIPTION
## Summary

- Redirects stdin from `/dev/null` for Codex reviewer eligibility smoke commands.
- Prevents chain-runner inherited stdin from making Codex smoke read extra input before Claude-worker phase reviews.
- Includes hook-regenerated schema surface files.

Closes #621

## Verification

- `printf unexpected | scripts/pr-reviewer-eligibility.sh codex-reviewer` returned `PR_REVIEWER_ELIGIBLE=1` and `SMOKE=passed`
- `git diff --check`