### PR TITLE
Define shared engineering principles (#328)

### DIFF
--- a/_shared/contracts/engineering-principles.md
+++ b/_shared/contracts/engineering-principles.md
@@ -1,0 +1,74 @@
+---
+name: Engineering Principles Contract
+description: Shared quality bar for manager shaping, worker execution, and reviewer evaluation.
+type: contract
+---
+
+# Engineering Principles Contract
+
+Studio roles treat user prompts, generated plans, and prior artifacts as inputs
+to sharpen, not as infallible instructions.
+
+## Core Principles
+
+- Prefer root-cause fixes over local bandages.
+- Identify the broader failure mode before editing when the requested solution
+  appears brittle, local-only, or likely to recur.
+- Convert vague work into measurable acceptance criteria before dispatch or
+  implementation.
+- Split L-sized implementation work into S or M leaf tasks unless splitting
+  would make the work less safe or less reviewable.
+- Treat verification as part of implementation. Skipped tests, builds, or lints
+  need an explicit reason and residual risk.
+- Surface tradeoffs when the simplest implementation risks scale,
+  maintainability, future feature work, or long-lived ownership.
+- Design for production systems that grow: clear boundaries, durable naming,
+  explicit ownership, and reviewable behavior changes.
+- Auto-propose stronger approaches when engineering evidence supports them, but
+  require user approval for scope, behavior, permission, release, or ask-first
+  policy changes.
+
+## Manager Application
+
+Manager-shaped work includes:
+
+- Goal and user impact.
+- In-scope changes and non-goals.
+- Measurable, reviewer-testable acceptance criteria.
+- Churn layer, task size, risk level, and recommended verification.
+- Challenge/refine notes when the initial request is vague, brittle, oversized,
+  or missing verification.
+
+## Worker Application
+
+Worker execution includes:
+
+- Root-cause notes for bug fixes and non-trivial changes.
+- A same-host self-review before final verification.
+- Final verification evidence appropriate to task size, risk, and churn layer.
+- Explicit blocked or skipped-check reasons when verification cannot run.
+
+## Reviewer Application
+
+Reviewer verdicts can evaluate against this contract without the full
+conversation by reading the shaped plan, worker summary, diff, and verification
+evidence. Findings distinguish:
+
+- Missing root-cause analysis.
+- Unmeasurable acceptance criteria.
+- Oversized work that should have been split.
+- Verification that is absent, stale, too narrow, or not tied to the diff.
+- Scope expansion that crosses ask-first boundaries without approval.
+
+## Verification Matrix
+
+| Size / risk | Minimum expectation |
+|---|---|
+| XS docs or metadata | Focused lint, schema, grep, or fixture check; explain if no executable check exists. |
+| S low-risk code | Focused unit, contract, script, or lint check that reaches the changed surface. |
+| M or shared behavior | Focused tests plus relevant contract/schema/lint checks; include self-review notes. |
+| Bug fix | Root-cause note plus reproducer, regression test, or explicit reason a reproducer is unavailable. |
+| High-risk or cross-role substrate | Plan review, outcome review, focused verification, and PR review before merge. |
+
+This contract complements `_shared/rules/test-strategy.md`: churn layer chooses
+the test type, while size and risk choose the evidence floor.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T03:28:58Z",
+  "generated_at": "2026-05-05T03:40:53Z",
   "agents": [
 
   ]

--- a/core/v2/roles/manager.yaml
+++ b/core/v2/roles/manager.yaml
@@ -75,6 +75,7 @@ failure_semantics:
   - Stop before side effects when the request is ambiguous across studio-internal and project-runtime boundaries.
 verification_floor:
   - Shaped intent names the selected route, target repo/profile, in-scope work, non-goals, acceptance criteria, and blocked state if any.
+  - "Shaped plans follow `_shared/contracts/engineering-principles.md`: challenge vague, brittle, oversized, or unverifiable requests before dispatch; include measurable acceptance criteria, task size, risk level, churn layer, and recommended verification."
   - Bare-role landings list only lightweight next moves and defer heavy docs, logs, traces, or issue sweeps until the user chooses a path.
   - Studio-internal suggestions are shown only for the studio repo or when the user explicitly asks for studio operations.
   - Locked-in workflows report the direct command or phrasing the user can use next time.

--- a/core/v2/roles/reviewer.yaml
+++ b/core/v2/roles/reviewer.yaml
@@ -59,6 +59,7 @@ failure_semantics:
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
 verification_floor:
   - Evidence reviewed is listed in the verdict.
+  - "Plans, worker summaries, diffs, and verification evidence are checked against `_shared/contracts/engineering-principles.md` for root-cause analysis, measurable acceptance criteria, task-size discipline, scoped verification, and ask-first boundary crossings."
   - Worker or planner review targets record self_review_checked in the verdict; missing same-host self-review is a warn or block workflow defect, not a weak-summary note.
   - Reviewers inspect self_review_findings, self_review_fixes, and final_verification_evidence before requesting extra test reruns.
   - Test or build confidence distinguishes verified_by_worker_evidence from independently_rerun_by_reviewer.

--- a/core/v2/roles/worker.yaml
+++ b/core/v2/roles/worker.yaml
@@ -57,6 +57,7 @@ failure_semantics:
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
 verification_floor:
   - Same-host self-review runs after implementation and before final verification; it checks missed edge cases, possible bugs, regressions, scope drift, and test adequacy.
+  - "Implementation follows `_shared/contracts/engineering-principles.md`: bug fixes and non-trivial changes record root-cause notes, avoid bandage fixes, and match final verification to task size, risk, and churn layer."
   - Material same-host self-review findings are fixed or recorded as blocked before final verification begins.
   - Final test, build, or lint verification runs once after self-review fixes, unless the worker contract explicitly requires a separate pre-fix reproducer.
   - Required checks from the worker contract are run or listed as skipped with reason.

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T03:28:58Z",
+  "generated_at": "2026-05-05T03:40:52Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/328-engineering-principles/test-engineering-principles-contract.sh
+++ b/scripts/test-fixtures/328-engineering-principles/test-engineering-principles-contract.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CONTRACT="$ROOT/_shared/contracts/engineering-principles.md"
+
+[ -f "$CONTRACT" ] || {
+  printf 'missing engineering principles contract\n' >&2
+  exit 1
+}
+
+for required in \
+  'Prefer root-cause fixes over local bandages.' \
+  'Convert vague work into measurable acceptance criteria' \
+  'Split L-sized implementation work into S or M leaf tasks' \
+  'Treat verification as part of implementation.' \
+  'Challenge/refine notes' \
+  'Root-cause notes for bug fixes and non-trivial changes.' \
+  'Reviewer verdicts can evaluate against this contract' \
+  'Verification Matrix'; do
+  grep -F "$required" "$CONTRACT" >/dev/null || {
+    printf 'engineering principles contract missing required phrase: %s\n' "$required" >&2
+    exit 1
+  }
+done
+
+for role in manager worker reviewer; do
+  grep -F '_shared/contracts/engineering-principles.md' "$ROOT/core/v2/roles/$role.yaml" >/dev/null || {
+    printf '%s role does not reference engineering principles contract\n' "$role" >&2
+    exit 1
+  }
+done
+
+printf 'PASS: engineering principles contract\n'


### PR DESCRIPTION
## Summary

- Adds a shared engineering-principles contract for manager, worker, and reviewer workflows.
- Wires manager/worker/reviewer role contracts to root-cause, challenge/refine, task sizing, and verification expectations.
- Adds a focused regression fixture for the contract and role references.

Closes #328

## Verification

- `scripts/test-fixtures/328-engineering-principles/test-engineering-principles-contract.sh`
- `bash scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- `git diff --check`
- `scripts/lint-host-agnostic.sh` (0 errors; existing Argus secret-scope warning)