### PR TITLE
Fix manager analyze project routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 /dev-studio reviewer review      # walk REVIEW.md against the pending diff
 /dev-studio release-manager      # draft release notes per RELEASES.md (never auto-tags)
 /dev-studio manager ingest       # capture one idea in the current repo context; --scope studio crosses to Forge
-/dev-studio manager analyze      # sweep analysis inputs, then route studio-feedback to durable issue destinations
+/dev-studio manager reconcile    # project repo: sync emitted debriefs/reports into the task ledger
+/dev-studio manager analyze      # studio repo: telemetry/log analysis plus studio feedback triage
 /dev-studio checkpoint           # manager-shaped checkpoint routing; explicit role owns content
 /dev-studio worker checkpoint    # worker-owned compact checkpoint; does not replace worker summary
 /dev-studio worker resume-checkpoint # resume worker checkpoint via manifest.json + context.md first
@@ -118,6 +119,8 @@ scripts/studio-weekly.sh --post                             # weekly GitHub PM d
 scripts/host-preflight.sh codex /repo                       # prove gh + git credential access before host task work
 scripts/studio-project-state.sh --status Todo               # Project-field backlog reader for Status / Track / Phase / Size / review state
 scripts/studio-gh.sh issue list --state open                # assistant-safe GitHub CLI wrapper for narrow issue lookups; normalizes synthetic Codex HOME
+scripts/manager-reconcile.sh --cwd "$PWD"                   # project report/debrief sync into the project task ledger
+scripts/manager-analyze.sh --cwd "$PWD"                     # studio-checkout analysis and feedback triage
 scripts/studio-dependency-export.sh --issue 443             # Mermaid graph from native GitHub blocked_by dependencies
 scripts/studio-chain-reviewed.sh v2-transition --host codex --review-host claude-reviewer  # pre-run plan review + reviewed chain PR merges
 # Chain manifests may set phase_review: required|auto|off; required/auto gates issue phases through scripts/phase-review.sh and forwards compact clean outcome feedback privately.
@@ -186,8 +189,10 @@ scripts/                # multi-worker fleet (BETA)
   host-preflight.sh    # pre-task host parity gate: gh auth + git ls-remote credential access
   studio-gh.sh          # GitHub CLI wrapper for assistant/interactive calls; normalizes synthetic Codex HOME
   dev-studio-ingest-resolve.sh # resolves /dev-studio manager ingest destination as JSON
+  manager-reconcile.sh  # /dev-studio manager reconcile: project debrief/report sync into task state
+  manager-analyze.sh    # /dev-studio manager analyze: studio-checkout analysis + feedback triage
   ingest-feedback.sh    # routes studio-feedback records to analysis + GH issue create/comment/defer
-  analyze-feedback-ingest.sh # manager analyze: consolidate feedback into existing/new GH issues before processed/
+  analyze-feedback-ingest.sh # studio feedback triage: consolidate into existing/new GH issues before processed/
   detect-edits.sh       # sweep-time blind-spot detector — brief_edited + debrief_edited
   appstore-watch.sh     # polls ASC for pending submission; finalizes draft release + Slack on release
   backfill-orphan-debriefs.sh  # recover tasks that finished without landing in master plan (dry-run default)

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T03:48:23Z",
+  "generated_at": "2026-05-05T13:40:43Z",
   "agents": [
 
   ]

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -54,6 +54,11 @@ supplies the task context and runtime slug.
    explicitly names another project slug. For `manager ingest`, call
    `$STUDIO_REPO/scripts/dev-studio-ingest-resolve.sh --cwd "$PROJECT_ROOT"`
    with any explicit `--scope` or `--to` arguments and follow its JSON route.
+   For `manager analyze`, call
+   `$STUDIO_REPO/scripts/manager-analyze.sh --cwd "$PROJECT_ROOT"`. It is
+   studio-checkout only; if invoked from a project checkout, surface the
+   script's refusal and point to `manager reconcile`. For `manager reconcile`,
+   call `$STUDIO_REPO/scripts/manager-reconcile.sh --cwd "$PROJECT_ROOT"`.
    Use studio scripts from `$STUDIO_REPO/scripts/`.
 
 7. For a bare-role landing:

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -6,144 +6,71 @@ schema_version: 1
 version: 0.1.0
 ---
 
-# dev-studio — Studio v2 Umbrella Router
+# dev-studio — Studio v2 Router
 
-`/dev-studio` is the Studio v2 entrypoint and primary traffic surface. It routes
-by canonical role first and keeps former top-level names as compatibility
-aliases. A10 records v2 as the only active traffic surface in
-`core/v2/cutover/manifest.yaml`; the v1 router surfaces are deleted from the
-repo and recoverable only from git history.
-
-Pattern contract: `core/v2/SPEC.md` §Roles and Handoffs. Canonical roles and
-compatibility aliases: `core/v2/registry/roles.json`. Forwarder manifest:
-`core/v2/skills/dev-studio/forwarders.yaml`.
+`/dev-studio` routes by canonical role. Role contracts live in `core/v2/roles`;
+aliases live in `core/v2/registry/roles.json` and `forwarders.yaml`. The v1
+router surfaces are deleted after A10.
 
 <!-- v2-dev-studio:scope -->
 ## Scope
 
-The router chooses the role contract for an invocation. Mode procedure,
-authority checks, handoff validation, event emission, and project-profile
-commands stay outside this router. Checkpoint storage, schema details, budget
-telemetry, and resume lazy-load policy stay in `core/v2/checkpoints/CONTRACT.md`.
-
-Former top-level skills (`/chanakya`, `/achilles`, `/argus`, `/apollo`) are no
-longer repo-local router surfaces after A10. Their compatibility meaning is
-preserved as `/dev-studio <alias>` role resolution and documented in
-`forwarders.yaml`.
+The router selects the role contract only. Mode procedure, authority checks,
+handoffs, events, project profiles, and checkpoint storage stay in their owning
+contracts.
 
 <!-- v2-dev-studio:dispatch -->
 ## Dispatch table
 
-| Invocation | Canonical role | Compatibility names | Status |
-|---|---|---|---|
-| `/dev-studio manager ...` | `manager` | `chanakya`, `coordinator`, `orchestrator` | v1 deleted |
-| `/dev-studio worker ...` | `worker` | `achilles`, `implementer` | v1 deleted |
-| `/dev-studio reviewer ...` | `reviewer` | `argus`, `verifier` | v1 deleted |
-| `/dev-studio perf ...` | `perf` | `apollo`, `performance`, `performance-engineer` | v1 deleted |
-| `/dev-studio planner ...` | `planner` | `architect`, `luban`, `lu-ban` | reserved for A7+ |
-| `/dev-studio qa-engineer ...` | `qa-engineer` | `qa`, `chiron`, `synthetic-qa` | reserved for A7+ |
-| `/dev-studio flow-tester ...` | `flow-tester` | `flow`, `manual-qa`, `exploratory-tester` | reserved for A7+ |
-| `/dev-studio release-manager ...` | `release-manager` | `release`, `shipper` | reserved for A7+ |
-| `/dev-studio host-adapter ...` | `host-adapter` | `adapter`, `host` | reserved for adapter operations |
-| `/dev-studio operator ...` | `operator` | `user`, `human`, `owner` | reserved, non-routable human authority |
+Canonical roles: `manager`, `worker`, `reviewer`, `perf`, `planner`,
+`qa-engineer`, `flow-tester`, `release-manager`, `host-adapter`, `operator`.
+Compatibility aliases resolve through `scripts/v2-role-resolve.sh`.
 
 <!-- v2-dev-studio:lifecycle -->
 ## Lifecycle Actions
 
-`checkpoint` and `resume-checkpoint` are cross-role lifecycle actions. The
-router resolves the role first and leaves checkpoint content to that role's
-contract:
-
-| Invocation | Route | Behavior |
-|---|---|---|
-| `/dev-studio checkpoint ...` | `manager` landing | Shape the request, identify the intended role, and suggest the explicit role command. |
-| `/dev-studio resume-checkpoint ...` | `manager` landing | Shape resume intent, find the likely role or checkpoint selector, and avoid loading specialist state until routed. |
-| `/dev-studio <role> checkpoint ...` | selected role | Create or update a role-owned compact checkpoint using the shared checkpoint contract. |
-| `/dev-studio <role> resume-checkpoint ...` | selected role | Load `manifest.json` and `context.md` first, then lazy-load role-owned state only as needed. |
-
-Checkpoint artifacts preserve compact resume context. They do not replace
-worker summaries, reviewer verdicts, release packets, QA or flow checklists,
-perf verdicts, or durable event logs.
+`checkpoint` and `resume-checkpoint` route through the selected role. Bare
+checkpoint invocations land in `manager`; role-qualified invocations are owned
+by that role. Checkpoints do not replace summaries, verdicts, release packets,
+QA/flow checklists, perf verdicts, or event logs.
 
 <!-- v2-dev-studio:manager-analyze -->
-## Manager Analyze Feedback Routing
+## Manager Analyze Routing
 
-`/dev-studio manager analyze` is a workflow manager for studio-scoped feedback,
-not a passive report generator. After writing the private analysis report, it
-runs `scripts/analyze-feedback-ingest.sh --apply` from the studio repo so each
-safe actionable feedback record reaches a durable issue destination.
+`/dev-studio manager analyze` must call
+`scripts/manager-analyze.sh --cwd <current-project-root>`. It runs only from a
+`generic-dev-studio` checkout and owns studio-side telemetry/log analysis plus
+feedback triage. Project report syncing must use `/dev-studio manager
+reconcile`, which calls `scripts/manager-reconcile.sh --cwd
+<current-project-root>`.
 
-The manager must search existing GitHub issues before filing, comment or update
-a clearly covered issue, create one issue only for distinct work, and move a
-source record to `processed/` only after the destination exists. Unsafe public
-records stay in the inbox with a policy reason. Final output includes the
-remaining inbox count and the destination list.
+Studio-feedback records still search issues first, consolidate covered work,
+create only distinct issues, and move to `processed/` only after a destination
+exists. Unsafe public records stay in the inbox with a policy reason.
 
-Treat `(studio-feedback)` and `(studio feedback)` as lightweight capture tags
-when either form appears at the start of the prompt, at the end of the prompt,
-or on a line by itself. Match the tag with
-`^\(studio[-\s]feedback\)`, `\(studio[-\s]feedback\)\s*$`, or a standalone
-`\(studio[-\s]feedback\)` line. Strip the tag before filing, use the remaining
-prompt content as the feedback body, infer kind and slug from that content, and
-write the sidecar record under
-`~/.dev-studio/generic-dev-studio/feedback-inbox/<source-project>/`.
-After capture, continue answering any non-feedback part of the user's prompt
-normally; the tag adds a feedback side effect and does not replace the request.
+`(studio-feedback)` and `(studio feedback)` tags create sidecar records under
+the studio feedback inbox and do not replace the rest of the prompt.
 
 <!-- v2-dev-studio:landing -->
 ## Bare Role Landing
 
-When the invocation names a role but no target or subcommand, start that role in
-a lightweight conversational landing instead of running a heavy default action.
-Load the role contract, identify the current repo/profile, and offer a short
-set of likely next moves. The user can then describe the desired work in plain
-language without retyping `/dev-studio`.
-
-After the user locks in a path, continue into the selected workflow and report
-the direct one-line invocation they can use next time. Existing explicit
-invocations keep routing directly and do not show the landing.
-
-Landing suggestions are cwd/profile-aware. Studio-internal options (`audit`,
-`guard`, `sync`, `nodes`, `resume-plan`) target `generic-dev-studio` unless the
-user explicitly asks for studio operations from another project. `manager
-ingest` calls `scripts/dev-studio-ingest-resolve.sh`; default ingest follows
-the current git repository, and Forge/Studio ingest requires explicit `--scope
-studio` or `--to generic-dev-studio`. Project repositories should bias
-suggestions toward project task shaping, implementation, review, QA, flow
-testing, performance, and release readiness.
+Bare role invocations start a lightweight landing. Load the role contract,
+inspect cheap cwd/profile context, suggest likely next moves, then report the
+direct invocation once the workflow is selected. `manager ingest` calls
+`scripts/dev-studio-ingest-resolve.sh`; `manager analyze` calls
+`scripts/manager-analyze.sh`; `manager reconcile` calls
+`scripts/manager-reconcile.sh`.
 
 <!-- v2-dev-studio:intent -->
 ## Intent detection
 
-Priority order:
-
-1. **Explicit canonical role** — `/dev-studio worker <contract>` routes to the
-   `worker` role.
-2. **Compatibility alias** — `/dev-studio achilles <contract>` resolves
-   `achilles` through `scripts/v2-role-resolve.sh` and routes to `worker`.
-3. **Former top-level name** — `/dev-studio achilles <contract>` keeps the
-   old role name available without restoring the deleted v1 router.
-4. **Bare role token** — `/dev-studio reviewer` or `/dev-studio
-   release-manager` starts that role's lightweight landing.
-5. **No role token** — route to the `manager` landing; the manager owns
-   conversational shaping and status.
-
-Unknown role tokens fail before side effects with the explicit resolver error.
-Routing intelligence remains advisory unless a role contract grants authority.
+Priority: explicit canonical role, compatibility alias, former top-level name,
+bare role landing, then manager landing. Unknown role tokens fail before side
+effects.
 
 <!-- v2-dev-studio:forwarders -->
 ## Forwarders
 
-Compatibility alias state is data, not duplicated router prose. The
-schema-bearing manifest at `forwarders.yaml` is the source for adapter-specific
-command surfaces and transition docs. During a rollback window, a forwarder row
-names:
-
-- the legacy invocation;
-- the canonical role;
-- the v2 invocation template;
-- the v1 skill path it preserves during transition;
-- whether runtime traffic has cut over.
-
-Post-A10, `forwarders: []` is the expected state. Aliases do not add business
-logic, bypass role contracts, or widen permissions.
+Compatibility alias state is data in `forwarders.yaml`. Post-A10,
+`forwarders: []` is expected. Aliases do not add business logic, bypass role
+contracts, or widen permissions.

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -626,10 +626,10 @@ core/v2/skills/dev-studio/
 scripts/dev-studio-ingest-resolve.sh --cwd "$PWD" --scope studio</code>
           </section>
           <section class="card">
-            <h3>Analyze Feedback</h3>
-            <p>Manager analyze routes actionable studio-feedback to durable issues after the private report: search first, consolidate when covered, create only distinct issues, and leave unsafe public records in the inbox with a reason. Parenthesized <code>(studio-feedback)</code> or <code>(studio feedback)</code> tags add a sidecar feedback record while the rest of the prompt is handled normally.</p>
-            <code class="shell">scripts/analyze-feedback-ingest.sh
-scripts/analyze-feedback-ingest.sh --apply</code>
+            <h3>Reconcile And Analyze</h3>
+            <p>Project repos use reconcile to sync emitted debriefs and reports into the project task ledger. Analyze runs from the studio repo for telemetry/log analysis and studio feedback triage; actionable feedback records are searched, consolidated, or filed after privacy screening.</p>
+            <code class="shell">scripts/manager-reconcile.sh --cwd "$PWD"
+scripts/manager-analyze.sh --cwd "$PWD"</code>
           </section>
           <section class="card">
             <h3>Project Profiles</h3>
@@ -735,6 +735,7 @@ scripts/worker-status.sh</code>
 /dev-studio manager resume-plan
 /dev-studio manager guard "has this shipped?"
 /dev-studio manager analyze
+/dev-studio manager reconcile
 /dev-studio manager ingest "capture this pattern"
 /dev-studio manager ingest --scope studio "capture this Forge workflow gap"</code>
           </article>

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T03:48:22Z",
+  "generated_at": "2026-05-05T13:40:42Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -173,9 +173,11 @@ scripts/monitor-install.sh install                      # opt-in laptop LaunchAg
 scripts/node-monitor.sh                                 # one-shot monitor check; tracks streak/cooldown state and emits node_unreachable alerts (#132)
 scripts/task-emit-debrief.sh <task-uuid> <brief-uuid> self-reviewed '{...}'   # YAML debrief + state flips
 
-# Studio-feedback ingestion (auto-fires via SessionStart hook + manager sweep):
+# Manager reconcile/analyze + studio-feedback ingestion:
+scripts/manager-reconcile.sh --cwd "$PWD"               # project repo: sync emitted debriefs/reports into the project task ledger
+scripts/manager-analyze.sh --cwd "$PWD"                 # studio repo: telemetry/log analysis plus studio feedback triage
 scripts/ingest-feedback.sh                              # idempotent feedback route: create/comment/defer; silent outside generic-dev-studio
-scripts/analyze-feedback-ingest.sh --apply              # manager analyze durable routing: search/comment/create, then processed/
+scripts/analyze-feedback-ingest.sh --apply              # studio-feedback durable routing: search/comment/create, then processed/
 scripts/feedback-retroactive-sweep.sh --project generic-dev-studio --since YYYY-MM-DD [--apply] # recover missed `(studio-feedback)` / `(studio feedback)` transcript prompts
 
 # Studio PR autopilot primitives (#318):

--- a/scripts/manager-analyze.sh
+++ b/scripts/manager-analyze.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# manager-analyze.sh — studio-side analysis entrypoint.
+#
+# Analyze is intentionally studio-repo scoped. Project debrief/report syncing
+# mutates project task state and belongs to manager-reconcile.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+
+CWD="${PWD:-.}"
+APPLY=1
+EXTRA_ARGS=()
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  scripts/manager-analyze.sh [--cwd <dir>] [--apply|--dry-run]
+
+Run from generic-dev-studio only. To sync project debriefs/reports into a
+project task ledger, use scripts/manager-reconcile.sh from that project.
+EOF
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cwd) CWD="${2:?--cwd requires a value}"; shift 2 ;;
+    --cwd=*) CWD="${1#--cwd=}"; shift ;;
+    --scope|--scope=*)
+      printf 'manager-analyze: --scope is retired; run from generic-dev-studio, or use manager-reconcile for project reports\n' >&2
+      exit 2
+      ;;
+    --apply) APPLY=1; shift ;;
+    --dry-run) APPLY=0; shift ;;
+    -h|--help) usage ;;
+    --*) EXTRA_ARGS+=("$1"); shift ;;
+    *) EXTRA_ARGS+=("$1"); shift ;;
+  esac
+done
+
+project_root=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$CWD")
+project_slug=$(basename "$project_root")
+
+if [ ! -f "$project_root/core/v2/skills/dev-studio/SKILL.md" ] \
+    || [ ! -f "$project_root/scripts/analyze-feedback-ingest.sh" ]; then
+  printf 'manager-analyze: refusing project checkout %s; run /dev-studio manager reconcile for project debrief/report sync\n' "$project_slug" >&2
+  printf 'manager-analyze: run analyze from the generic-dev-studio repo for studio-side analysis and feedback triage\n' >&2
+  exit 2
+fi
+
+data_home="${HOME:-}"
+case "${STUDIO_BYPASS_ANALYZE_LOGIN_HOME:-0}" in
+  1|true|TRUE|yes|YES) ;;
+  *)
+    login_home=$(resolve_user_login_home 2>/dev/null || true)
+    if [ -n "$login_home" ] && [ -d "$login_home" ]; then
+      data_home="$login_home"
+    fi
+    ;;
+esac
+
+inbox_root=$(HOME="$data_home" resolve_feedback_inbox_root)
+export HOME="$data_home"
+if [ "$APPLY" = "1" ]; then
+  if [ "${#EXTRA_ARGS[@]}" -gt 0 ]; then
+    exec "$SCRIPT_DIR/analyze-feedback-ingest.sh" --apply --inbox-root "$inbox_root" "${EXTRA_ARGS[@]}"
+  fi
+  exec "$SCRIPT_DIR/analyze-feedback-ingest.sh" --apply --inbox-root "$inbox_root"
+fi
+if [ "${#EXTRA_ARGS[@]}" -gt 0 ]; then
+  exec "$SCRIPT_DIR/analyze-feedback-ingest.sh" --inbox-root "$inbox_root" "${EXTRA_ARGS[@]}"
+fi
+exec "$SCRIPT_DIR/analyze-feedback-ingest.sh" --inbox-root "$inbox_root"

--- a/scripts/manager-reconcile.sh
+++ b/scripts/manager-reconcile.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# manager-reconcile.sh — sync project reports into the project ledger.
+#
+# Reconcile mutates project task state from emitted debrief/report artifacts.
+# Studio-side analysis and feedback triage stay in manager-analyze.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+
+CWD="${PWD:-.}"
+APPLY=1
+EXTRA_ARGS=()
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  scripts/manager-reconcile.sh [--cwd <dir>] [--apply|--dry-run]
+
+Run from a project checkout to ingest emitted debrief/report artifacts into
+that project's task ledger. Studio feedback analysis belongs to manager analyze.
+EOF
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cwd) CWD="${2:?--cwd requires a value}"; shift 2 ;;
+    --cwd=*) CWD="${1#--cwd=}"; shift ;;
+    --scope|--scope=*)
+      printf 'manager-reconcile: --scope is not supported; reconcile always targets the current project ledger\n' >&2
+      exit 2
+      ;;
+    --apply) APPLY=1; shift ;;
+    --dry-run) APPLY=0; shift ;;
+    -h|--help) usage ;;
+    --*) EXTRA_ARGS+=("$1"); shift ;;
+    *) EXTRA_ARGS+=("$1"); shift ;;
+  esac
+done
+
+project_root=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$CWD")
+project_slug=$(basename "$project_root")
+
+if [ -f "$project_root/core/v2/skills/dev-studio/SKILL.md" ] \
+    && [ -f "$project_root/scripts/analyze-feedback-ingest.sh" ]; then
+  printf 'manager-reconcile: refusing generic-dev-studio; run from a project checkout, or use manager analyze for studio-side analysis\n' >&2
+  exit 2
+fi
+
+data_home="${HOME:-}"
+case "${STUDIO_BYPASS_ANALYZE_LOGIN_HOME:-0}" in
+  1|true|TRUE|yes|YES) ;;
+  *)
+    login_home=$(resolve_user_login_home 2>/dev/null || true)
+    if [ -n "$login_home" ] && [ -d "$login_home" ]; then
+      data_home="$login_home"
+    fi
+    ;;
+esac
+
+json_escape() {
+  jq -Rn --arg s "$1" '$s'
+}
+
+tmpdir=$(mktemp -d -t manager-reconcile.XXXXXX)
+trap 'rm -rf "$tmpdir"' EXIT
+queue="$tmpdir/debrief-queue.tsv"
+errors="$tmpdir/debrief-enumerate.err"
+processed="$tmpdir/processed.jsonl"
+failed="$tmpdir/failed.jsonl"
+touch "$processed" "$failed"
+
+if ! HOME="$data_home" ACHILLES_PROJECT="$project_slug" "$SCRIPT_DIR/sweep-enumerate-debriefs.sh" >"$queue" 2>"$errors"; then
+  printf 'manager-reconcile: debrief enumeration failed for %s\n' "$project_slug" >&2
+  cat "$errors" >&2
+  exit 2
+fi
+
+before_count=$(wc -l < "$queue" | tr -d ' ')
+
+if [ "$APPLY" = "1" ]; then
+  while IFS=$'\t' read -r subcmd source _format; do
+    [ -n "${subcmd:-}" ] || continue
+    if [ "${#EXTRA_ARGS[@]}" -gt 0 ]; then
+      if HOME="$data_home" ACHILLES_PROJECT="$project_slug" "$SCRIPT_DIR/sweep-ingest.sh" "$subcmd" "$source" "${EXTRA_ARGS[@]}" >/dev/null 2>"$tmpdir/ingest.err"; then
+        ingest_rc=0
+      else
+        ingest_rc=$?
+      fi
+    else
+      if HOME="$data_home" ACHILLES_PROJECT="$project_slug" "$SCRIPT_DIR/sweep-ingest.sh" "$subcmd" "$source" >/dev/null 2>"$tmpdir/ingest.err"; then
+        ingest_rc=0
+      else
+        ingest_rc=$?
+      fi
+    fi
+    if [ "$ingest_rc" -eq 0 ]; then
+      printf '{"subcommand":%s,"source":%s,"status":"ingested"}\n' \
+        "$(json_escape "$subcmd")" "$(json_escape "$source")" >> "$processed"
+    else
+      err=$(sed -n '1,20p' "$tmpdir/ingest.err" | paste -sd ' ' -)
+      printf '{"subcommand":%s,"source":%s,"status":"failed","error":%s}\n' \
+        "$(json_escape "$subcmd")" "$(json_escape "$source")" "$(json_escape "$err")" >> "$failed"
+    fi
+  done < "$queue"
+fi
+
+after_queue="$tmpdir/debrief-queue-after.tsv"
+after_errors="$tmpdir/debrief-enumerate-after.err"
+HOME="$data_home" ACHILLES_PROJECT="$project_slug" "$SCRIPT_DIR/sweep-enumerate-debriefs.sh" >"$after_queue" 2>"$after_errors" || true
+after_count=$(wc -l < "$after_queue" | tr -d ' ')
+processed_json=$(jq -s '.' "$processed")
+failed_json=$(jq -s '.' "$failed")
+
+jq -n \
+  --arg mode "$([ "$APPLY" = "1" ] && printf apply || printf dry-run)" \
+  --arg project "$project_slug" \
+  --arg cwd "$project_root" \
+  --argjson before "${before_count:-0}" \
+  --argjson after "${after_count:-0}" \
+  --argjson processed "$processed_json" \
+  --argjson failed "$failed_json" \
+  '{
+    schema_version: 1,
+    kind: "manager_reconcile_project_reports",
+    mode: $mode,
+    scope: "project",
+    project: $project,
+    project_root: $cwd,
+    debrief_queue_count_before: $before,
+    debrief_queue_count_after: $after,
+    processed_count: ($processed | length),
+    failed_count: ($failed | length),
+    processed: $processed,
+    failed: $failed
+  }'

--- a/scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh
+++ b/scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression fixture: manager analyze stays studio-scoped while manager
+# reconcile processes project debriefs without draining studio feedback.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+ANALYZE="$ROOT/scripts/manager-analyze.sh"
+RECONCILE="$ROOT/scripts/manager-reconcile.sh"
+ISSUES="$ROOT/scripts/test-fixtures/608-feedback-analyze-ingest/issues.json"
+TMPROOT=$(mktemp -d -t manager-analyze-routing.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq required"
+if ! command -v yq >/dev/null 2>&1; then
+  printf 'SKIP: yq required for manager analyze/reconcile routing fixture\n'
+  exit 0
+fi
+
+export HOME="$TMPROOT/home"
+export STUDIO_BYPASS_ANALYZE_LOGIN_HOME=1
+PROJECT_CWD="$TMPROOT/sample-app"
+PROJECT_ROOT="$HOME/.dev-studio/sample-app"
+STUDIO_INBOX="$HOME/.dev-studio/generic-dev-studio/feedback-inbox/sample-app"
+mkdir -p "$PROJECT_CWD" "$PROJECT_ROOT/plans/debriefs" "$STUDIO_INBOX"
+
+cat > "$PROJECT_ROOT/plans/debriefs/project-bug.yaml" <<'YAML'
+schema: debrief@2.0.2
+id: project-bug
+state: emitted
+mode: direct-debrief
+task_id: null
+legacy_task_id: null
+branch:
+  worked_on: null
+  merged_into: null
+  merge_sha: null
+argus_review:
+  status: invoked
+  review_id: null
+report_state: done_with_concerns
+follow_ups:
+  - title: Fix project-only bug reported from direct debrief
+YAML
+
+cat > "$STUDIO_INBOX/studio-feedback.md" <<'MD'
+---
+kind: rule-gap
+scope: generic-dev-studio
+ts: 2026-05-05T00:00:00Z
+---
+# Studio feedback should wait for studio scope
+
+Do not process this while analyzing project debriefs.
+MD
+
+if "$ANALYZE" --cwd "$PROJECT_CWD" >"$TMPROOT/analyze-project.out" 2>"$TMPROOT/analyze-project.err"; then
+  fail "project analyze should refuse outside generic-dev-studio"
+fi
+grep -q 'manager reconcile' "$TMPROOT/analyze-project.err" \
+  || fail "project analyze refusal should point to manager reconcile"
+
+PROJECT_OUT="$TMPROOT/project-out.json"
+"$RECONCILE" --cwd "$PROJECT_CWD" > "$PROJECT_OUT"
+
+jq -e '
+  .kind == "manager_reconcile_project_reports"
+  and .scope == "project"
+  and .project == "sample-app"
+  and .debrief_queue_count_before == 1
+  and .debrief_queue_count_after == 0
+  and .processed_count == 1
+  and .failed_count == 0
+' "$PROJECT_OUT" >/dev/null
+
+yq -e '.state == "ingested"' "$PROJECT_ROOT/plans/debriefs/project-bug.yaml" >/dev/null \
+  || fail "project debrief was not ingested"
+
+find "$PROJECT_ROOT/plans/tasks" -maxdepth 1 -type f -name '*.yaml' -print -quit | grep -q . \
+  || fail "project follow-up task was not minted"
+
+[ -f "$STUDIO_INBOX/studio-feedback.md" ] \
+  || fail "project reconcile should not process studio-feedback sidecar"
+
+STUDIO_OUT="$TMPROOT/studio-out.json"
+"$ANALYZE" --cwd "$ROOT" --dry-run --issues-file "$ISSUES" > "$STUDIO_OUT"
+jq -e '
+  .kind == "manager_analyze_feedback_ingest"
+  and .mode == "dry-run"
+  and .inbox_count_before == 1
+  and .inbox_count_after == 1
+' "$STUDIO_OUT" >/dev/null
+
+printf 'PASS: manager analyze/reconcile routing\n'


### PR DESCRIPTION
## Summary
- Add `scripts/manager-analyze.sh` as the studio-checkout-only `/dev-studio manager analyze` entrypoint.
- Add `scripts/manager-reconcile.sh` for project checkouts to sync emitted debrief/report artifacts into the project task ledger.
- Keep studio feedback triage inside studio-side analyze, and make project analyze refuse with a pointer to `manager reconcile`.
- Update router/docs surfaces and add a regression fixture for the analyze/reconcile split.

## Verification
- `scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh`
- `scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh`
- `bash -n scripts/manager-analyze.sh scripts/manager-reconcile.sh scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh`
- `git diff --check`
- `scripts/lint-skill-prose.sh core/v2/skills/dev-studio/SKILL.md`
- `scripts/lint-mode-pack.sh --staged`
- `scripts/lint-v2-enforcement.sh --staged`
- `STUDIO_REVIEW_PAYLOAD_MODE=expanded scripts/pre-commit-review.sh --review-host codex-reviewer` -> approved

## Manual Routing Checks
- `scripts/manager-analyze.sh --cwd /path/to/project --dry-run` refuses and points to `manager reconcile`.
- `scripts/manager-reconcile.sh --cwd /path/to/project --dry-run` returns `kind=manager_reconcile_project_reports`.
- `scripts/manager-analyze.sh --cwd <studio-checkout> --dry-run` returns `kind=manager_analyze_feedback_ingest`.

## Review
Codex reviewer approved. Claude reviewer could not read the temp review payload in this permission mode.
