### PR TITLE
Add Definition of Done contract (#50)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -239,6 +239,7 @@ Tag-only is fine for **internal markers** (`pre-merge-test`, `scratch-before-ref
 
 1. Ensure `main` is green (scripts pass `bash -n`, smoke tests pass, REVIEW.md rules satisfied).
 2. Draft the release notes in this template — work on a scratch file first (`/tmp/vX.Y.Z-notes.md`), not directly in the tag annotation.
+   Start from `Changelog:` commit trailers when they exist; see `_shared/contracts/definition-of-done.md`. If trailers are missing, insufficient, or superseded, record that in the release packet instead of silently reconstructing notes from commit subjects.
 3. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z — <short title>"` with an annotated tag, not a lightweight one.
 4. Push the tag: `git push origin vX.Y.Z`.
 5. Create the release: `gh release create vX.Y.Z --notes-file /tmp/vX.Y.Z-notes.md --title "vX.Y.Z — <short title>"`. Add `--prerelease` for `-beta.N` / `-rc.N`; omit for stable drops.

--- a/_shared/contracts/definition-of-done.md
+++ b/_shared/contracts/definition-of-done.md
@@ -1,0 +1,58 @@
+---
+name: Definition Of Done Contract
+description: Shared completion checklist and changelog trailer convention for worker and release workflows.
+type: contract
+---
+
+# Definition Of Done Contract
+
+Done means completion evidence is explicit, not inferred from a commit subject
+or a vague final note.
+
+## Checklist
+
+For every implementation task, worker evidence records each item as `done`,
+`not_applicable`, or `waived`, with a short reason for every non-`done` item:
+
+- Tests or equivalent verification.
+- Accessibility impact.
+- Localization impact.
+- Performance impact.
+- Analytics or telemetry impact.
+- Feature flag or rollout impact.
+- Changelog trailer.
+
+The checklist is scaled by task type. Documentation-only, internal substrate,
+and no-user-visible-change tasks can mark product-facing items
+`not_applicable`, but they still record that judgment.
+
+## Changelog Trailer
+
+Commits that change user-visible behavior include one trailer:
+
+```text
+Changelog: <release-note bullet>
+```
+
+The trailer is a concise release-note candidate, written from the user's point
+of view. It avoids implementation detail, private project names, branch names,
+task IDs, and raw review text.
+
+Internal-only commits use an explicit waiver instead of an empty trailer:
+
+```text
+Changelog: none (internal-only)
+```
+
+Release tooling and release-manager packets treat `Changelog:` trailers as
+source material for release notes. Human editing remains allowed, but the
+default path is trailer aggregation rather than reconstructing intent from
+commit subjects.
+
+## Evidence Rules
+
+- Worker summaries name the checklist state or point to the artifact that
+  carries it.
+- A completion claim without checklist state is incomplete.
+- A release packet that ignores available `Changelog:` trailers records why the
+  trailers were insufficient or superseded.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T03:40:53Z",
+  "generated_at": "2026-05-05T03:48:23Z",
   "agents": [
 
   ]

--- a/core/v2/roles/release-manager.yaml
+++ b/core/v2/roles/release-manager.yaml
@@ -54,6 +54,7 @@ failure_semantics:
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
 verification_floor:
   - Release packet names release scope, anchor issues including #214, notes state, tag state, GitHub release state, TestFlight/App Store state, and blockers.
+  - "Release notes inspect `Changelog:` trailers per `_shared/contracts/definition-of-done.md`; if trailers are ignored or rewritten, the release packet records why."
   - Build/release message lint and external-channel states are represented as explicit evidence states.
   - Any release-blocking item names the missing evidence or required operator decision.
   - Release-manager checkpoints may summarize packet progress, but release-packet remains the release readiness artifact.

--- a/core/v2/roles/worker.yaml
+++ b/core/v2/roles/worker.yaml
@@ -63,6 +63,7 @@ verification_floor:
   - Required checks from the worker contract are run or listed as skipped with reason.
   - Reviewer-requested changes include a worker self-check and per-finding response state before implementation.
   - The private worker-summary artifact is valid JSON, names the final commit when changes are made, and distinguishes self_review_performed, self_review_findings, self_review_fixes, and final_verification_evidence.
+  - "Completion evidence follows `_shared/contracts/definition-of-done.md`: tests, accessibility, localization, performance, analytics, feature flag, and changelog trailer are each marked done, not_applicable, or waived with reason."
   - Worker artifacts distinguish refactoring needed now from refactoring follow-up proposed, and deferred refactoring concerns are copied into carryover or follow_ups for manager ingestion.
   - "User-facing task completion or debrief summaries follow `_shared/contracts/completion-summary.md`: lead with a truthful fixed/implemented outcome, split user impact into before/after/new behavior when applicable, state PR or merge, local sync, worktree cleanup, and derived-data or stale-artifact cleanup, and use `Safe to end the session.` only when those closure facts are true."
   - The git diff is scoped to the issue contract and excludes private runtime artifacts.

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T03:40:52Z",
+  "generated_at": "2026-05-05T03:48:22Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/50-definition-of-done/test-definition-of-done-contract.sh
+++ b/scripts/test-fixtures/50-definition-of-done/test-definition-of-done-contract.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CONTRACT="$ROOT/_shared/contracts/definition-of-done.md"
+
+[ -f "$CONTRACT" ] || {
+  printf 'missing definition-of-done contract\n' >&2
+  exit 1
+}
+
+for required in \
+  'Tests or equivalent verification.' \
+  'Accessibility impact.' \
+  'Localization impact.' \
+  'Performance impact.' \
+  'Analytics or telemetry impact.' \
+  'Feature flag or rollout impact.' \
+  'Changelog trailer.' \
+  'Changelog: <release-note bullet>' \
+  'Changelog: none (internal-only)'; do
+  grep -F "$required" "$CONTRACT" >/dev/null || {
+    printf 'definition-of-done contract missing required phrase: %s\n' "$required" >&2
+    exit 1
+  }
+done
+
+grep -F '_shared/contracts/definition-of-done.md' "$ROOT/core/v2/roles/worker.yaml" >/dev/null || {
+  printf 'worker role does not reference definition-of-done contract\n' >&2
+  exit 1
+}
+
+grep -F '_shared/contracts/definition-of-done.md' "$ROOT/core/v2/roles/release-manager.yaml" >/dev/null || {
+  printf 'release-manager role does not reference definition-of-done contract\n' >&2
+  exit 1
+}
+
+grep -F 'Changelog:' "$ROOT/RELEASES.md" >/dev/null || {
+  printf 'RELEASES.md does not mention Changelog trailers\n' >&2
+  exit 1
+}
+
+printf 'PASS: definition-of-done contract\n'


### PR DESCRIPTION
## Summary

- Adds a Definition-of-Done contract with explicit done/not-applicable/waived checklist states.
- Defines `Changelog:` commit trailer conventions and release-manager consumption guidance.
- Wires worker and release-manager role contracts plus RELEASES.md to the convention.

Closes #50

## Verification

- `scripts/test-fixtures/50-definition-of-done/test-definition-of-done-contract.sh`
- `bash scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- `git diff --check`
- `scripts/lint-host-agnostic.sh` (0 errors; existing Argus secret-scope warning)