### PR TITLE
studio chain: release-notification-handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ STUDIO_TRACK=<track>             # session-start shortcut for v2 track work
 /dev-studio release-manager tf-push --background     # start TF archive/upload and keep session free for Slack drafting
 /dev-studio release-manager tf-push --version 26.5.0 # TestFlight push with explicit MARKETING_VERSION; live work needs STUDIO_TF_PUSH_LIVE=1
 scripts/studio-tf-push.sh withdraw-tf-tag --version 26.4.17 --build 3162 # rename TF anchor to tf-<version>-<build>-WITHDRAWN
-scripts/release-manager-configure.sh --project turnip-ios --quick --tf-slack-channel C... # configure threaded TF Slack defaults
+scripts/release-manager-configure.sh --project turnip-ios --quick --appstore-slack-channel C... # configure opt-in App Store Slack release announcements
 /studio-setup                    # onboard THIS machine — auto-pilot, prompts for role only
 /studio-setup --manager          # zero-prompt manager onboarding
 /studio-setup --worker           # zero-prompt worker (id = hostname; --id X to override)

--- a/commands/fullSendToAppStore.md
+++ b/commands/fullSendToAppStore.md
@@ -80,39 +80,13 @@ https://github.com/turnip-ios/turnip-zaps/releases/tag/${CURRENT_BUILD_NUMBER}-z
 
 ## Step 6: Optional configured Slack post
 
-If `STUDIO_RELEASES_SLACK_CHANNEL` is configured, post the unified A body to
-the release channel and seed the expected release thread replies. If it is not
-configured, skip Slack cleanly and report that release announcements are not
-configured.
-
-```bash
-cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
-export STUDIO_RELEASE_PROJECT="${STUDIO_RELEASE_PROJECT:-<project>}"
-. ./scripts/lib-release-config.sh
-load_release_config
-RELEASES_CHANNEL="${STUDIO_RELEASES_SLACK_CHANNEL:-}"
-if [ -n "$RELEASES_CHANNEL" ]; then
-  RESP=$(./scripts/slack-post.sh --channel "$RELEASES_CHANNEL" --text "$RELEASE_BODY")
-  PARENT_TS=$(echo "$RESP" | jq -r .ts)
-  [ -n "$PARENT_TS" ] && [ "$PARENT_TS" != "null" ] || { echo "slack-post returned no ts"; exit 1; }
-  WHATS_NEW_REPLY=$(cat <<EOF
-App Store "What's New" submitted with this build:
-
-
-$WHATS_NEW_BODY
-EOF
-)
-  ./scripts/slack-post.sh --channel "$RELEASES_CHANNEL" --thread-ts "$PARENT_TS" \
-    --text "$WHATS_NEW_REPLY"
-  ./scripts/slack-post.sh --channel "$RELEASES_CHANNEL" --thread-ts "$PARENT_TS" \
-    --text "https://github.com/turnip-ios/turnip-zaps/releases/tag/${CURRENT_BUILD_NUMBER}-zaps"
-fi
-```
-
-Persist the Slack channel id and parent `ts` into the release artifact or
-pending App Store marker so `scripts/appstore-watch.sh` can post lifecycle
-replies into the same thread. Confirm to the user with the Slack thread and GH
-release URL when Slack was configured.
+`scripts/studio-tf-push.sh appstore` reads the project release config and, when
+`STUDIO_RELEASES_SLACK_CHANNEL` plus the App Store Slack toggles are enabled,
+posts the release parent message and configured thread replies. It persists the
+Slack channel id and parent `ts` into the pending App Store marker so
+`scripts/appstore-watch.sh` can post lifecycle replies into the same thread. If
+Slack is not configured, the script skips Slack cleanly and reports that release
+announcements are not configured.
 
 ## Rollback
 

--- a/config/release.env.example
+++ b/config/release.env.example
@@ -13,3 +13,10 @@ STUDIO_TF_ASC_ISSUER_ID="<app-store-connect-issuer-id>"
 STUDIO_TF_ASC_KEY_PATH="$HOME/.dev-studio/<project>/secrets/appstoreconnect/AuthKey_<app-store-connect-key-id>.p8"
 
 STUDIO_SLACK_TOKEN_FILE="$HOME/.dev-studio/<project>/secrets/slack-bot-token"
+
+STUDIO_RELEASES_SLACK_CHANNEL="<app-store-release-channel-id>"
+STUDIO_RELEASES_SLACK_CHANNEL_NAME="#releases"
+STUDIO_RELEASES_SLACK_APPSTORE_PARENT="1"
+STUDIO_RELEASES_SLACK_WHATSNEW_REPLY="1"
+STUDIO_RELEASES_SLACK_GITHUB_REPLY="1"
+STUDIO_RELEASES_SLACK_WATCHER_REPLIES="1"

--- a/scripts/appstore-watch.sh
+++ b/scripts/appstore-watch.sh
@@ -81,6 +81,7 @@ read_field() {
       repo) yq -r '.repo // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       slack_channel) yq -r '.slack.channel_id // .slack.posted_to // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       slack_parent_ts) yq -r '.slack.message_ts // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      slack_watcher_replies) yq -r '.asc_metadata.slack_watcher_replies // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       github_release_url) yq -r '.github_release_url // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       asc_key_path) printf '%s\n' "${STUDIO_TF_ASC_KEY_PATH:-}" ;;
       asc_issuer_id) printf '%s\n' "${STUDIO_TF_ASC_ISSUER_ID:-}" ;;
@@ -119,6 +120,7 @@ REPO=$(read_field repo)
 CHANNEL=$(read_field slack_channel)
 PARENT_TS=$(read_field slack_parent_ts)
 URL=$(read_field github_release_url)
+WATCHER_REPLIES=$(read_field slack_watcher_replies)
 KEY_PATH=$(read_field asc_key_path)
 ISSUER_ID=$(read_field asc_issuer_id)
 KEY_ID=$(read_field asc_key_id)
@@ -126,6 +128,8 @@ KEY_ID=$(read_field asc_key_id)
 APP_ID="${APP_ID:-${STUDIO_TF_APP_ID:-}}"
 REPO="${REPO:-${STUDIO_TF_GH_REPO:-turnip-ios/turnip-zaps}}"
 URL="${URL:-https://github.com/${REPO}/releases/tag/${TAG}}"
+CHANNEL="${CHANNEL:-${STUDIO_RELEASES_SLACK_CHANNEL:-}}"
+WATCHER_REPLIES="${WATCHER_REPLIES:-${STUDIO_RELEASES_SLACK_WATCHER_REPLIES:-1}}"
 KEY_ID="${KEY_ID:-${STUDIO_TF_ASC_KEY_ID:-}}"
 ISSUER_ID="${ISSUER_ID:-${STUDIO_TF_ASC_ISSUER_ID:-}}"
 if [ -z "$KEY_PATH" ]; then
@@ -267,28 +271,44 @@ PY
 
     if [ "$SLACK_DONE" != "True" ] && [ "$SLACK_DONE" != "true" ]; then
       SLACK_TOKEN_FILE=$(release_slack_token_file)
-      if [ -r "$SLACK_TOKEN_FILE" ] && [ -n "$PARENT_TS" ] && [ -n "$CHANNEL" ]; then
-        SLACK_BOT_TOKEN=$(cat "$SLACK_TOKEN_FILE")
-        MSG="🎉 Live on App Store — notes: $URL"
-        BODY=$(python3 - "$CHANNEL" "$PARENT_TS" "$MSG" <<'PY'
-import json, sys
-print(json.dumps({'channel': sys.argv[1], 'thread_ts': sys.argv[2], 'text': sys.argv[3]}))
-PY
-)
-        if curl -s --max-time 20 -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d "$BODY" >/dev/null 2>&1; then
-          if [ "$MARKER_SOURCE" = "json" ]; then
-            python3 - "$MARKER" <<'PY'
+      if [ "$WATCHER_REPLIES" = "0" ] || [ "$WATCHER_REPLIES" = "false" ] || [ "$WATCHER_REPLIES" = "FALSE" ]; then
+        if [ "$MARKER_SOURCE" = "json" ]; then
+          python3 - "$MARKER" <<'PY'
 import json, sys
 p = sys.argv[1]; m = json.load(open(p)); m['finalize_slack_posted'] = True
+m['finalize_slack_skipped_reason'] = 'watcher_replies_disabled'
+json.dump(m, open(p, 'w'), indent=2)
+PY
+        else
+          if [ -n "$release_uuid" ]; then
+            set_release_finalize_progress "$release_uuid" finalize_slack_posted true || true
+            set_release_finalize_progress "$release_uuid" finalize_slack_skipped_reason watcher_replies_disabled || true
+          fi
+        fi
+      elif [ -r "$SLACK_TOKEN_FILE" ] && [ -n "$PARENT_TS" ] && [ -n "$CHANNEL" ]; then
+        MSG="Live on App Store — notes: $URL"
+        SLACK_OUT=$(mktemp /tmp/appstore-watch-slack.XXXXXX)
+        SLACK_ERR=$(mktemp /tmp/appstore-watch-slack.XXXXXX)
+        if STUDIO_RELEASE_PROJECT="$STUDIO_RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+            --channel "$CHANNEL" --thread-ts "$PARENT_TS" --text "$MSG" >"$SLACK_OUT" 2>"$SLACK_ERR"; then
+          if [ "$MARKER_SOURCE" = "json" ]; then
+            python3 - "$MARKER" "$SLACK_OUT" <<'PY'
+import json, sys
+p = sys.argv[1]; out_path = sys.argv[2]; m = json.load(open(p)); m['finalize_slack_posted'] = True
+try:
+    out = json.load(open(out_path))
+    if out.get('ts'):
+        m['slack_reply_ts'] = out['ts']
+except Exception:
+    pass
 json.dump(m, open(p, 'w'), indent=2)
 PY
           else
             [ -n "$release_uuid" ] && set_release_finalize_progress "$release_uuid" finalize_slack_posted true || true
           fi
+          rm -f "$SLACK_OUT" "$SLACK_ERR"
         else
+          rm -f "$SLACK_OUT" "$SLACK_ERR"
           fails=$(mark_failure slack_post_failed "$STATE")
           [ "$fails" -ge 3 ] && append_event chanakya appstore_watch_stuck "$TAG" \
             "{\"reason\":\"slack_post_failed\",\"failures\":$fails,\"state\":\"$STATE\"}" 2>/dev/null || true

--- a/scripts/release-manager-configure.sh
+++ b/scripts/release-manager-configure.sh
@@ -4,6 +4,9 @@
 # Usage:
 #   scripts/release-manager-configure.sh --project <slug> --quick \
 #     --tf-slack-channel C... --appstore-slack-channel C...
+#   scripts/release-manager-configure.sh --project <slug> --quick \
+#     --disable-testflight --appstore-slack-channel C... \
+#     [--no-appstore-github-reply] [--send-test-message]
 #
 # Writes reusable release-manager notification settings to the project-scoped
 # release config. Secrets stay in the existing project secrets directory; this
@@ -22,6 +25,10 @@ DRY_RUN=0
 SEND_TEST=0
 ENABLE_TF=1
 ENABLE_APPSTORE=1
+APPSTORE_PARENT=1
+APPSTORE_WHATSNEW_REPLY=1
+APPSTORE_GITHUB_REPLY=1
+APPSTORE_WATCHER_REPLIES=1
 TF_CHANNEL=""
 TF_CHANNEL_NAME="#testing"
 APPSTORE_CHANNEL=""
@@ -42,6 +49,14 @@ while [ $# -gt 0 ]; do
     --tf-slack-channel-name|--testflight-slack-channel-name) TF_CHANNEL_NAME="${2:?--tf-slack-channel-name requires value}"; shift 2 ;;
     --appstore-slack-channel|--releases-slack-channel) APPSTORE_CHANNEL="${2:?--appstore-slack-channel requires value}"; shift 2 ;;
     --appstore-slack-channel-name|--releases-slack-channel-name) APPSTORE_CHANNEL_NAME="${2:?--appstore-slack-channel-name requires value}"; shift 2 ;;
+    --appstore-parent-message) APPSTORE_PARENT="${2:?--appstore-parent-message requires 0 or 1}"; shift 2 ;;
+    --appstore-whatsnew-reply) APPSTORE_WHATSNEW_REPLY="${2:?--appstore-whatsnew-reply requires 0 or 1}"; shift 2 ;;
+    --appstore-github-reply) APPSTORE_GITHUB_REPLY="${2:?--appstore-github-reply requires 0 or 1}"; shift 2 ;;
+    --appstore-watcher-replies) APPSTORE_WATCHER_REPLIES="${2:?--appstore-watcher-replies requires 0 or 1}"; shift 2 ;;
+    --no-appstore-parent-message) APPSTORE_PARENT=0; shift ;;
+    --no-appstore-whatsnew-reply) APPSTORE_WHATSNEW_REPLY=0; shift ;;
+    --no-appstore-github-reply) APPSTORE_GITHUB_REPLY=0; shift ;;
+    --no-appstore-watcher-replies) APPSTORE_WATCHER_REPLIES=0; shift ;;
     --disable-testflight) ENABLE_TF=0; shift ;;
     --disable-appstore) ENABLE_APPSTORE=0; shift ;;
     --describe) DESCRIPTIVE_INTAKE="${2:?--describe requires value}"; shift 2 ;;
@@ -113,10 +128,33 @@ validate_channel_shape() {
   esac
 }
 
+validate_bool() {
+  local name="$1" value="$2"
+  case "$value" in
+    0|1|true|false|TRUE|FALSE|yes|no|YES|NO) ;;
+    *) printf 'release-manager-configure: %s must be 0/1/true/false/yes/no (got %s)\n' "$name" "$value" >&2; exit 2 ;;
+  esac
+}
+
+normalize_bool() {
+  case "$1" in
+    1|true|TRUE|yes|YES) printf '1\n' ;;
+    *) printf '0\n' ;;
+  esac
+}
+
 [ "$DRY_RUN" = "1" ] || mkdir -p "$RELEASE_CONFIG_DIR"
 
 validate_channel_shape testflight "$TF_CHANNEL"
 validate_channel_shape appstore "$APPSTORE_CHANNEL"
+validate_bool --appstore-parent-message "$APPSTORE_PARENT"
+validate_bool --appstore-whatsnew-reply "$APPSTORE_WHATSNEW_REPLY"
+validate_bool --appstore-github-reply "$APPSTORE_GITHUB_REPLY"
+validate_bool --appstore-watcher-replies "$APPSTORE_WATCHER_REPLIES"
+APPSTORE_PARENT=$(normalize_bool "$APPSTORE_PARENT")
+APPSTORE_WHATSNEW_REPLY=$(normalize_bool "$APPSTORE_WHATSNEW_REPLY")
+APPSTORE_GITHUB_REPLY=$(normalize_bool "$APPSTORE_GITHUB_REPLY")
+APPSTORE_WATCHER_REPLIES=$(normalize_bool "$APPSTORE_WATCHER_REPLIES")
 
 write_setting STUDIO_RELEASE_NOTIFICATIONS_CONFIGURED 1
 write_setting STUDIO_RELEASE_NOTIFICATION_PROFILE quick
@@ -135,10 +173,10 @@ fi
 if [ "$ENABLE_APPSTORE" = "1" ] && [ -n "$APPSTORE_CHANNEL" ]; then
   write_setting STUDIO_RELEASES_SLACK_CHANNEL "$APPSTORE_CHANNEL"
   write_setting STUDIO_RELEASES_SLACK_CHANNEL_NAME "$APPSTORE_CHANNEL_NAME"
-  write_setting STUDIO_RELEASES_SLACK_APPSTORE_PARENT 1
-  write_setting STUDIO_RELEASES_SLACK_WHATSNEW_REPLY 1
-  write_setting STUDIO_RELEASES_SLACK_GITHUB_REPLY 1
-  write_setting STUDIO_RELEASES_SLACK_WATCHER_REPLIES 1
+  write_setting STUDIO_RELEASES_SLACK_APPSTORE_PARENT "$APPSTORE_PARENT"
+  write_setting STUDIO_RELEASES_SLACK_WHATSNEW_REPLY "$APPSTORE_WHATSNEW_REPLY"
+  write_setting STUDIO_RELEASES_SLACK_GITHUB_REPLY "$APPSTORE_GITHUB_REPLY"
+  write_setting STUDIO_RELEASES_SLACK_WATCHER_REPLIES "$APPSTORE_WATCHER_REPLIES"
 fi
 
 if [ "$DRY_RUN" = "1" ]; then
@@ -161,4 +199,7 @@ if [ "$SEND_TEST" = "1" ] && [ "$DRY_RUN" != "1" ]; then
 elif [ -n "$TF_CHANNEL" ]; then
   STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
     --channel "$TF_CHANNEL" --text "Release notification dry run for ${RELEASE_PROJECT}" --dry-run >/dev/null
+elif [ -n "$APPSTORE_CHANNEL" ]; then
+  STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+    --channel "$APPSTORE_CHANNEL" --text "Release notification dry run for ${RELEASE_PROJECT}" --dry-run >/dev/null
 fi

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -389,6 +389,143 @@ cmd_emit() {
   emit_event_keyed studio release "$event" "$rt" "$data" >/dev/null
 }
 
+release_bool_enabled() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+appstore_notify_slack() {
+  local build="$1" version="$2" tag="$3" release_notes_file="$4" whatsnew_file="$5" release_url="$6" dry_run_flag="$7"
+  APPSTORE_SLACK_STATUS="skipped_not_configured"
+  APPSTORE_SLACK_CHANNEL_USED=""
+  APPSTORE_SLACK_PARENT_TS=""
+
+  local channel="${STUDIO_RELEASES_SLACK_CHANNEL:-}"
+  if [ -z "$channel" ]; then
+    printf 'studio-tf-push: Slack release announcements not configured; skipping Slack post. Run /dev-studio release-manager configure to enable.\n' >&2
+    return 0
+  fi
+  if ! release_bool_enabled "${STUDIO_RELEASES_SLACK_APPSTORE_PARENT:-1}"; then
+    printf 'studio-tf-push: Slack release parent disabled by config; skipping App Store Slack post.\n' >&2
+    APPSTORE_SLACK_STATUS="skipped_parent_disabled"
+    return 0
+  fi
+
+  APPSTORE_SLACK_CHANNEL_USED="$channel"
+  local parent_text whatsnew_text whatsnew_reply resp parent_ts
+  parent_text=$(cat "$release_notes_file")
+  whatsnew_text=$(cat "$whatsnew_file")
+
+  if [ "$dry_run_flag" = "1" ]; then
+    printf 'studio-tf-push: [dry-run] would post App Store Slack parent to %s for build=%s version=%s tag=%s\n' \
+      "$channel" "$build" "$version" "$tag" >&2
+    if release_bool_enabled "${STUDIO_RELEASES_SLACK_WHATSNEW_REPLY:-1}"; then
+      printf 'studio-tf-push: [dry-run] would post App Store What'\''s New as a thread reply\n' >&2
+    fi
+    if release_bool_enabled "${STUDIO_RELEASES_SLACK_GITHUB_REPLY:-1}"; then
+      printf 'studio-tf-push: [dry-run] would post GitHub release URL as a thread reply\n' >&2
+    fi
+    APPSTORE_SLACK_STATUS="dry_run"
+    return 0
+  fi
+
+  if ! resp=$(STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+      --channel "$channel" --text "$parent_text" 2>&1); then
+    printf 'studio-tf-push: Slack parent post failed after App Store submission was prepared: %s\n' "$resp" >&2
+    APPSTORE_SLACK_STATUS="failed_parent"
+    return 0
+  fi
+  parent_ts=$(printf '%s' "$resp" | jq -r '.ts // empty' 2>/dev/null || true)
+  if [ -z "$parent_ts" ]; then
+    printf 'studio-tf-push: Slack parent post returned no ts; watcher thread replies disabled for this release.\n' >&2
+    APPSTORE_SLACK_STATUS="failed_no_ts"
+    return 0
+  fi
+  APPSTORE_SLACK_PARENT_TS="$parent_ts"
+
+  if release_bool_enabled "${STUDIO_RELEASES_SLACK_WHATSNEW_REPLY:-1}"; then
+    whatsnew_reply=$(cat <<EOF
+App Store "What's New" submitted with this build:
+
+
+$whatsnew_text
+EOF
+)
+    if ! STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+        --channel "$channel" --thread-ts "$parent_ts" --text "$whatsnew_reply" >/dev/null; then
+      printf 'studio-tf-push: warning: Slack What'\''s New thread reply failed\n' >&2
+    fi
+  fi
+
+  if release_bool_enabled "${STUDIO_RELEASES_SLACK_GITHUB_REPLY:-1}"; then
+    if ! STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+        --channel "$channel" --thread-ts "$parent_ts" --text "$release_url" >/dev/null; then
+      printf 'studio-tf-push: warning: Slack GitHub release thread reply failed\n' >&2
+    fi
+  fi
+
+  APPSTORE_SLACK_STATUS="posted"
+}
+
+write_appstore_pending_marker() {
+  local build="$1" version="$2" tag="$3" version_id="$4" build_id="$5" release_url="$6"
+  local state_dir marker_path watcher_replies
+  state_dir="$RELEASE_PROJECT_ROOT/.runtime/state"
+  marker_path="$state_dir/pending-appstore-review.json"
+  mkdir -p "$state_dir" || {
+    printf 'studio-tf-push: could not create marker state dir %s\n' "$state_dir" >&2
+    return 1
+  }
+  if release_bool_enabled "${STUDIO_RELEASES_SLACK_WATCHER_REPLIES:-1}"; then
+    watcher_replies=true
+  else
+    watcher_replies=false
+  fi
+  jq -nc \
+    --arg project "$RELEASE_PROJECT" \
+    --arg tag "$tag" \
+    --arg version "$version" \
+    --arg asc_app_id "$APP_ID" \
+    --arg repo "${STUDIO_TF_GH_REPO:-turnip-ios/turnip-zaps}" \
+    --arg github_release_url "$release_url" \
+    --arg asc_key_id "$ASC_KEY_ID" \
+    --arg asc_issuer_id "$ASC_ISSUER_ID" \
+    --arg build_id "$build_id" \
+    --arg appstore_version_id "$version_id" \
+    --arg slack_channel "$APPSTORE_SLACK_CHANNEL_USED" \
+    --arg slack_parent_ts "$APPSTORE_SLACK_PARENT_TS" \
+    --arg slack_post_status "$APPSTORE_SLACK_STATUS" \
+    --arg created_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg build "$build" \
+    --argjson watcher_replies "$watcher_replies" \
+    '{
+      project:$project,
+      tag:$tag,
+      version:$version,
+      build:($build | tonumber? // $build),
+      asc_app_id:$asc_app_id,
+      repo:$repo,
+      github_release_url:$github_release_url,
+      asc_key_id:$asc_key_id,
+      asc_issuer_id:$asc_issuer_id,
+      asc_build_id:$build_id,
+      appstore_version_id:$appstore_version_id,
+      slack_channel:$slack_channel,
+      slack_parent_ts:$slack_parent_ts,
+      slack_post_status:$slack_post_status,
+      slack_watcher_replies:$watcher_replies,
+      created_at:$created_at,
+      next_check_at:null,
+      failures:0,
+      finalize_draft_published:false,
+      finalize_slack_posted:false
+    }' >"$marker_path"
+  chmod 600 "$marker_path" 2>/dev/null || true
+  printf 'studio-tf-push: pending App Store marker: %s\n' "$marker_path" >&2
+}
+
 cmd_push() {
   DRY_RUN_FLAG=0
   local BACKGROUND_FLAG=0
@@ -858,9 +995,12 @@ cmd_appstore() {
   route_to_release_node
 
   local TAG="${BUILD}-zaps"
+  local GH_REPO="${STUDIO_TF_GH_REPO:-turnip-ios/turnip-zaps}"
+  local RELEASE_URL="https://github.com/${GH_REPO}/releases/tag/${TAG}"
   if [ "$DRY_RUN_FLAG" = "1" ]; then
     printf 'studio-tf-push: [dry-run] would tag %s, push, gh release create --draft, ASC submit build=%s version=%s\n' \
       "$TAG" "$BUILD" "$VERSION" >&2
+    appstore_notify_slack "$BUILD" "$VERSION" "$TAG" "$RELEASE_NOTES_FILE" "$WHATSNEW_FILE" "$RELEASE_URL" "$DRY_RUN_FLAG"
     return 0
   fi
 
@@ -878,13 +1018,13 @@ cmd_appstore() {
 
   gh auth switch --user vishal-zaps >/dev/null 2>&1 || true
   if ! gh release create "$TAG" \
-      --repo turnip-ios/turnip-zaps \
+      --repo "$GH_REPO" \
       --title "$TAG" \
       --notes-file "$RELEASE_NOTES_FILE" \
       --draft >/dev/null; then
     halt_failed prereq "gh release create failed"
   fi
-  printf 'studio-tf-push: GH draft release: https://github.com/turnip-ios/turnip-zaps/releases/tag/%s\n' "$TAG" >&2
+  printf 'studio-tf-push: GH draft release: %s\n' "$RELEASE_URL" >&2
 
   local TOKEN
   TOKEN=$(mint_jwt)
@@ -935,13 +1075,21 @@ cmd_appstore() {
   printf 'studio-tf-push: appstore submission ready (build=%s version=%s, %d localizations updated)\n' \
     "$BUILD" "$VERSION" "$loc_count" >&2
 
+  appstore_notify_slack "$BUILD" "$VERSION" "$TAG" "$RELEASE_NOTES_FILE" "$WHATSNEW_FILE" "$RELEASE_URL" "$DRY_RUN_FLAG"
+  write_appstore_pending_marker "$BUILD" "$VERSION" "$TAG" "$version_id" "$build_id" "$RELEASE_URL" \
+    || printf 'studio-tf-push: warning: pending App Store marker write failed; watcher will not thread lifecycle replies\n' >&2
+
   jq -nc \
     --arg release_tag "$RELEASE_TAG" \
     --arg tag "$TAG" \
+    --arg github_release_url "$RELEASE_URL" \
     --arg version_id "$version_id" \
     --arg build_id "$build_id" \
+    --arg slack_status "$APPSTORE_SLACK_STATUS" \
+    --arg slack_channel "$APPSTORE_SLACK_CHANNEL_USED" \
+    --arg slack_parent_ts "$APPSTORE_SLACK_PARENT_TS" \
     --argjson loc_count "$loc_count" \
-    '{release_tag:$release_tag, tag:$tag, version_id:$version_id, build_id:$build_id, localizations:$loc_count}'
+    '{release_tag:$release_tag, tag:$tag, github_release_url:$github_release_url, version_id:$version_id, build_id:$build_id, localizations:$loc_count, slack:{status:$slack_status, channel_id:$slack_channel, message_ts:$slack_parent_ts}}'
 }
 
 case "${1:-}" in

--- a/scripts/test-fixtures/628-release-manager-configure/run.sh
+++ b/scripts/test-fixtures/628-release-manager-configure/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO=$(cd "$SCRIPT_DIR/../../.." && pwd)
+
+TMPHOME=$(mktemp -d -t studio-release-configure-XXXXXX)
+trap 'rm -rf "$TMPHOME"' EXIT
+
+export HOME="$TMPHOME"
+export ACHILLES_PROJECT="fixture-ios"
+
+NOTES="$TMPHOME/release-notes.txt"
+WHATSNEW="$TMPHOME/whats-new.txt"
+printf '*New*\n• Fixture release\n' >"$NOTES"
+printf 'Fixture release notes for App Store users.\n' >"$WHATSNEW"
+
+echo "=== Test 1: App Store Slack config writes opt-in release.env settings ==="
+"$REPO/scripts/release-manager-configure.sh" \
+  --project fixture-ios \
+  --quick \
+  --disable-testflight \
+  --appstore-slack-channel CAPPSTORE123 \
+  --appstore-slack-channel-name '#releases' \
+  --no-appstore-github-reply
+
+CONFIG="$TMPHOME/.dev-studio/fixture-ios/config/release.env"
+grep -q "STUDIO_RELEASES_SLACK_CHANNEL='CAPPSTORE123'" "$CONFIG" || { echo "FAIL: missing App Store channel"; exit 1; }
+grep -q "STUDIO_RELEASES_SLACK_CHANNEL_NAME='#releases'" "$CONFIG" || { echo "FAIL: missing channel name"; exit 1; }
+grep -q "STUDIO_RELEASES_SLACK_APPSTORE_PARENT='1'" "$CONFIG" || { echo "FAIL: missing parent default"; exit 1; }
+grep -q "STUDIO_RELEASES_SLACK_WHATSNEW_REPLY='1'" "$CONFIG" || { echo "FAIL: missing whats-new default"; exit 1; }
+grep -q "STUDIO_RELEASES_SLACK_GITHUB_REPLY='0'" "$CONFIG" || { echo "FAIL: missing disabled GitHub reply"; exit 1; }
+grep -q "STUDIO_RELEASES_SLACK_WATCHER_REPLIES='1'" "$CONFIG" || { echo "FAIL: missing watcher default"; exit 1; }
+if grep -q "STUDIO_TF_SLACK_CHANNEL" "$CONFIG"; then
+  echo "FAIL: disabled TestFlight should not write TF Slack settings"; exit 1
+fi
+echo "PASS: App Store release Slack settings persisted"
+
+echo
+echo "=== Test 2: dry-run App Store submission announces configured Slack shape without posting ==="
+OUT=$(STUDIO_RELEASE_PROJECT=fixture-ios STUDIO_TF_PUSH_FIXTURE_NODE=fixture-laptop \
+  "$REPO/scripts/studio-tf-push.sh" appstore \
+    --dry-run \
+    --build 123 \
+    --version 26.5.0 \
+    --release-notes-file "$NOTES" \
+    --whatsnew-file "$WHATSNEW" 2>&1)
+echo "$OUT" | grep -q "would post App Store Slack parent to CAPPSTORE123" || { echo "FAIL: missing parent dry-run"; echo "$OUT"; exit 1; }
+echo "$OUT" | grep -q "would post App Store What's New as a thread reply" || { echo "FAIL: missing whats-new dry-run"; echo "$OUT"; exit 1; }
+if echo "$OUT" | grep -q "would post GitHub release URL"; then
+  echo "FAIL: GitHub dry-run should honor disabled reply"; echo "$OUT"; exit 1
+fi
+echo "PASS: appstore dry-run consumes configured Slack settings"
+
+echo
+echo "=== Test 3: missing Slack config skips cleanly ==="
+OUT=$(STUDIO_RELEASE_PROJECT=missing-ios STUDIO_TF_PUSH_FIXTURE_NODE=fixture-laptop \
+  "$REPO/scripts/studio-tf-push.sh" appstore \
+    --dry-run \
+    --build 124 \
+    --version 26.5.1 \
+    --release-notes-file "$NOTES" \
+    --whatsnew-file "$WHATSNEW" 2>&1)
+echo "$OUT" | grep -q "Slack release announcements not configured; skipping Slack post" || { echo "FAIL: missing clean skip note"; echo "$OUT"; exit 1; }
+echo "PASS: unconfigured App Store Slack path skips without failing"
+
+echo
+echo "All checks passed."


### PR DESCRIPTION
Automated chain PR for `release-notification-handoff`.

Run by `scripts/studio-chain-runner.sh`.

Chain run: `019dfa37-76c8-7157-a64f-fc318f9cc2e4`
Chain-run UUID: `019dfa37-7783-7755-a18f-0ad71d230da3`
Private report: local only; resolve by run ID on the machine that ran the chain.

Review gate: `scripts/pr-headless-review.sh <pr> --method auto`.