### PR TITLE
Add configurable release notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 /dev-studio manager resume-plan  # "where were we" — load ROADMAP + ARCHITECTURE + pending memory
 /dev-studio reviewer review      # walk REVIEW.md against the pending diff
 /dev-studio release-manager      # draft release notes per RELEASES.md (never auto-tags)
+/dev-studio release-manager configure # one-time release notification setup (Slack TF/App Store)
 /dev-studio manager ingest       # capture one idea in the current repo context; --scope studio crosses to Forge
 /dev-studio manager reconcile    # project repo: sync emitted debriefs/reports into the task ledger
 /dev-studio manager analyze      # studio repo: telemetry/log analysis plus studio feedback triage
@@ -82,6 +83,7 @@ STUDIO_TRACK=<track>             # session-start shortcut for v2 track work
 /dev-studio host-adapter nodes   # day-2 fleet management — status, add, remove, health, sync, schedule
 /dev-studio release-manager tf-push --background     # start TF archive/upload and keep session free for Slack drafting
 /dev-studio release-manager tf-push --version 26.5.0 # TestFlight push with explicit MARKETING_VERSION; live work needs STUDIO_TF_PUSH_LIVE=1
+scripts/release-manager-configure.sh --project turnip-ios --quick --tf-slack-channel C... # configure threaded TF Slack defaults
 /studio-setup                    # onboard THIS machine — auto-pilot, prompts for role only
 /studio-setup --manager          # zero-prompt manager onboarding
 /studio-setup --worker           # zero-prompt worker (id = hostname; --id X to override)
@@ -176,6 +178,7 @@ scripts/                # multi-worker fleet (BETA)
   achilles-queue.sh     # work-stealing dispatch queue — enqueue/drain/list/depth/clear
   chanakya-task-train.sh # manual single-train runner with sibling plan/outcome reviews and resume state
   analyze-collect.sh    # mechanical stats for usage-analysis passes (see ANALYSIS.md)
+  release-manager-configure.sh # project release notification setup (Slack first)
   forge-latency-report.sh  # stage-level task latency + review-gate comparison from event logs
   field-workflow-report.sh # Field loop report: timing, token, gate, review, and improvement mining
   studio-pr-baseline-report.sh # PR-level timing, churn, gate, and generated-file baselines

--- a/_shared/contracts/build-message-format.md
+++ b/_shared/contracts/build-message-format.md
@@ -9,14 +9,23 @@ schema_version: 1
 
 **Status: authoritative** (promoted from informal under #287). `studio-tf-push.sh` Step 7 and the `/pushTFBuild` / `/fullSendToAppStore` wrappers compose against this contract; format-iteration work (Phase 4 of #217) updates this file as the single source of truth. Cross-referenced from `_shared/contracts/release-tf-push.md` Step 7 and Stage C's `slack_drafted` event.
 
-Shared composition rules for `#testing` (TF builds) and `#releases` (App Store submissions). Both channels use the same three-section shape: `*New*` / `*Fixed*` / `*Crash fixes*`. **Skip any section with no bullets.** The goal is skimmability — the channel is the changelog index; readers want to know what changed without reading prose.
+Shared composition rules for the configured TestFlight and App Store release
+channels. Both channels use the same three-section shape: `*New*` / `*Fixed*`
+/ `*Crash fixes*`. **Skip any section with no bullets.** The goal is
+skimmability — the channel is the changelog index; readers want to know what
+changed without reading prose.
 
 ## Headline
 
-- **TF:** `<!here> [iOS] build <NEW_BUILD_NUMBER> is available on TestFlight` — drop `<!here>` for buddy/internal/silent builds.
+- **TF:** `[iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. `<!here>` is opt-in via release config and is off by default.
 - **Release:** `[iOS] v<VERSION> (build <BUILD>) has been submitted for App Store review` — no `<!here>` on release parent.
 
-Blank line after headline, then sections.
+For TestFlight, the parent should stay brief: headline, blank line, one short
+tester-facing summary of what is ready, then `Details in thread.` The detailed
+sections move to the first thread reply when `STUDIO_TF_SLACK_DETAILS_MODE=thread`
+(the default).
+
+For App Store, blank line after headline, then sections.
 
 ## *New* section
 
@@ -73,9 +82,17 @@ Last line of the body. Signals cumulative state without re-listing prior bullets
 
 `*New*` → `*Fixed*` → `*Crash fixes*` → (TF only) rollover bullet.
 
+## Grouping
+
+When configured grouping is `module`, group the detailed TestFlight thread by
+tester-visible product area or module before falling back to the standard
+section labels. Use tester language: what changed in UX, UI behavior, flows,
+or verification surfaces. Do not expose implementation structure unless it is
+the only useful way to test the change.
+
 ## Thread replies
 
-- **TF:** threads are where reproduction steps, device-specific notes, and reporter follow-ups live — keep the parent terse. Composer should not seed the thread.
+- **TF:** first thread reply carries the detailed tester checklist when threaded details are enabled. Group by module when it makes the build easier to test; put important technical notes at the end under `*Technical notes*`, and only when they affect QA/product expectations.
 - **Release:** after the parent is sent, post two thread replies in this order:
   1. **App Store "What's New"** with a two-blank-line header `App Store "What's New" submitted with this build:\n\n\n<text>`. Highest-skim-value for product/leadership.
   2. **GitHub release URL** — stable tag URL (not the draft preview).

--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -138,15 +138,25 @@ Emit `dsym_uploaded` with `data: { build: NEW_BUILD_NUMBER, count_succeeded, cou
 
 Run only when Steps 4 and 5 both verified successful.
 
-Compose the build-message body from the user's commits since the last shared TF build. Find the last shared build via `scripts/slack-fetch.sh history --channel #testing` (wraps `conversations.history`), filtering for messages from the studio's posting bot identity that match `build NNNN is available on TestFlight`. The matching `Bump build number to NNNN` commit is the lower bound for `git log --no-merges --author="<owner>" --format=...`. Thread-reply scans for cc-mention attribution use `scripts/slack-fetch.sh replies --channel <id> --ts <parent-ts>`; display-name resolution uses `scripts/slack-fetch.sh user --user <U>`.
+Compose the build-message body from the user's commits since the last shared TF build. Resolve the Slack channel from `STUDIO_TF_SLACK_CHANNEL` in the project release config; run `/dev-studio release-manager configure` if it is absent. Find the last shared build via `scripts/slack-fetch.sh history --channel "$STUDIO_TF_SLACK_CHANNEL"` (wraps `conversations.history`), filtering for messages from the studio's posting bot identity that match `build NNNN is available on TestFlight`. The matching `Bump build number to NNNN` commit is the lower bound for `git log --no-merges --author="<owner>" --format=...`. Thread-reply scans for cc-mention attribution use `scripts/slack-fetch.sh replies --channel <id> --ts <parent-ts>`; display-name resolution uses `scripts/slack-fetch.sh user --user <U>`.
 
-Format the body per `_shared/contracts/build-message-format.md` — three-section shape (`*New*` / `*Fixed*` / `*Crash fixes*`, skip empty sections), feature rollup, regression labelling, rollover bullet `• includes changes from <PREV_BUILD_NUMBER>` when stacking on an unreleased TF.
+Format the parent and thread per `_shared/contracts/build-message-format.md`.
+The default parent is brief: headline, one tester-facing summary, then
+`Details in thread.` The detailed tester checklist goes in the first thread
+reply. Group by product area/module when useful; otherwise use the standard
+three-section shape (`*New*` / `*Fixed*` / `*Crash fixes*`, skip empty
+sections), feature rollup, regression labelling, rollover bullet
+`• includes changes from <PREV_BUILD_NUMBER>` when stacking on an unreleased TF.
+Important technical notes go at the end under `*Technical notes*` only when
+they affect testing or product expectations.
 
-Headline: `<!here> [iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. Drop `<!here>` for buddy/internal/silent builds.
+Headline: `[iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. Prefix
+`<!here>` only when `STUDIO_TF_SLACK_NOTIFY_HERE=1`; the configured default is
+off.
 
-Scan the last 3–4 build threads from the studio's posting bot in `#testing`. For each composed bullet, check thread replies for matching bug reports or feature requests. Append `cc: <@USER_ID>` inline on matching bullets. Resolve display names via `users.info` for review only — the parenthesised name is not part of the final message.
+Scan the last 3–4 build threads from the studio's posting bot in the configured TestFlight channel. For each composed bullet, check thread replies for matching bug reports or feature requests. Append `cc: <@USER_ID>` inline on bullets in the thread detail that match a reporter. Resolve display names via `users.info` for review only — the parenthesised name is not part of the final message.
 
-Emit `slack_drafted` with `data: { build: NEW_BUILD_NUMBER, channel: "#testing", bullet_count, cc_count }`. Persist the draft text and resolved cc-list to a transient artifact under `~/.dev-studio/<project>/state/release-drafts/<release-tag>.txt` for the approval gate.
+Emit `slack_drafted` with `data: { build: NEW_BUILD_NUMBER, channel, bullet_count, cc_count }`. Persist the draft text and resolved cc-list to a transient artifact under `~/.dev-studio/<project>/state/release-drafts/<release-tag>.txt` for the approval gate.
 
 ### Step 8 — Human approval gate
 
@@ -158,9 +168,9 @@ D1 of issue #217 locks this gate. The driver does not auto-send. A future iterat
 
 ### Step 9 — Send to Slack
 
-Post via `scripts/slack-post.sh --channel #testing --text <body>` (wraps `chat.postMessage` per `_shared/primitives/slack-post.md`). Capture the response `ts` as `PARENT_TS`; assert non-empty before any thread reply via `scripts/slack-post.sh --thread-ts <PARENT_TS>`. Strip the parenthesised display names from the body before sending — they are reviewer-only.
+Post the parent via `scripts/slack-post.sh --channel "$STUDIO_TF_SLACK_CHANNEL" --text <parent>` (wraps `chat.postMessage` per `_shared/primitives/slack-post.md`). Capture the response `ts` as `PARENT_TS`; assert non-empty before posting the detail thread via `scripts/slack-post.sh --thread-ts <PARENT_TS> --text <thread>`. Strip the parenthesised display names before sending — they are reviewer-only.
 
-Emit `slack_sent` with `data: { build: NEW_BUILD_NUMBER, channel: "#testing", parent_ts: PARENT_TS, message_chars }`.
+Emit `slack_sent` with `data: { build: NEW_BUILD_NUMBER, channel, parent_ts: PARENT_TS, message_chars }`.
 
 If the post fails, emit `release_failed` with `data: { stage: "slack_send", reason }` and surface to the user. The build is already on TestFlight — the failure is in notification, not delivery — so the driver does not retry the upload steps.
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T13:40:43Z",
+  "generated_at": "2026-05-05T20:50:49Z",
   "agents": [
 
   ]

--- a/_shared/schemas/release.md
+++ b/_shared/schemas/release.md
@@ -46,6 +46,7 @@ asc_metadata:
   stuck: false
 slack:
   posted_to: "#releases"
+  channel_id: "C0123456789"
   message_ts: "1745332800.001200"
   reply_ts: null                                 # filled when watcher finalizes
 notes: null

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -49,6 +49,9 @@ supplies the task context and runtime slug.
    - `reviewer` -> plan, outcome, diff, PR, or release-packet review.
    - `perf` -> performance, battery, memory, thermal, network, or instrumentation evidence.
    - `planner`, `qa-engineer`, `flow-tester`, `release-manager` -> active role contracts, usually manager-mediated or approval-gated.
+   - `release-manager configure` -> project-scoped release notification setup;
+     call `$STUDIO_REPO/scripts/release-manager-configure.sh` after shaping
+     quick/custom/descriptive Slack options with the user.
 
 6. Keep project state under `~/.dev-studio/$PROJECT_SLUG/` unless the user
    explicitly names another project slug. For `manager ingest`, call

--- a/commands/fullSendToAppStore.md
+++ b/commands/fullSendToAppStore.md
@@ -7,7 +7,9 @@ allowed-tools: [Bash, Read, Edit, Grep]
 
 Tag the current commit, create a GitHub draft release, and submit the build to App Store Connect for review with manual release. Mechanical work (tag + push, GH draft, ASC API calls) routes through `scripts/studio-tf-push.sh appstore` in the studio repo (`~/Documents/v-i-s-h-a-l/github/generic-dev-studio`). This wrapper drives release-notes composition, the human-approval gate, and the optional Slack post.
 
-Authoritative knobs: `_shared/primitives/turnip-project-config.md` (App ID, ASC ids), `_shared/contracts/build-message-format.md` (release-notes shape).
+Authoritative knobs: project release config (App ID, ASC ids, Slack channels),
+`_shared/contracts/build-message-format.md` (release-notes shape). Configure
+Slack release announcements with `/dev-studio release-manager configure`.
 
 ## Step 1: Resolve build + previous tag + commits
 
@@ -76,17 +78,41 @@ The stable GH release URL — same for draft and published — is:
 https://github.com/turnip-ios/turnip-zaps/releases/tag/${CURRENT_BUILD_NUMBER}-zaps
 ```
 
-## Step 6: Optional Slack post
+## Step 6: Optional configured Slack post
 
-Post the unified A body via:
+If `STUDIO_RELEASES_SLACK_CHANNEL` is configured, post the unified A body to
+the release channel and seed the expected release thread replies. If it is not
+configured, skip Slack cleanly and report that release announcements are not
+configured.
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
 export STUDIO_RELEASE_PROJECT="${STUDIO_RELEASE_PROJECT:-<project>}"
-./scripts/slack-post.sh --channel <release-channel-id> --text "$RELEASE_BODY"
+. ./scripts/lib-release-config.sh
+load_release_config
+RELEASES_CHANNEL="${STUDIO_RELEASES_SLACK_CHANNEL:-}"
+if [ -n "$RELEASES_CHANNEL" ]; then
+  RESP=$(./scripts/slack-post.sh --channel "$RELEASES_CHANNEL" --text "$RELEASE_BODY")
+  PARENT_TS=$(echo "$RESP" | jq -r .ts)
+  [ -n "$PARENT_TS" ] && [ "$PARENT_TS" != "null" ] || { echo "slack-post returned no ts"; exit 1; }
+  WHATS_NEW_REPLY=$(cat <<EOF
+App Store "What's New" submitted with this build:
+
+
+$WHATS_NEW_BODY
+EOF
+)
+  ./scripts/slack-post.sh --channel "$RELEASES_CHANNEL" --thread-ts "$PARENT_TS" \
+    --text "$WHATS_NEW_REPLY"
+  ./scripts/slack-post.sh --channel "$RELEASES_CHANNEL" --thread-ts "$PARENT_TS" \
+    --text "https://github.com/turnip-ios/turnip-zaps/releases/tag/${CURRENT_BUILD_NUMBER}-zaps"
+fi
 ```
 
-Confirm to the user with the Slack permalink and the GH release URL.
+Persist the Slack channel id and parent `ts` into the release artifact or
+pending App Store marker so `scripts/appstore-watch.sh` can post lifecycle
+replies into the same thread. Confirm to the user with the Slack thread and GH
+release URL when Slack was configured.
 
 ## Rollback
 

--- a/commands/postSlackTesting.md
+++ b/commands/postSlackTesting.md
@@ -1,5 +1,5 @@
 ---
-description: Post an iOS TestFlight build notification to the #testing Slack channel
+description: Post an iOS TestFlight build notification to the configured Slack channel
 allowed-tools: [Bash, Read, Grep]
 ---
 
@@ -9,7 +9,9 @@ Notification-only path — for when a build was already pushed (perhaps manually
 
 If you want the full push path (bump → archive → upload → Slack), use `/pushTFBuild` instead.
 
-Authoritative composition rules: `_shared/contracts/build-message-format.md` in the studio repo.
+Authoritative composition rules: `_shared/contracts/build-message-format.md` in
+the studio repo. Configure the Slack channel and threaded-message defaults with
+`/dev-studio release-manager configure`.
 
 ## Step 1: Get the latest build number from TestFlight
 
@@ -18,6 +20,7 @@ cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
 export STUDIO_RELEASE_PROJECT="${STUDIO_RELEASE_PROJECT:-<project>}"
 . ./scripts/lib-release-config.sh
 load_release_config
+TF_CHANNEL="${STUDIO_TF_SLACK_CHANNEL:?run /dev-studio release-manager configure first}"
 ASC_KEY_PATH=$(release_asc_key_path "$STUDIO_TF_ASC_KEY_ID")
 TOKEN=$(python3 - "$ASC_KEY_PATH" "$STUDIO_TF_ASC_ISSUER_ID" "$STUDIO_TF_ASC_KEY_ID" <<'PY'
 import jwt, time
@@ -45,14 +48,14 @@ else
 fi
 ```
 
-## Step 3: Scan recent #testing threads for cc-tag attribution
+## Step 3: Scan recent configured TestFlight threads for cc-tag attribution
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
 export STUDIO_RELEASE_PROJECT="${STUDIO_RELEASE_PROJECT:-<project>}"
-./scripts/slack-fetch.sh history --channel C016BNCGDM2 --limit 3
+./scripts/slack-fetch.sh history --channel "$TF_CHANNEL" --limit 3
 # For messages with replies:
-./scripts/slack-fetch.sh replies --channel C016BNCGDM2 --ts <MESSAGE_TS>
+./scripts/slack-fetch.sh replies --channel "$TF_CHANNEL" --ts <MESSAGE_TS>
 # Resolve display names (review only):
 ./scripts/slack-fetch.sh user --user <USER_ID>
 ```
@@ -63,8 +66,10 @@ Append `<@USER_ID>` to bullets that match a thread reply.
 
 Compose per `build-message-format.md`:
 
-- First line: `<!here> [iOS] build ${BUILD_NUMBER} is available on TestFlight`
-- Bullet points in plain, non-technical language — translate technical commits into user-facing impact.
+- Parent first line: `[iOS] build ${BUILD_NUMBER} is available on TestFlight`; prefix `<!here>` only when `STUDIO_TF_SLACK_NOTIFY_HERE=1`.
+- Parent body: brief tester-facing summary, then `Details in thread.`
+- Thread body: grouped tester checklist in plain, non-technical language — translate technical commits into UI/UX behavior to verify.
+- Put important technical changes at the end of the thread under `*Technical notes*` only when they affect testing.
 
 Show the draft with parenthesised display names next to each `<@USER_ID>` (review only). Ask: **"Does this look good, or would you like to edit anything before sending?"**
 
@@ -77,7 +82,10 @@ Strip parenthesised names, then:
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
 export STUDIO_RELEASE_PROJECT="${STUDIO_RELEASE_PROJECT:-<project>}"
-./scripts/slack-post.sh --channel C016BNCGDM2 --text "$FINAL_BODY"
+RESP=$(./scripts/slack-post.sh --channel "$TF_CHANNEL" --text "$FINAL_PARENT_BODY")
+PARENT_TS=$(echo "$RESP" | jq -r .ts)
+[ -n "$PARENT_TS" ] && [ "$PARENT_TS" != "null" ] || { echo "slack-post returned no ts"; exit 1; }
+./scripts/slack-post.sh --channel "$TF_CHANNEL" --thread-ts "$PARENT_TS" --text "$FINAL_THREAD_BODY"
 ```
 
 Confirm to the user that the message was sent.

--- a/commands/pushTFBuild.md
+++ b/commands/pushTFBuild.md
@@ -7,7 +7,10 @@ allowed-tools: [Bash, Read, Edit, Grep]
 
 Hybrid wrapper around `scripts/studio-tf-push.sh` (studio repo at `~/Documents/v-i-s-h-a-l/github/generic-dev-studio`). The studio script owns all mechanical work — bump, archive, export+upload, dSYMs — and emits the four pre-Slack events. This wrapper drives Slack composition + the human-approval gate, then emits `slack_drafted` / `slack_sent` via the same script's `emit` subcommand so all six events share one release-tag.
 
-Authoritative procedure: `_shared/contracts/release-tf-push.md`. Project knobs (paths, scheme, ASC ids, Crashlytics plist): `_shared/primitives/turnip-project-config.md`. Slack body rules: `_shared/contracts/build-message-format.md`.
+Authoritative procedure: `_shared/contracts/release-tf-push.md`. Project knobs
+(paths, scheme, ASC ids, Crashlytics plist) live in the project release config.
+Slack body rules: `_shared/contracts/build-message-format.md`. Configure
+channel and notification shape with `/dev-studio release-manager configure`.
 
 ## Arguments
 
@@ -33,11 +36,25 @@ NEW_BUILD_NUMBER=$(echo "$CTX" | jq -r .build)
 VERSION=$(echo "$CTX" | jq -r .version)
 BRANCH=$(echo "$CTX" | jq -r .branch)
 PREV_BUILD=$(echo "$CTX" | jq -r .prev_build)
+. ./scripts/lib-release-config.sh
+load_release_config
 ```
 
 The script emits `release_started`, `archive_completed`, `upload_completed`, `dsym_uploaded` along the way. If it exits non-zero it has already emitted `release_failed` with the stage that broke — surface stderr to the user and stop. Do NOT continue to Slack steps.
 
 The script reads release config from `~/.dev-studio/${STUDIO_RELEASE_PROJECT}/config/release.env` and secrets from `~/.dev-studio/${STUDIO_RELEASE_PROJECT}/secrets/`. It preflights non-interactive GitHub push auth, ASC key/JWT prerequisites, Slack token readability, and the app-scoped live-version lookup before it mutates the pbxproj. If it prints `WARNING: Could not determine live App Store version`, stop and resolve ASC/API access first; do not infer that there is no version conflict. For an intentionally upload-only run with Slack deferred, set `STUDIO_TF_SLACK_DEFERRED=1`.
+
+Required Slack config for notification:
+
+```bash
+STUDIO_TF_SLACK_CHANNEL=<Slack channel id>
+STUDIO_TF_SLACK_CHANNEL_NAME="#testing"          # display only
+STUDIO_TF_SLACK_NOTIFY_HERE=0                    # opt-in only
+STUDIO_TF_SLACK_PARENT_MODE=brief
+STUDIO_TF_SLACK_DETAILS_MODE=thread
+STUDIO_TF_SLACK_GROUPING=module
+STUDIO_TF_SLACK_TECHNICAL_FOOTER=1
+```
 
 ### Background option
 
@@ -77,7 +94,8 @@ Find the last shared build:
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
-LAST_SHARED_BUILD=$(./scripts/slack-fetch.sh history --channel C016BNCGDM2 --limit 10 \
+TF_CHANNEL="${STUDIO_TF_SLACK_CHANNEL:?run /dev-studio release-manager configure first}"
+LAST_SHARED_BUILD=$(./scripts/slack-fetch.sh history --channel "$TF_CHANNEL" --limit 10 \
   | jq -r 'select(.user=="U0AJYVC8P8X") | .text' \
   | grep -oE 'build [0-9]+ is available on TestFlight' \
   | head -1 | grep -oE '[0-9]+')
@@ -93,19 +111,21 @@ git log --no-merges --author="vishal" --format="%h | %s%n%b%n---" ${LAST_SHARED_
 
 Read full commit messages (subject + body). Compose per `build-message-format.md`:
 
-- Three sections: `*New*` / `*Fixed*` / `*Crash fixes*` — skip empty sections.
+- Parent: brief tester-facing summary since the last posted TF build, then `Details in thread.`
+- Thread detail: grouped tester checklist. Prefer module/product-area groups when useful; otherwise use `*New*` / `*Fixed*` / `*Crash fixes*`.
 - Feature rollup under *New*; bare crash-link bullets under *Crash fixes*.
 - Name regressions explicitly under *Fixed* as `• regression bug fix: <thing>`.
 - Rollover line `• includes changes from <PREV_BUILD_NUMBER>` when stacking on an unreleased TF (compare `LAST_SHARED_BUILD` vs `PREV_BUILD` from the context — if they differ, prepend a rollover bullet).
-- Headline: `<!here> [iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. Drop `<!here>` for buddy/internal/silent builds.
+- Headline: `[iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. Prefix `<!here>` only when `STUDIO_TF_SLACK_NOTIFY_HERE=1`.
+- Technical notes go at the end of the thread under `*Technical notes*`, only when they materially affect testing or product expectations.
 
 ## Step 4: Scan recent threads for cc-tag attribution
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
-./scripts/slack-fetch.sh history --channel C016BNCGDM2 --limit 15
+./scripts/slack-fetch.sh history --channel "$TF_CHANNEL" --limit 15
 # For each Vishal-CLI build message with replies:
-./scripts/slack-fetch.sh replies --channel C016BNCGDM2 --ts <MESSAGE_TS>
+./scripts/slack-fetch.sh replies --channel "$TF_CHANNEL" --ts <MESSAGE_TS>
 # Resolve display names (review only):
 ./scripts/slack-fetch.sh user --user <USER_ID>
 ```
@@ -120,7 +140,8 @@ CCS=$(echo "$BODY" | grep -oE 'cc: <@[A-Z0-9]+>' | wc -l | tr -d ' ')
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
 ./scripts/studio-tf-push.sh emit slack_drafted --release-tag "$RELEASE_TAG" \
   --data "$(jq -nc --argjson b "$NEW_BUILD_NUMBER" --argjson bc "$BULLETS" --argjson cc "$CCS" \
-              '{build:$b, channel:"#testing", bullet_count:$bc, cc_count:$cc}')"
+              --arg ch "${STUDIO_TF_SLACK_CHANNEL_NAME:-$TF_CHANNEL}" \
+              '{build:$b, channel:$ch, bullet_count:$bc, cc_count:$cc}')"
 ```
 
 ## Step 6: Human-approval gate
@@ -135,14 +156,16 @@ Strip parenthesised display names from the body, then:
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
-RESP=$(./scripts/slack-post.sh --channel C016BNCGDM2 --text "$FINAL_BODY")
+RESP=$(./scripts/slack-post.sh --channel "$TF_CHANNEL" --text "$FINAL_PARENT_BODY")
 PARENT_TS=$(echo "$RESP" | jq -r .ts)
 [ -n "$PARENT_TS" ] && [ "$PARENT_TS" != "null" ] || { echo "slack-post returned no ts"; exit 1; }
+./scripts/slack-post.sh --channel "$TF_CHANNEL" --thread-ts "$PARENT_TS" --text "$FINAL_THREAD_BODY" >/dev/null
 
-CHARS=$(printf '%s' "$FINAL_BODY" | wc -c | tr -d ' ')
+CHARS=$(printf '%s%s' "$FINAL_PARENT_BODY" "$FINAL_THREAD_BODY" | wc -c | tr -d ' ')
 ./scripts/studio-tf-push.sh emit slack_sent --release-tag "$RELEASE_TAG" \
   --data "$(jq -nc --argjson b "$NEW_BUILD_NUMBER" --arg ts "$PARENT_TS" --argjson c "$CHARS" \
-              '{build:$b, channel:"#testing", parent_ts:$ts, message_chars:$c}')"
+              --arg ch "${STUDIO_TF_SLACK_CHANNEL_NAME:-$TF_CHANNEL}" \
+              '{build:$b, channel:$ch, parent_ts:$ts, message_chars:$c}')"
 ```
 
 If the post fails:

--- a/core/v2/roles/release-manager.yaml
+++ b/core/v2/roles/release-manager.yaml
@@ -18,6 +18,9 @@ inputs:
   - kind: release-anchor
     required: false
     description: Detailed release-management scope from issue #214 or a successor planning artifact.
+  - kind: release-notification-config-request
+    required: false
+    description: Project-scoped request to configure reusable release notification defaults such as Slack channels and message shape.
 outputs:
   - kind: release-packet
     required: true
@@ -25,6 +28,9 @@ outputs:
   - kind: checkpoint-artifact
     required: false
     description: Release-manager-owned compact checkpoint with release scope, channel state, blockers, operator decisions, and next packet action; not a release packet.
+  - kind: release-notification-config
+    required: false
+    description: Project release.env settings for optional Slack TestFlight/App Store announcements.
 reads:
   - scope: owned worktree
     description: Release docs, changelog, build/release scripts, tags, issue references, and verification artifacts.
@@ -34,13 +40,14 @@ writes:
   - scope: owned worktree
     description: Release-packet fixtures or checked-in release contracts when the source issue explicitly asks for substrate artifacts.
   - scope: ~/.dev-studio/**
-    description: Release packets, blocker records, operator-decision escrows, release-manager checkpoints, and private release-readiness notes.
+    description: Release packets, blocker records, operator-decision escrows, release-manager checkpoints, private release-readiness notes, and project release notification config.
 idempotency_key: release-manager:{subject_ref}:{release_scope}:{channel}
 decision_rights:
   - Declare release readiness, release blockers, and required operator decisions from gathered verification evidence.
   - Reference issue #214 as the detailed release-manager anchor without closing or duplicating its implementation scope.
   - Require build/release message lint, tag, GitHub release, TestFlight, and App Store evidence before external release actions.
   - Create or resume release-manager-owned checkpoints for long release preparation without granting external release authority.
+  - Configure reusable release notification defaults without posting externally unless the operator explicitly requests a test send.
   - Stop release preparation when the user has deferred release or when verification evidence is incomplete.
 escalation_triggers:
   - Tagging, GitHub release publication, TestFlight submission, App Store submission, or production messaging needs operator approval.
@@ -56,5 +63,6 @@ verification_floor:
   - Release packet names release scope, anchor issues including #214, notes state, tag state, GitHub release state, TestFlight/App Store state, and blockers.
   - "Release notes inspect `Changelog:` trailers per `_shared/contracts/definition-of-done.md`; if trailers are ignored or rewritten, the release packet records why."
   - Build/release message lint and external-channel states are represented as explicit evidence states.
+  - Notification setup writes project-scoped config only; Slack is optional, `<!here>` is opt-in, and TestFlight details default to a thread.
   - Any release-blocking item names the missing evidence or required operator decision.
   - Release-manager checkpoints may summarize packet progress, but release-packet remains the release readiness artifact.

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -51,6 +51,18 @@ exists. Unsafe public records stay in the inbox with a policy reason.
 `(studio-feedback)` and `(studio feedback)` tags create sidecar records under
 the studio feedback inbox and do not replace the rest of the prompt.
 
+<!-- v2-dev-studio:release-configure -->
+## Release Manager Configure
+
+`/dev-studio release-manager configure` routes to the release-manager role and
+uses `scripts/release-manager-configure.sh` for project-scoped release
+notification setup. Slack is the first supported integration. Quick setup writes
+defaults the user can change later: TestFlight uses no `<!here>` by default,
+a brief parent message, threaded tester details, module grouping when useful,
+and technical notes at the end only when they affect testing. App Store release
+announcements remain optional and post to the configured releases channel when
+present.
+
 <!-- v2-dev-studio:landing -->
 ## Bare Role Landing
 

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-05-05T13:40:42Z",
+  "generated_at": "2026-05-05T20:50:48Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},
     {"name": "fullSendToAppStore", "source": "commands/fullSendToAppStore.md", "description": "Tag current commit, draft GitHub release, and submit build to App Store review", "agent": null, "scope": "global"},
-    {"name": "postSlackTesting", "source": "commands/postSlackTesting.md", "description": "Post an iOS TestFlight build notification to the #testing Slack channel", "agent": null, "scope": "global"},
+    {"name": "postSlackTesting", "source": "commands/postSlackTesting.md", "description": "Post an iOS TestFlight build notification to the configured Slack channel", "agent": null, "scope": "global"},
     {"name": "pushTFBuild", "source": "commands/pushTFBuild.md", "description": "Bump build number/version, archive, and push to TestFlight via App Store Connect", "agent": null, "scope": "global"},
     {"name": "capture", "source": ".claude/commands/capture.md", "description": "Retrospectively scan the current session for idea-worthy content and update IDEAS.md with dedup", "agent": null, "scope": "project"},
     {"name": "resume-plan", "source": ".claude/commands/resume-plan.md", "description": "Resume the architecture refactor — read roadmap + memory, report current state, ask pending questions", "agent": null, "scope": "project"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,6 +120,7 @@ scripts/push-queue.sh list                              # unread entries on stdo
 scripts/push-queue.sh mark-displayed <id>...            # clear after surfacing
 scripts/status-domain.sh rounds                         # one-line round summary (prefers YAML; legacy fallback)
 scripts/status-domain.sh releases                       # one-line release summary + push-tf suggestion
+scripts/release-manager-configure.sh --project <slug> --quick --tf-slack-channel C... # release notification setup
 
 # Reviewer pipeline — mechanical extractions from the v2 reviewer role contract:
 eval "$(scripts/argus-setup.sh T001 S /path/to/worktree)"           # marker + review_requested + trap line

--- a/scripts/appstore-watch.sh
+++ b/scripts/appstore-watch.sh
@@ -12,7 +12,7 @@
 #
 # On terminal state (PENDING_DEVELOPER_RELEASE / READY_FOR_SALE):
 #   1. gh release edit <tag> --draft=false
-#   2. Threaded Slack reply on the original #releases message
+#   2. Threaded Slack reply on the original configured release message
 #   3. Delete marker
 #   4. Emit appstore_released
 # Steps 1 and 2 are tracked in marker.finalize_progress for idempotency —
@@ -79,7 +79,7 @@ read_field() {
       version) yq -r '.version // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       asc_app_id) yq -r '.asc_metadata.asc_app_id // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       repo) yq -r '.repo // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
-      slack_channel) yq -r '.slack.posted_to // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      slack_channel) yq -r '.slack.channel_id // .slack.posted_to // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       slack_parent_ts) yq -r '.slack.message_ts // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       github_release_url) yq -r '.github_release_url // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       asc_key_path) printf '%s\n' "${STUDIO_TF_ASC_KEY_PATH:-}" ;;

--- a/scripts/lint-build-release-message.sh
+++ b/scripts/lint-build-release-message.sh
@@ -71,7 +71,8 @@ case "$CHANNEL" in
     ;;
 esac
 
-awk '
+saw_details_thread=$(grep -c '^Details in thread[.]$' "$tmp" || true)
+awk -v channel="$CHANNEL" -v saw_details_thread="$saw_details_thread" '
   function trim(s) {
     gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
     return s
@@ -90,6 +91,13 @@ awk '
     }
     next
   }
+  channel == "testflight" && /^\*[^*]+\*$/ {
+    section_count += 1
+    if (heading_seen[$0]++) {
+      printf "duplicate-heading: %s\n", $0
+    }
+    next
+  }
   /^[[:space:]]*(-|•)[[:space:]]+/ {
     if (section_count == 0) {
       printf "shape: bullet appears before any recognized section\n"
@@ -101,7 +109,7 @@ awk '
     next
   }
   END {
-    if (section_count == 0) {
+    if (section_count == 0 && !(channel == "testflight" && saw_details_thread > 0)) {
       printf "shape: expected at least one section heading: *New*, *Fixed*, or *Crash fixes*\n"
     }
   }

--- a/scripts/release-manager-configure.sh
+++ b/scripts/release-manager-configure.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# release-manager-configure.sh — project release notification setup.
+#
+# Usage:
+#   scripts/release-manager-configure.sh --project <slug> --quick \
+#     --tf-slack-channel C... --appstore-slack-channel C...
+#
+# Writes reusable release-manager notification settings to the project-scoped
+# release config. Secrets stay in the existing project secrets directory; this
+# script never asks for token text.
+
+set -u
+umask 077
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=lib-release-config.sh
+. "$SCRIPT_DIR/lib-release-config.sh"
+
+PROJECT=""
+QUICK=0
+DRY_RUN=0
+SEND_TEST=0
+ENABLE_TF=1
+ENABLE_APPSTORE=1
+TF_CHANNEL=""
+TF_CHANNEL_NAME="#testing"
+APPSTORE_CHANNEL=""
+APPSTORE_CHANNEL_NAME="#releases"
+DESCRIPTIVE_INTAKE=""
+
+usage() {
+  sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project) PROJECT="${2:?--project requires value}"; shift 2 ;;
+    --quick) QUICK=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --send-test-message) SEND_TEST=1; shift ;;
+    --tf-slack-channel|--testflight-slack-channel) TF_CHANNEL="${2:?--tf-slack-channel requires value}"; shift 2 ;;
+    --tf-slack-channel-name|--testflight-slack-channel-name) TF_CHANNEL_NAME="${2:?--tf-slack-channel-name requires value}"; shift 2 ;;
+    --appstore-slack-channel|--releases-slack-channel) APPSTORE_CHANNEL="${2:?--appstore-slack-channel requires value}"; shift 2 ;;
+    --appstore-slack-channel-name|--releases-slack-channel-name) APPSTORE_CHANNEL_NAME="${2:?--appstore-slack-channel-name requires value}"; shift 2 ;;
+    --disable-testflight) ENABLE_TF=0; shift ;;
+    --disable-appstore) ENABLE_APPSTORE=0; shift ;;
+    --describe) DESCRIPTIVE_INTAKE="${2:?--describe requires value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'release-manager-configure: unknown arg %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -n "$PROJECT" ]; then
+  export STUDIO_RELEASE_PROJECT="$PROJECT"
+fi
+load_release_config || {
+  printf 'release-manager-configure: could not resolve project release config\n' >&2
+  exit 2
+}
+
+TF_CHANNEL="${TF_CHANNEL:-${STUDIO_TF_SLACK_CHANNEL:-}}"
+APPSTORE_CHANNEL="${APPSTORE_CHANNEL:-${STUDIO_RELEASES_SLACK_CHANNEL:-}}"
+TF_CHANNEL_NAME="${TF_CHANNEL_NAME:-${STUDIO_TF_SLACK_CHANNEL_NAME:-#testing}}"
+APPSTORE_CHANNEL_NAME="${APPSTORE_CHANNEL_NAME:-${STUDIO_RELEASES_SLACK_CHANNEL_NAME:-#releases}}"
+
+if [ "$QUICK" = "0" ] && [ -z "$DESCRIPTIVE_INTAKE" ]; then
+  printf 'release-manager-configure: no setup mode supplied; use --quick or --describe\n' >&2
+  exit 2
+fi
+if [ "$ENABLE_TF" = "1" ] && [ -z "$TF_CHANNEL" ] && [ "$ENABLE_APPSTORE" = "1" ] && [ -z "$APPSTORE_CHANNEL" ]; then
+  printf 'release-manager-configure: provide --tf-slack-channel or --appstore-slack-channel\n' >&2
+  exit 2
+fi
+
+quote_env() {
+  local value="$1"
+  value=${value//\'/\'\\\'\'}
+  printf "'%s'" "$value"
+}
+
+upsert_env_line() {
+  local file="$1" key="$2" value="$3" tmp
+  tmp=$(mktemp "${file}.XXXXXX") || return 1
+  if [ -f "$file" ]; then
+    awk -v key="$key" -v val="$value" '
+      BEGIN { done = 0 }
+      $0 ~ "^" key "=" { print key "=" val; done = 1; next }
+      { print }
+      END { if (!done) print key "=" val }
+    ' "$file" > "$tmp"
+  else
+    printf '%s=%s\n' "$key" "$value" > "$tmp"
+  fi
+  mv "$tmp" "$file"
+}
+
+write_setting() {
+  local key="$1" value="$2" quoted
+  quoted=$(quote_env "$value")
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '%s=%s\n' "$key" "$quoted"
+  else
+    upsert_env_line "$RELEASE_CONFIG_FILE" "$key" "$quoted"
+  fi
+}
+
+validate_channel_shape() {
+  local name="$1" channel="$2"
+  [ -z "$channel" ] && return 0
+  case "$channel" in
+    C*|G*|D*) return 0 ;;
+    *) printf 'release-manager-configure: warning: %s channel id usually starts with C/G/D: %s\n' "$name" "$channel" >&2 ;;
+  esac
+}
+
+[ "$DRY_RUN" = "1" ] || mkdir -p "$RELEASE_CONFIG_DIR"
+
+validate_channel_shape testflight "$TF_CHANNEL"
+validate_channel_shape appstore "$APPSTORE_CHANNEL"
+
+write_setting STUDIO_RELEASE_NOTIFICATIONS_CONFIGURED 1
+write_setting STUDIO_RELEASE_NOTIFICATION_PROFILE quick
+[ -n "$DESCRIPTIVE_INTAKE" ] && write_setting STUDIO_RELEASE_NOTIFICATION_INTAKE "$DESCRIPTIVE_INTAKE"
+
+if [ "$ENABLE_TF" = "1" ] && [ -n "$TF_CHANNEL" ]; then
+  write_setting STUDIO_TF_SLACK_CHANNEL "$TF_CHANNEL"
+  write_setting STUDIO_TF_SLACK_CHANNEL_NAME "$TF_CHANNEL_NAME"
+  write_setting STUDIO_TF_SLACK_NOTIFY_HERE 0
+  write_setting STUDIO_TF_SLACK_PARENT_MODE brief
+  write_setting STUDIO_TF_SLACK_DETAILS_MODE thread
+  write_setting STUDIO_TF_SLACK_GROUPING module
+  write_setting STUDIO_TF_SLACK_TECHNICAL_FOOTER 1
+fi
+
+if [ "$ENABLE_APPSTORE" = "1" ] && [ -n "$APPSTORE_CHANNEL" ]; then
+  write_setting STUDIO_RELEASES_SLACK_CHANNEL "$APPSTORE_CHANNEL"
+  write_setting STUDIO_RELEASES_SLACK_CHANNEL_NAME "$APPSTORE_CHANNEL_NAME"
+  write_setting STUDIO_RELEASES_SLACK_APPSTORE_PARENT 1
+  write_setting STUDIO_RELEASES_SLACK_WHATSNEW_REPLY 1
+  write_setting STUDIO_RELEASES_SLACK_GITHUB_REPLY 1
+  write_setting STUDIO_RELEASES_SLACK_WATCHER_REPLIES 1
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'release-manager-configure: dry-run only; no file written\n' >&2
+else
+  chmod 600 "$RELEASE_CONFIG_FILE" 2>/dev/null || true
+  printf 'release-manager-configure: wrote %s\n' "$RELEASE_CONFIG_FILE"
+fi
+
+if [ "$SEND_TEST" = "1" ] && [ "$DRY_RUN" != "1" ]; then
+  if [ -n "$TF_CHANNEL" ]; then
+    STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+      --channel "$TF_CHANNEL" --text "Release notification test for ${RELEASE_PROJECT}" >/dev/null
+  elif [ -n "$APPSTORE_CHANNEL" ]; then
+    STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+      --channel "$APPSTORE_CHANNEL" --text "Release notification test for ${RELEASE_PROJECT}" >/dev/null
+  else
+    printf 'release-manager-configure: no Slack channel configured for test message\n' >&2
+  fi
+elif [ -n "$TF_CHANNEL" ]; then
+  STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+    --channel "$TF_CHANNEL" --text "Release notification dry run for ${RELEASE_PROJECT}" --dry-run >/dev/null
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/release-manager-configure.sh` for project-scoped Slack release notification defaults.
- Update TestFlight messaging defaults to configurable channel, no `<!here>` by default, brief parent, and threaded tester details.
- Update App Store release docs/schema/watcher to use configured Slack release channels and persisted channel ids.

Closes #628.

## Verification
- `bash -n scripts/release-manager-configure.sh scripts/lint-build-release-message.sh scripts/appstore-watch.sh`
- temp-HOME dry-run confirms no config directory is written
- temp-HOME live run writes `release.env` with TF/App Store Slack defaults
- `scripts/test-fixtures/528-build-release-messaging/test-build-release-messaging-lint.sh`
- `bash scripts/test-fixtures/288-tf-push/run.sh`
- `scripts/lint-skill-prose.sh --staged`
- `scripts/lint-host-agnostic.sh --staged` (0 errors, existing Argus secret-scope warning)
- `git diff --cached --check` before commit

Review notes: walked `REVIEW.md` before commit; fixed the R2 concern by keeping the script non-interactive. Portable: yes.