### PR TITLE
studio chain: release-tag-anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ STUDIO_TRACK=<track>             # session-start shortcut for v2 track work
 /dev-studio host-adapter nodes   # day-2 fleet management — status, add, remove, health, sync, schedule
 /dev-studio release-manager tf-push --background     # start TF archive/upload and keep session free for Slack drafting
 /dev-studio release-manager tf-push --version 26.5.0 # TestFlight push with explicit MARKETING_VERSION; live work needs STUDIO_TF_PUSH_LIVE=1
+scripts/studio-tf-push.sh withdraw-tf-tag --version 26.4.17 --build 3162 # rename TF anchor to tf-<version>-<build>-WITHDRAWN
 scripts/release-manager-configure.sh --project turnip-ios --quick --tf-slack-channel C... # configure threaded TF Slack defaults
 /studio-setup                    # onboard THIS machine — auto-pilot, prompts for role only
 /studio-setup --manager          # zero-prompt manager onboarding

--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -37,6 +37,7 @@ Before Step 1:
 - Non-interactive GitHub push works for the active branch: `GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=Never git push --dry-run --porcelain -u origin HEAD` succeeds. This preflight runs before any build-number or version mutation; auth failures must not open a credential prompt or create a stranded release commit.
 - Slack notification credentials are verified before mutation unless `STUDIO_TF_SLACK_DEFERRED=1` explicitly marks the run as upload-only/deferred-notification.
 - Long-running push work can be started with `scripts/studio-tf-push.sh push --background`. The parent returns a JSON handle immediately and the child writes status/log/context artifacts under `~/.dev-studio/<project>/state/release-runs/<release-tag>/`.
+- Every TF push creates an annotated git tag at the build-number commit before the archive phase: `tf-<version>-<build>` (for example `tf-26.4.17-3162`). The driver pushes both the active feature branch and that tag to origin before archiving so withdrawn or superseded TF builds still leave a stable diff/revert anchor.
 
 Halt with `release_started` not emitted if any prerequisite fails. Stage C's wrapper surfaces the missing piece to the user.
 
@@ -90,9 +91,34 @@ Preparing TestFlight build <NEW_BUILD_NUMBER> (v<VERSION>) from branch <BRANCH>.
 Co-Authored-By: Claude Opus 4.X (1M context) <noreply@anthropic.com>
 ```
 
-Push the branch with `git push -u origin HEAD`. R11 (no studio-initiated pushes to base branches) applies — the driver halts if the active branch is `main` / `master` / `release/*`.
+Create an annotated TF anchor tag at the bump commit:
 
-If a future push failure still occurs after the local bump commit, emit a stranded-release-state warning naming the local commit and the next safe `git push -u origin HEAD` recovery command. Do not write release artifacts or debriefs unless upload later succeeds.
+```
+tf-<VERSION>-<NEW_BUILD_NUMBER>
+```
+
+Push the branch with `git push -u origin HEAD`, then push the tag with
+`git push origin refs/tags/tf-<VERSION>-<NEW_BUILD_NUMBER>`. R11 (no
+studio-initiated pushes to base branches) applies — the driver halts if the
+active branch is `main` / `master` / `release/*`. Tag pushes are allowed because
+they do not advance a base branch.
+
+If a future push failure still occurs after the local bump commit, emit a
+stranded-release-state warning naming the local commit, TF tag, and the next
+safe recovery command. Do not write release artifacts or debriefs unless upload
+later succeeds.
+
+If a TF build is later withdrawn, mark the anchor by renaming it to:
+
+```
+tf-<VERSION>-<NEW_BUILD_NUMBER>-WITHDRAWN
+```
+
+Use `scripts/studio-tf-push.sh withdraw-tf-tag --version <VERSION> --build <NEW_BUILD_NUMBER>`.
+The command creates an annotated withdrawn tag at the original commit, pushes
+it, deletes the unqualified remote tag, and removes the local unqualified tag.
+The withdrawn tag remains the stable anchor for diff/revert workflows while
+making state visible in tag lists.
 
 No event emitted at the commit boundary; the next event closes the archive phase.
 
@@ -100,7 +126,7 @@ No event emitted at the commit boundary; the next event closes the archive phase
 
 Run `xcodebuild archive` against the project, scheme, and configuration declared in `turnip-project-config.md`. The archive lands at `/tmp/<SCHEME>-<NEW_BUILD_NUMBER>.xcarchive`.
 
-When running in background mode, write `prepared-context.json` after Step 2 and before this archive starts. The file carries `release_tag`, `build`, `version`, `scheme`, `branch`, `archive_path`, and `prev_build`, allowing the wrapper to draft the Slack message while archive/upload continue. The wrapper must still wait for final `status.json` to reach `state=="succeeded"` before sending Slack.
+When running in background mode, write `prepared-context.json` after Step 2 and before this archive starts. The file carries `release_tag`, `build`, `version`, `scheme`, `branch`, `archive_path`, `tf_tag`, and `prev_build`, allowing the wrapper to draft the Slack message while archive/upload continue. The wrapper must still wait for final `status.json` to reach `state=="succeeded"` before sending Slack.
 
 Before invoking `xcodebuild archive`, enqueue the archive with `priority: "release"` in `~/.dev-studio/.runtime/build-queue/<node-id>/`, then acquire an `xcodebuild-lock/<node-id>/slot-<n>/` lock before starting the archive. The queue grants up to the node's `parallel_build_slots` and moves release entries ahead of queued task/background work without stopping any in-flight holder.
 
@@ -139,6 +165,16 @@ Emit `dsym_uploaded` with `data: { build: NEW_BUILD_NUMBER, count_succeeded, cou
 Run only when Steps 4 and 5 both verified successful.
 
 Compose the build-message body from the user's commits since the last shared TF build. Resolve the Slack channel from `STUDIO_TF_SLACK_CHANNEL` in the project release config; run `/dev-studio release-manager configure` if it is absent. Find the last shared build via `scripts/slack-fetch.sh history --channel "$STUDIO_TF_SLACK_CHANNEL"` (wraps `conversations.history`), filtering for messages from the studio's posting bot identity that match `build NNNN is available on TestFlight`. The matching `Bump build number to NNNN` commit is the lower bound for `git log --no-merges --author="<owner>" --format=...`. Thread-reply scans for cc-mention attribution use `scripts/slack-fetch.sh replies --channel <id> --ts <parent-ts>`; display-name resolution uses `scripts/slack-fetch.sh user --user <U>`.
+
+If a `tf-<version>-<build>` tag exists for the last shared build on this
+branch, prefer it as the lower bound:
+
+```
+git log <last-tf-tag-on-this-branch>..HEAD --no-merges --author="<owner>" --format=...
+```
+
+This keeps Slack composition independent of whether the prior TF build was
+eventually released, superseded, or withdrawn.
 
 Format the parent and thread per `_shared/contracts/build-message-format.md`.
 The default parent is brief: headline, one tester-facing summary, then

--- a/commands/pushTFBuild.md
+++ b/commands/pushTFBuild.md
@@ -34,13 +34,14 @@ CTX=$(STUDIO_TF_PUSH_LIVE=1 ./scripts/studio-tf-push.sh push ${SCHEME:+--scheme 
 RELEASE_TAG=$(echo "$CTX" | jq -r .release_tag)
 NEW_BUILD_NUMBER=$(echo "$CTX" | jq -r .build)
 VERSION=$(echo "$CTX" | jq -r .version)
+TF_TAG=$(echo "$CTX" | jq -r .tf_tag)
 BRANCH=$(echo "$CTX" | jq -r .branch)
 PREV_BUILD=$(echo "$CTX" | jq -r .prev_build)
 . ./scripts/lib-release-config.sh
 load_release_config
 ```
 
-The script emits `release_started`, `archive_completed`, `upload_completed`, `dsym_uploaded` along the way. If it exits non-zero it has already emitted `release_failed` with the stage that broke — surface stderr to the user and stop. Do NOT continue to Slack steps.
+The script creates and pushes `tf-<version>-<build>` at the bump-build commit before archiving, then emits `release_started`, `archive_completed`, `upload_completed`, `dsym_uploaded` along the way. If it exits non-zero it has already emitted `release_failed` with the stage that broke — surface stderr to the user and stop. Do NOT continue to Slack steps.
 
 The script reads release config from `~/.dev-studio/${STUDIO_RELEASE_PROJECT}/config/release.env` and secrets from `~/.dev-studio/${STUDIO_RELEASE_PROJECT}/secrets/`. It preflights non-interactive GitHub push auth, ASC key/JWT prerequisites, Slack token readability, and the app-scoped live-version lookup before it mutates the pbxproj. If it prints `WARNING: Could not determine live App Store version`, stop and resolve ASC/API access first; do not infer that there is no version conflict. For an intentionally upload-only run with Slack deferred, set `STUDIO_TF_SLACK_DEFERRED=1`.
 
@@ -80,6 +81,7 @@ done
 CTX=$(cat "$PREPARED_CONTEXT_PATH")
 NEW_BUILD_NUMBER=$(echo "$CTX" | jq -r .build)
 VERSION=$(echo "$CTX" | jq -r .version)
+TF_TAG=$(echo "$CTX" | jq -r .tf_tag)
 BRANCH=$(echo "$CTX" | jq -r .branch)
 PREV_BUILD=$(echo "$CTX" | jq -r .prev_build)
 ```
@@ -90,7 +92,7 @@ Proceed to Slack drafting while the background run continues. Before sending Sla
 
 Compose from the user's commits since the last shared TF build, per `_shared/contracts/build-message-format.md`.
 
-Find the last shared build:
+Find the last shared build and prefer its TF tag as the lower bound:
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
@@ -105,8 +107,15 @@ Then:
 
 ```bash
 cd /Users/vishalsingh/Documents/Turnip.gg/turnip-ios
-LAST_SHARED_BUMP=$(git log --oneline --all --grep="Bump build number to $LAST_SHARED_BUILD" | head -1 | cut -d' ' -f1)
-git log --no-merges --author="vishal" --format="%h | %s%n%b%n---" ${LAST_SHARED_BUMP}..HEAD | grep -viE "Bump (build|version)"
+LAST_SHARED_TF_TAG=$(git tag --merged HEAD --sort=-creatordate \
+  | grep -E "^tf-[0-9]+[.][0-9]+[.][0-9]+-${LAST_SHARED_BUILD}(-WITHDRAWN)?$" \
+  | head -1)
+if [ -n "$LAST_SHARED_TF_TAG" ]; then
+  LOWER_BOUND="$LAST_SHARED_TF_TAG"
+else
+  LOWER_BOUND=$(git log --oneline --all --grep="Bump build number to $LAST_SHARED_BUILD" | head -1 | cut -d' ' -f1)
+fi
+git log --no-merges --author="vishal" --format="%h | %s%n%b%n---" ${LOWER_BOUND}..HEAD | grep -viE "Bump (build|version)"
 ```
 
 Read full commit messages (subject + body). Compose per `build-message-format.md`:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -160,7 +160,8 @@ scripts/task-build-debt-gate.sh [--override]            # exit 2 if blocked; emi
 scripts/task-claim.sh <task-uuid> <brief-uuid> <size>   # task + brief state transitions
 eval "$(scripts/task-worktree-setup.sh T001 /repo)"     # PROJECT/ORIG_BRANCH/ORIG_HEAD/WORKTREE
 scripts/task-build-gate.sh lsp-only T001 /wt MyScheme "platform=iOS Simulator" [zaps-app/Turnip.xcodeproj] # xcodebuild + lock; 6th arg pins -project/-workspace in multi-project repos (#238); exit 4 = duplicate-invocation refused (#209)
-scripts/studio-tf-push.sh push [--version X.Y.Z]        # TestFlight push driver; explicit version override + rejected-version preflight
+scripts/studio-tf-push.sh push [--version X.Y.Z]        # TestFlight push driver; creates/pushes tf-<version>-<build> anchor
+scripts/studio-tf-push.sh withdraw-tf-tag --version X.Y.Z --build N # rename TF anchor to tf-<version>-<build>-WITHDRAWN
 scripts/node-parity.sh [--fix|--dry-run]                # probe + cache toolchain versions; optionally install missing brew packages and print manual Xcode/runtime fixes (#126/#131)
 scripts/check-xcode-parity.sh m1mini                    # pre-dispatch guard; exit 1 = MAJOR Xcode drift; STUDIO_IGNORE_XCODE_DRIFT=1 overrides (#136)
 scripts/node-warmup.sh m1mini [project]                 # async-safe pre-dispatch source sync + package cache warm-up (#138)

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -13,12 +13,13 @@
 #              version, archives, exports + uploads to ASC, uploads dSYMs.
 #              Outputs a one-line JSON context blob on stdout for the wrapper
 #              (release_tag, build, version, scheme, branch, archive_path,
-#              prev_build).
+#              prev_build, tf_tag).
 #   appstore   — App Store submission: tag + push tag, GH draft release,
 #              find build on ASC, create/update version, set MANUAL release,
 #              update whatsNew per localization. Inputs (release notes, what's
 #              new) come from files prepared by the wrapper after user
 #              approval.
+#   withdraw-tf-tag — rename a TF anchor tag to tf-<version>-<build>-WITHDRAWN.
 #   emit       — emit one release event (`slack_drafted` / `slack_sent` /
 #              `release_failed`) with the same release-tag the wrapper
 #              captured from `push`. Lets the wrapper participate in the
@@ -29,6 +30,7 @@
 #   scripts/studio-tf-push.sh appstore --build <n> --version <v> \
 #                              --release-notes-file <path> --whatsnew-file <path> \
 #                              [--dry-run]
+#   scripts/studio-tf-push.sh withdraw-tf-tag --build <n> --version <v> [--dry-run]
 #   scripts/studio-tf-push.sh emit <event> --release-tag <tag> --data <json>
 #
 # Env:
@@ -133,6 +135,47 @@ failure_excerpt() {
 require_cmd() {
   local name="$1"
   command -v "$name" >/dev/null 2>&1 || halt_failed prereq "$name required before release mutation"
+}
+
+tf_tag_name() {
+  local version="$1" build="$2"
+  case "$version" in
+    *[!0-9.]*|.*|*.) printf 'tf_tag: invalid version %s\n' "$version" >&2; return 2 ;;
+  esac
+  printf '%s\n' "$version" | grep -Eq '^[0-9]+[.][0-9]+[.][0-9]+$' || {
+    printf 'tf_tag: invalid version %s\n' "$version" >&2
+    return 2
+  }
+  case "$build" in
+    ''|*[!0-9]*) printf 'tf_tag: invalid build %s\n' "$build" >&2; return 2 ;;
+  esac
+  printf 'tf-%s-%s\n' "$version" "$build"
+}
+
+local_tag_commit() {
+  local tag="$1"
+  git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null || true
+}
+
+ensure_tf_tag() {
+  local tag="$1" target="$2" version="$3" build="$4" branch="$5"
+  local existing
+  existing=$(local_tag_commit "$tag")
+  if [ -n "$existing" ]; then
+    local target_full
+    target_full=$(git rev-parse "$target^{commit}" 2>/dev/null || true)
+    if [ "$existing" != "$target_full" ]; then
+      halt_failed prereq "TF tag $tag already points at $existing, not bump commit $target_full"
+    fi
+    printf 'studio-tf-push: TF tag %s already exists at bump commit; reusing\n' "$tag" >&2
+    return 0
+  fi
+  git tag -a "$tag" "$target" -m "TestFlight build ${build} (v${version}) from ${branch}"
+}
+
+push_tf_tag() {
+  local tag="$1"
+  git push origin "refs/tags/${tag}"
 }
 
 preflight_push_release() {
@@ -522,10 +565,23 @@ EOF
       cd "$oldpwd" || true
       halt_failed prereq "version-bump commit failed"
     fi
-    bump_commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+    bump_commit=$(git rev-parse HEAD 2>/dev/null || echo unknown)
+    local TF_TAG
+    TF_TAG=$(tf_tag_name "$VERSION" "$NEW_BUILD_NUMBER") || {
+      cd "$oldpwd" || true
+      halt_failed prereq "could not derive TF tag for version=$VERSION build=$NEW_BUILD_NUMBER"
+    }
+    ensure_tf_tag "$TF_TAG" "$bump_commit" "$VERSION" "$NEW_BUILD_NUMBER" "$BRANCH" || {
+      cd "$oldpwd" || true
+      halt_failed prereq "TF tag creation failed"
+    }
     if ! git push -u origin HEAD; then
       cd "$oldpwd" || true
-      halt_failed prereq "STRANDED_RELEASE_STATE: build-number commit $bump_commit exists locally but push failed after mutation. Next safe command: git -C '$PROJECT_ROOT' push -u origin HEAD"
+      halt_failed prereq "STRANDED_RELEASE_STATE: build-number commit ${bump_commit:0:12} and TF tag $TF_TAG exist locally but branch push failed after mutation. Next safe command: git -C '$PROJECT_ROOT' push -u origin HEAD && git -C '$PROJECT_ROOT' push origin refs/tags/$TF_TAG"
+    fi
+    if ! push_tf_tag "$TF_TAG"; then
+      cd "$oldpwd" || true
+      halt_failed prereq "STRANDED_RELEASE_STATE: build-number commit ${bump_commit:0:12} is on origin but TF tag $TF_TAG was not pushed. Next safe command: git -C '$PROJECT_ROOT' push origin refs/tags/$TF_TAG"
     fi
     cd "$oldpwd" || halt_failed prereq "return to studio repo failed after version bump"
   fi
@@ -535,6 +591,8 @@ EOF
   # jump ahead of queued Achilles task builds without preempting in-flight
   # ones (#267). Priority=release → rank 0 → sorts before task (rank 1).
   local ARCHIVE_PATH="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}.xcarchive"
+  local TF_TAG
+  TF_TAG=$(tf_tag_name "$VERSION" "$NEW_BUILD_NUMBER") || halt_failed prereq "could not derive TF tag for version=$VERSION build=$NEW_BUILD_NUMBER"
   if [ -n "${STUDIO_TF_PUSH_PREPARED_CONTEXT_PATH:-}" ]; then
     mkdir -p "$(dirname "$STUDIO_TF_PUSH_PREPARED_CONTEXT_PATH")" 2>/dev/null || true
     jq -nc \
@@ -544,8 +602,9 @@ EOF
       --arg scheme "$SCHEME" \
       --arg branch "$BRANCH" \
       --arg archive_path "$ARCHIVE_PATH" \
+      --arg tf_tag "$TF_TAG" \
       --argjson prev_build "$LATEST_BUILD_NUMBER" \
-      '{release_tag:$release_tag, build:$build, version:$version, scheme:$scheme, branch:$branch, archive_path:$archive_path, prev_build:$prev_build, prepared:true}' \
+      '{release_tag:$release_tag, build:$build, version:$version, scheme:$scheme, branch:$branch, archive_path:$archive_path, tf_tag:$tf_tag, prev_build:$prev_build, prepared:true}' \
       >"$STUDIO_TF_PUSH_PREPARED_CONTEXT_PATH"
   fi
   local archive_started_at archive_duration_s=0
@@ -710,8 +769,60 @@ PLIST
     --arg scheme "$SCHEME" \
     --arg branch "$BRANCH" \
     --arg archive_path "$ARCHIVE_PATH" \
+    --arg tf_tag "$TF_TAG" \
     --argjson prev_build "$LATEST_BUILD_NUMBER" \
-    '{release_tag:$release_tag, build:$build, version:$version, scheme:$scheme, branch:$branch, archive_path:$archive_path, prev_build:$prev_build}'
+    '{release_tag:$release_tag, build:$build, version:$version, scheme:$scheme, branch:$branch, archive_path:$archive_path, tf_tag:$tf_tag, prev_build:$prev_build}'
+}
+
+cmd_withdraw_tf_tag() {
+  DRY_RUN_FLAG=0
+  local BUILD="" VERSION=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dry-run) DRY_RUN_FLAG=1; shift ;;
+      --build) BUILD="${2:?}"; shift 2 ;;
+      --version) VERSION="${2:?}"; shift 2 ;;
+      *) printf 'withdraw-tf-tag: unknown arg %s\n' "$1" >&2; exit 2 ;;
+    esac
+  done
+  [ -n "$BUILD" ] || { printf 'withdraw-tf-tag: --build required\n' >&2; exit 2; }
+  [ -n "$VERSION" ] || { printf 'withdraw-tf-tag: --version required\n' >&2; exit 2; }
+  local OLD_TAG NEW_TAG
+  OLD_TAG=$(tf_tag_name "$VERSION" "$BUILD") || exit 2
+  NEW_TAG="${OLD_TAG}-WITHDRAWN"
+  RELEASE_TAG="${STUDIO_RELEASE_TAG:-withdraw-${OLD_TAG}-$(date -u +%Y%m%d-%H%M%S)}"
+
+  if [ "$DRY_RUN_FLAG" != "1" ] && [ "${STUDIO_TF_PUSH_LIVE:-0}" != "1" ]; then
+    halt_failed prereq "STUDIO_TF_PUSH_LIVE=1 required to rename/push TF withdrawal tags"
+  fi
+
+  if [ "$DRY_RUN_FLAG" = "1" ]; then
+    printf 'studio-tf-push: [dry-run] would rename TF tag %s to %s and push withdrawn marker\n' "$OLD_TAG" "$NEW_TAG" >&2
+    jq -nc --arg old "$OLD_TAG" --arg new "$NEW_TAG" '{old_tag:$old, withdrawn_tag:$new, dry_run:true}'
+    return 0
+  fi
+
+  require_cmd git
+  (
+    cd "$PROJECT_ROOT" || exit 1
+    git fetch --tags origin >/dev/null 2>&1 || exit 1
+    local old_commit new_commit
+    old_commit=$(local_tag_commit "$OLD_TAG")
+    [ -n "$old_commit" ] || { printf 'withdraw-tf-tag: source tag %s not found\n' "$OLD_TAG" >&2; exit 1; }
+    new_commit=$(local_tag_commit "$NEW_TAG")
+    if [ -n "$new_commit" ] && [ "$new_commit" != "$old_commit" ]; then
+      printf 'withdraw-tf-tag: %s already points at %s, not %s\n' "$NEW_TAG" "$new_commit" "$old_commit" >&2
+      exit 1
+    fi
+    if [ -z "$new_commit" ]; then
+      git tag -a "$NEW_TAG" "$old_commit" -m "WITHDRAWN: TestFlight build ${BUILD} (v${VERSION})"
+    fi
+    git push origin "refs/tags/${NEW_TAG}" || exit 1
+    git push origin ":refs/tags/${OLD_TAG}" || exit 1
+    git tag -d "$OLD_TAG" >/dev/null 2>&1 || true
+  ) || halt_failed prereq "TF withdrawn tag rename failed"
+
+  jq -nc --arg old "$OLD_TAG" --arg new "$NEW_TAG" '{old_tag:$old, withdrawn_tag:$new}'
 }
 
 cmd_appstore() {
@@ -834,10 +945,11 @@ cmd_appstore() {
 }
 
 case "${1:-}" in
-  push|""|--dry-run|--scheme|--background)
+  push|""|--dry-run|--scheme|--version|--background)
     [ "${1:-}" = "push" ] && shift
     cmd_push "$@" ;;
   appstore) shift; cmd_appstore "$@" ;;
+  withdraw-tf-tag) shift; cmd_withdraw_tf_tag "$@" ;;
   emit) shift; cmd_emit "$@" ;;
   -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
   *) printf 'studio-tf-push: unknown subcommand %s\n' "$1" >&2; exit 2 ;;

--- a/scripts/test-fixtures/288-tf-push/run.sh
+++ b/scripts/test-fixtures/288-tf-push/run.sh
@@ -7,7 +7,7 @@
 #      third are filtered out — issue #288 step 5).
 #   2. studio-tf-push.sh push --dry-run walks all four pre-Slack events
 #      (release_started, archive_completed, upload_completed, dsym_uploaded)
-#      and emits the JSON context blob on stdout.
+#      and emits the JSON context blob on stdout, including the TF anchor tag.
 #   3. studio-tf-push.sh emit slack_drafted | slack_sent | release_failed
 #      reuses the captured release-tag.
 #
@@ -60,6 +60,8 @@ echo "$OUT" | grep -q "DRY-RUN event dsym_uploaded" || { echo "FAIL: missing dsy
 echo "$OUT" | grep -q "version decision:" || { echo "FAIL: missing version decision"; exit 1; }
 RT=$(echo "$CTX" | jq -r .release_tag)
 [ "$RT" = "release-fixture-288" ] || { echo "FAIL: release_tag mismatch ($RT)"; exit 1; }
+TF_TAG=$(echo "$CTX" | jq -r .tf_tag)
+[ "$TF_TAG" = "tf-0.0.0-1" ] || { echo "FAIL: tf_tag mismatch ($TF_TAG)"; exit 1; }
 echo "PASS: 4 events + context (release_tag=$RT)"
 
 echo
@@ -84,6 +86,8 @@ done
 [ -s "$BG_PREPARED" ] || { echo "FAIL: prepared context missing"; echo "$BG"; exit 1; }
 PREPARED_BUILD=$(jq -r .build "$BG_PREPARED")
 [ "$PREPARED_BUILD" = "1" ] || { echo "FAIL: prepared build mismatch ($PREPARED_BUILD)"; exit 1; }
+PREPARED_TF_TAG=$(jq -r .tf_tag "$BG_PREPARED")
+[ "$PREPARED_TF_TAG" = "tf-0.0.0-1" ] || { echo "FAIL: prepared tf_tag mismatch ($PREPARED_TF_TAG)"; exit 1; }
 for _ in $(seq 1 20); do
   [ "$(jq -r .state "$BG_STATUS" 2>/dev/null)" = "succeeded" ] && break
   sleep 0.2
@@ -125,6 +129,21 @@ if STUDIO_TF_PUSH_FIXTURE_NODE=fixture-laptop "$REPO/scripts/studio-tf-push.sh" 
   echo "FAIL: should have halted without STUDIO_TF_PUSH_LIVE=1"; exit 1
 fi
 echo "PASS: halted at prereq gate"
+
+echo
+echo "=== Test 6b: withdrawn TF tag dry-run reports renamed anchor ==="
+WITHDRAW_OUT=$("$REPO/scripts/studio-tf-push.sh" withdraw-tf-tag --dry-run --version 26.4.17 --build 3162 2>"$TMPHOME/withdraw.err")
+[ "$(echo "$WITHDRAW_OUT" | jq -r .old_tag)" = "tf-26.4.17-3162" ] || { echo "FAIL: old withdrawn tag mismatch"; exit 1; }
+[ "$(echo "$WITHDRAW_OUT" | jq -r .withdrawn_tag)" = "tf-26.4.17-3162-WITHDRAWN" ] || { echo "FAIL: withdrawn tag mismatch"; exit 1; }
+grep -q "would rename TF tag" "$TMPHOME/withdraw.err" || { echo "FAIL: missing withdrawn dry-run note"; exit 1; }
+echo "PASS: withdrawn tag dry-run shape"
+
+echo
+echo "=== Test 6c: script documents TF anchor creation and push ==="
+grep -q 'git tag -a "$tag"' "$REPO/scripts/studio-tf-push.sh" || { echo "FAIL: missing annotated TF tag creation"; exit 1; }
+grep -q 'git push origin "refs/tags/${tag}"' "$REPO/scripts/studio-tf-push.sh" || { echo "FAIL: missing TF tag push"; exit 1; }
+grep -q 'tf-<VERSION>-<NEW_BUILD_NUMBER>-WITHDRAWN' "$REPO/_shared/contracts/release-tf-push.md" || { echo "FAIL: missing withdrawn tag contract"; exit 1; }
+echo "PASS: TF anchor creation/push documented"
 
 echo
 echo "=== Test 6: failed push preflight leaves pbxproj untouched ==="


### PR DESCRIPTION
Automated chain PR for `release-tag-anchors`.

Run by `scripts/studio-chain-runner.sh`.

Chain run: `019dfa2a-e26f-778c-addb-bc22f0385336`
Chain-run UUID: `019dfa2a-e350-762b-afe4-25612038d410`
Private report: local only; resolve by run ID on the machine that ran the chain.

Review gate: `scripts/pr-headless-review.sh <pr> --method auto`.