### PR TITLE
Add release flow hardening chain

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T21:31:50Z",
+  "generated_at": "2026-05-05T21:53:54Z",
   "agents": [
 
   ]

--- a/chains/release-flow-hardening.yaml
+++ b/chains/release-flow-hardening.yaml
@@ -1,0 +1,50 @@
+# Release-flow hardening chain from the 2026-05-06 studio session.
+#
+# Run a dry-run first:
+#   scripts/studio-chain-runner.sh chains/release-flow-hardening.yaml --dry-run
+#
+# Execute sequentially:
+#   scripts/studio-chain-runner.sh chains/release-flow-hardening.yaml --host codex --parallel-chains 1
+#
+# Sequence rationale:
+# - TF tags are the base anchor for release notes, rollback, and replacement.
+# - Configured Slack/App Store notification handoff persists the thread metadata
+#   that later lifecycle steps need.
+# - App Store PR lifecycle depends on the watcher knowing the active release
+#   attempt and thread.
+# - Withdrawn/superseded reopening flow depends on both tag anchors and PR
+#   lifecycle semantics.
+# - #293 remains a broader release-attempt state-machine follow-up after these
+#   concrete primitives are in place.
+
+schema_version: 1
+chains:
+  - name: release-tag-anchors
+    base: main
+    branch: feature/release-tag-anchors
+    host: auto
+    issues: [211]
+
+  - name: release-notification-handoff
+    base: main
+    branch: feature/release-notification-handoff
+    host: auto
+    issues: [628]
+
+  - name: appstore-pr-lifecycle
+    base: main
+    branch: feature/appstore-pr-lifecycle
+    host: auto
+    issues: [164]
+
+  - name: release-replacement-flow
+    base: main
+    branch: feature/release-replacement-flow
+    host: auto
+    issues: [190]
+
+  - name: release-attempt-state-machine
+    base: main
+    branch: feature/release-attempt-state-machine
+    host: auto
+    issues: [293]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T21:31:50Z",
+  "generated_at": "2026-05-05T21:53:54Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- Add `chains/release-flow-hardening.yaml` for the release-flow hardening sequence.
- Sequence issues: #211 → #628 → #164 → #190 → #293.
- Keep execution sequential because each stage creates state used by the next release lifecycle step.

## Verification
- `scripts/studio-chain-runner.sh chains/release-flow-hardening.yaml --dry-run` completed for all chains.
- Confirmed #211, #628, #164, #190, and #293 are open.
- Pre-commit hook passed architecture/comms/debrief/v2 gates.

Portable: yes.