### PR TITLE
studio chain: appstore-pr-lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ scripts/                # multi-worker fleet (BETA)
   ingest-feedback.sh    # routes studio-feedback records to analysis + GH issue create/comment/defer
   analyze-feedback-ingest.sh # studio feedback triage: consolidate into existing/new GH issues before processed/
   detect-edits.sh       # sweep-time blind-spot detector — brief_edited + debrief_edited
-  appstore-watch.sh     # polls ASC for pending submission; finalizes draft release + Slack on release
+  appstore-watch.sh     # polls ASC; publishes release + merge-commit PR only at READY_FOR_SALE
   backfill-orphan-debriefs.sh  # recover tasks that finished without landing in master plan (dry-run default)
   achilles-refresh-base.sh     # legacy worker helper: fetch + merge base before reviewer handoff
   task-merge.sh                # serialized merge gate: approved-only option + post-review base re-check

--- a/_shared/contracts/build-message-format.md
+++ b/_shared/contracts/build-message-format.md
@@ -95,7 +95,7 @@ the only useful way to test the change.
 - **TF:** first thread reply carries the detailed tester checklist when threaded details are enabled. Group by module when it makes the build easier to test; put important technical notes at the end under `*Technical notes*`, and only when they affect QA/product expectations.
 - **Release:** after the parent is sent, post two thread replies in this order:
   1. **App Store "What's New"** with a two-blank-line header `App Store "What's New" submitted with this build:\n\n\n<text>`. Highest-skim-value for product/leadership.
-  2. **GitHub release URL** — stable tag URL (not the draft preview).
+  2. **GitHub lifecycle URL** — while the GitHub release is a draft, post the App Store PR URL. When ASC reaches `READY_FOR_SALE`, replace that reply with the published GitHub release URL.
 
 ## Tone
 

--- a/_shared/schemas/release.md
+++ b/_shared/schemas/release.md
@@ -4,11 +4,11 @@ description: YAML shape for TestFlight / App Store release artifacts under plans
 type: reference
 ---
 
-# Release Schema (`release@1.1.0`)
+# Release Schema (`release@1.2.0`)
 
 Per-release artifact written to `~/.dev-studio/<project>/plans/releases/<release-id>.yaml`. One file per build submitted to a release channel (TestFlight or App Store). Authored by `/achilles push-tf` or `/achilles app-store`; updated by `scripts/appstore-watch.sh` as the release transitions states.
 
-Version 1.1.0 is non-breaking — adds the optional `replaced_by` and `cancelled_reason` fields to support the cancel-and-replace flow Nabu (#214) needs. `min_reader: 1.0.0` keeps the entire active fleet compatible.
+Version 1.2.0 is non-breaking — adds optional App Store PR metadata so the watcher can merge the submitted source branch only after `READY_FOR_SALE`. `min_reader: 1.0.0` keeps the entire active fleet compatible.
 
 Release state transitions governed by `state-machines/release-lifecycle.md` (landed alongside this schema in Phase 2.6 Commit B).
 
@@ -17,7 +17,7 @@ Release state transitions governed by `state-machines/release-lifecycle.md` (lan
 ```yaml
 schema_version:
   name: release
-  version: 1.1.0
+  version: 1.2.0
   min_reader: 1.0.0
   deprecated_at: null
 id: 0190f52a-9000-7f01-8aaa-77fe8fa99bbb        # UUIDv7
@@ -37,6 +37,10 @@ tasks:
   - 0190f52a-6f15-7b4c-9b2e-1e5faa80f622
 reviews:
   - 0190f52a-7b22-7e04-8cff-66ef7ec99c99        # pre-release review-ids (if any)
+github_pr:
+  number: 42                                      # App Store source PR to main; null until submission creates/reuses it
+  url: "https://github.com/org/repo/pull/42"
+  source_branch: "feature/appstore-release"
 asc_metadata:
   asc_build_id: "1234567890"                     # App Store Connect build identifier
   app_store_state: "WAITING_FOR_REVIEW"          # ASC appStoreState verbatim
@@ -44,10 +48,12 @@ asc_metadata:
   next_check_at: 2026-04-22T15:02:11Z
   consecutive_failures: 0
   stuck: false
+  finalize_pr_merged: false                      # true after READY_FOR_SALE merge commit lands
 slack:
   posted_to: "#releases"
   channel_id: "C0123456789"
   message_ts: "1745332800.001200"
+  pr_reply_ts: "1745332810.001300"                # PR URL reply, updated to release URL at READY_FOR_SALE
   reply_ts: null                                 # filled when watcher finalizes
 notes: null
 ```
@@ -69,6 +75,7 @@ notes: null
 | `released_at` | RFC3339 UTC \| null | yes | Set when state transitions to `released`. |
 | `tasks` | array of UUIDv7 | yes | Task-ids shipped in this release. Bidirectional with `task.links.release`. |
 | `reviews` | array of UUIDv7 | yes | Pre-release review artifacts (e.g. release-gate reviews). |
+| `github_pr` | object \| null | no | App Store source PR opened from the submitted branch to `main`; merged with a merge commit only after `READY_FOR_SALE`. Null for TestFlight and for legacy artifacts. |
 | `asc_metadata` | object \| null | yes | ASC poll state. Null for channels without ASC (none today). |
 | `slack` | object \| null | yes | Slack post metadata for release announcements. Null when no post made. |
 | `notes` | string \| null | yes | Optional commentary. |
@@ -136,6 +143,7 @@ Active watcher state files (`pending-appstore-review.json`) migrate into the per
 
 | Version | Landed | Changes |
 |---|---|---|
+| 1.2.0 | 2026-05-05 | Non-breaking: add optional `github_pr`, `asc_metadata.finalize_pr_merged`, and `slack.pr_reply_ts` fields for App Store submission PR lifecycle (#164). |
 | 1.1.0 | 2026-04-27 | Non-breaking: add optional `replaced_by` (release-id pointer) and `cancelled_reason` (free text) fields for the cancel-and-replace flow that Nabu (#214) consumes (#247 Stage C deliverable 2). |
 | 1.0.0 | 2026-04-22 | Initial Phase 2.6 landing alongside `state-machines/release-lifecycle.md`. |
 

--- a/_shared/state-machines/release-lifecycle.md
+++ b/_shared/state-machines/release-lifecycle.md
@@ -15,8 +15,8 @@ Every release routed through the studio — TestFlight or App Store — traverse
 | `drafted` | Release artifact created but not yet submitted to ASC. | Achilles `push-tf` / `app-store` modes pre-upload. |
 | `submitted` | Build uploaded to App Store Connect; ASC processing begins. | Achilles release modes post-upload. |
 | `in-review` | Apple has started formal review (App Store channel only). | `scripts/appstore-watch.sh` on ASC state `IN_REVIEW`. |
-| `pending-developer-release` | Apple approved; awaiting developer release (App Store channel only). | `scripts/appstore-watch.sh` on ASC state `PENDING_DEVELOPER_RELEASE`. |
-| `released` | Live on the channel. TestFlight: processed + available to testers. App Store: shipped to production. | `scripts/appstore-watch.sh` on ASC state `READY_FOR_SALE` (App Store) or `PROCESSED` for TestFlight. |
+| `pending-developer-release` | Apple approved; awaiting developer release (App Store channel only). This is not live and must not merge the source PR. | `scripts/appstore-watch.sh` on ASC state `PENDING_DEVELOPER_RELEASE`. |
+| `released` | Live on the channel. TestFlight: processed + available to testers. App Store: shipped to production. App Store source PR merge and GitHub release publication happen only here. | `scripts/appstore-watch.sh` on ASC state `READY_FOR_SALE` (App Store) or `PROCESSED` for TestFlight. |
 | `rejected` | Apple rejected the submission (App Store channel only). | `scripts/appstore-watch.sh` on ASC state `DEVELOPER_REJECTED` / `REJECTED`. |
 | `cancelled` | User or agent cancelled the submission before review terminal. | Explicit cancellation by Chanakya or user. |
 | `archived` | Post-compact cold storage. Terminal. | Chanakya compact mode. |
@@ -40,7 +40,13 @@ cancelled             → archived                  : compact sweep.
 **Channel-specific notes:**
 
 - **TestFlight channel** typically transitions `drafted → submitted → released`. ASC may emit build-processing states (`PROCESSING`, `INVALID_BINARY`) during `submitted`; these stay inside `submitted` until a terminal TF state is observed.
-- **App Store channel** has the full review flow. `pending-developer-release` is the holdpoint where the release awaits the developer to push the "Release" button.
+- **App Store channel** has the full review flow. `pending-developer-release` is the holdpoint where the release awaits the developer to push the "Release" button; it is not a merge signal. `READY_FOR_SALE` is the first unambiguous live signal and triggers the source PR merge with `gh pr merge --merge`.
+
+## App Store PR Lifecycle
+
+`/fullSendToAppStore` creates or reuses a PR from the submitted source branch to `main` immediately after the watcher marker is armed. PR creation is idempotent per source branch. If a different source branch already has a pending App Store PR, the submission continues and the user is notified that a separate PR is being raised.
+
+The watcher keeps the PR open through `PENDING_DEVELOPER_RELEASE`. On `READY_FOR_SALE`, it publishes the draft GitHub release, updates the Slack thread link from the PR URL to the GitHub release URL when possible, then merges the PR with a merge commit. If `gh pr merge --merge` fails, the watcher posts `PR merge failed — conflicts detected. Manual resolution needed.` to the Slack thread and stops without attempting a rebase.
 
 ## Required fields per transition event
 

--- a/commands/fullSendToAppStore.md
+++ b/commands/fullSendToAppStore.md
@@ -72,6 +72,8 @@ STUDIO_TF_PUSH_LIVE=1 ./scripts/studio-tf-push.sh appstore \
 
 The script tags `${BUILD}-zaps`, pushes the tag, creates a GH draft release (account-switched to `vishal-zaps`), finds the build on ASC, creates or updates the App Store version, sets MANUAL release type with the build attached, and updates `whatsNew` for every localization.
 
+After the pending App Store watcher marker is armed, the script immediately raises a PR from the current source branch to `main`. If that branch already has an open PR to `main`, it reuses the existing PR. If another branch already has a pending App Store PR, it surfaces: `There is already a PR pending from <branch>. This new build is from <new-branch>. Raising a separate PR.` The PR is intentionally left open until the watcher sees `READY_FOR_SALE`; the watcher then merges it with `gh pr merge --merge`.
+
 The stable GH release URL — same for draft and published — is:
 
 ```
@@ -84,9 +86,12 @@ https://github.com/turnip-ios/turnip-zaps/releases/tag/${CURRENT_BUILD_NUMBER}-z
 `STUDIO_RELEASES_SLACK_CHANNEL` plus the App Store Slack toggles are enabled,
 posts the release parent message and configured thread replies. It persists the
 Slack channel id and parent `ts` into the pending App Store marker so
-`scripts/appstore-watch.sh` can post lifecycle replies into the same thread. If
-Slack is not configured, the script skips Slack cleanly and reports that release
-announcements are not configured.
+`scripts/appstore-watch.sh` can post lifecycle replies into the same thread.
+While the GitHub release is still a draft, the thread link is the PR URL. When
+ASC reaches `READY_FOR_SALE`, the watcher publishes the GitHub release and
+updates that thread reply to the release URL. If Slack is not configured, the
+script skips Slack cleanly and reports that release announcements are not
+configured.
 
 ## Rollback
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -209,7 +209,7 @@ scripts/recommend-model.sh --size s --kind impl --cross-file-count 3 --novelty-s
 scripts/detect-edits.sh --quiet                         # emits brief_edited + debrief_edited
 
 # App Store submission watcher (auto-invoked by every sweep):
-scripts/appstore-watch.sh                               # idempotent; self-gated on marker.next_check_at
+scripts/appstore-watch.sh                               # idempotent; publishes release + merge-commit PR only at READY_FOR_SALE
 ```
 
 **Why work-stealing over upfront fan-out.** Task durations span 3–5× (XS LSP-only vs. M/L with full `xcodebuild`). Batch-assigning N+1…2N tasks to inboxes upfront leaves fast workers idle while slow ones still have a backlog. The queue hands one task at a time on each `task_completed` event, so every freed worker gets the next pending task.

--- a/scripts/appstore-watch.sh
+++ b/scripts/appstore-watch.sh
@@ -10,13 +10,15 @@
 # Written by /fullSendToAppStore after submission. Absent marker → no-op.
 # Wrong project → no-op.
 #
-# On terminal state (PENDING_DEVELOPER_RELEASE / READY_FOR_SALE):
+# On live state (READY_FOR_SALE):
 #   1. gh release edit <tag> --draft=false
-#   2. Threaded Slack reply on the original configured release message
-#   3. Delete marker
-#   4. Emit appstore_released
+#   2. Replace the PR URL Slack thread reply with the GitHub release URL
+#   3. Merge the App Store PR with a merge commit
+#   4. Delete marker
+#   5. Emit appstore_released
 # Steps 1 and 2 are tracked in marker.finalize_progress for idempotency —
 # a partial failure re-attempts only the unfinished step on the next sweep.
+# PENDING_DEVELOPER_RELEASE only records the intermediate state; it is not live.
 #
 # On non-terminal: update last_state + next_check_at (30–60 min jitter),
 # emit appstore_state_checked.
@@ -83,11 +85,16 @@ read_field() {
       slack_parent_ts) yq -r '.slack.message_ts // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       slack_watcher_replies) yq -r '.asc_metadata.slack_watcher_replies // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       github_release_url) yq -r '.github_release_url // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      github_pr_url) yq -r '.github_pr.url // .github_pr_url // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      github_pr_number) yq -r '.github_pr.number // .github_pr_number // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      source_branch) yq -r '.source_branch // .github_pr.source_branch // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      slack_pr_reply_ts) yq -r '.slack.pr_reply_ts // .asc_metadata.slack_pr_reply_ts // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       asc_key_path) printf '%s\n' "${STUDIO_TF_ASC_KEY_PATH:-}" ;;
       asc_issuer_id) printf '%s\n' "${STUDIO_TF_ASC_ISSUER_ID:-}" ;;
       asc_key_id) printf '%s\n' "${STUDIO_TF_ASC_KEY_ID:-}" ;;
       finalize_draft_published) yq -r '.asc_metadata.finalize_draft_published // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       finalize_slack_posted) yq -r '.asc_metadata.finalize_slack_posted // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
+      finalize_pr_merged) yq -r '.asc_metadata.finalize_pr_merged // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null ;;
       *) printf '\n' ;;
     esac
     return 0
@@ -120,6 +127,10 @@ REPO=$(read_field repo)
 CHANNEL=$(read_field slack_channel)
 PARENT_TS=$(read_field slack_parent_ts)
 URL=$(read_field github_release_url)
+PR_URL=$(read_field github_pr_url)
+PR_NUMBER=$(read_field github_pr_number)
+SOURCE_BRANCH=$(read_field source_branch)
+SLACK_PR_REPLY_TS=$(read_field slack_pr_reply_ts)
 WATCHER_REPLIES=$(read_field slack_watcher_replies)
 KEY_PATH=$(read_field asc_key_path)
 ISSUER_ID=$(read_field asc_issuer_id)
@@ -188,6 +199,65 @@ print(m.get('failures', 0))
 PY
 }
 
+mark_json_finalize_field() {
+  local field="$1" value="$2"
+  [ "$MARKER_SOURCE" = "json" ] || return 0
+  python3 - "$MARKER" "$field" "$value" <<'PY'
+import json, sys
+p, field, value = sys.argv[1], sys.argv[2], sys.argv[3]
+m = json.load(open(p))
+if value == "true":
+    m[field] = True
+elif value == "false":
+    m[field] = False
+else:
+    m[field] = value
+json.dump(m, open(p, 'w'), indent=2)
+PY
+}
+
+post_slack_thread_reply() {
+  local msg="$1" out_path="$2"
+  STUDIO_RELEASE_PROJECT="$STUDIO_RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+    --channel "$CHANNEL" --thread-ts "$PARENT_TS" --text "$msg" >"$out_path"
+}
+
+update_slack_thread_reply() {
+  local ts="$1" msg="$2"
+  local token_file token payload response ok
+  token_file=$(release_slack_token_file)
+  [ -r "$token_file" ] || return 2
+  token=$(cat "$token_file")
+  [ -n "$token" ] || return 2
+  payload=$(jq -nc --arg channel "$CHANNEL" --arg ts "$ts" --arg text "$msg" \
+    '{channel:$channel, ts:$ts, text:$text}')
+  response=$(curl -sS -X POST "https://slack.com/api/chat.update" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    --data "$payload") || return 1
+  ok=$(printf '%s' "$response" | jq -r '.ok // false' 2>/dev/null || printf false)
+  [ "$ok" = "true" ]
+}
+
+merge_appstore_pr() {
+  [ -n "$PR_NUMBER" ] || return 0
+  if with_login_home_for_github gh pr merge "$PR_NUMBER" --repo "$REPO" --merge >/dev/null 2>&1; then
+    mark_json_finalize_field finalize_pr_merged true
+    return 0
+  fi
+
+  local msg="PR merge failed — conflicts detected. Manual resolution needed."
+  printf '[appstore-watch] %s\n' "$msg" >&2
+  if [ "$WATCHER_REPLIES" != "0" ] && [ "$WATCHER_REPLIES" != "false" ] && \
+     [ "$WATCHER_REPLIES" != "FALSE" ] && [ -n "$PARENT_TS" ] && [ -n "$CHANNEL" ]; then
+    local out
+    out=$(mktemp /tmp/appstore-watch-pr-merge.XXXXXX)
+    post_slack_thread_reply "$msg" "$out" >/dev/null 2>&1 || true
+    rm -f "$out"
+  fi
+  return 1
+}
+
 # Generate ASC JWT (pattern from _shared/primitives/appstore-connect-jwt.md).
 TOKEN=$(python3 - "$KEY_PATH" "$ISSUER_ID" "$KEY_ID" <<'PY'
 import jwt, time, sys
@@ -245,13 +315,14 @@ if [ -n "$release_uuid" ]; then
 fi
 
 case "$STATE" in
-  PENDING_DEVELOPER_RELEASE|READY_FOR_SALE)
+  READY_FOR_SALE)
     # Idempotent finalize driven by marker.finalize_progress.
     DRAFT_DONE=$(read_field finalize_draft_published)
     SLACK_DONE=$(read_field finalize_slack_posted)
+    PR_MERGED=$(read_field finalize_pr_merged)
 
     if [ "$DRAFT_DONE" != "True" ] && [ "$DRAFT_DONE" != "true" ]; then
-      if gh release edit "$TAG" --repo "$REPO" --draft=false >/dev/null 2>&1; then
+      if with_login_home_for_github gh release edit "$TAG" --repo "$REPO" --draft=false >/dev/null 2>&1; then
         if [ "$MARKER_SOURCE" = "json" ]; then
           python3 - "$MARKER" <<'PY'
 import json, sys
@@ -289,8 +360,19 @@ PY
         MSG="Live on App Store — notes: $URL"
         SLACK_OUT=$(mktemp /tmp/appstore-watch-slack.XXXXXX)
         SLACK_ERR=$(mktemp /tmp/appstore-watch-slack.XXXXXX)
-        if STUDIO_RELEASE_PROJECT="$STUDIO_RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
-            --channel "$CHANNEL" --thread-ts "$PARENT_TS" --text "$MSG" >"$SLACK_OUT" 2>"$SLACK_ERR"; then
+        if [ -n "$SLACK_PR_REPLY_TS" ]; then
+          if update_slack_thread_reply "$SLACK_PR_REPLY_TS" "$MSG" >"$SLACK_OUT" 2>"$SLACK_ERR"; then
+            printf '{"ts":"%s"}\n' "$SLACK_PR_REPLY_TS" >"$SLACK_OUT"
+            slack_ok=true
+          else
+            slack_ok=false
+          fi
+        elif post_slack_thread_reply "$MSG" "$SLACK_OUT" 2>"$SLACK_ERR"; then
+          slack_ok=true
+        else
+          slack_ok=false
+        fi
+        if [ "$slack_ok" = "true" ]; then
           if [ "$MARKER_SOURCE" = "json" ]; then
             python3 - "$MARKER" "$SLACK_OUT" <<'PY'
 import json, sys
@@ -332,6 +414,15 @@ PY
       fi
     fi
 
+    if [ "$PR_MERGED" != "True" ] && [ "$PR_MERGED" != "true" ]; then
+      if ! merge_appstore_pr; then
+        fails=$(mark_failure pr_merge_failed "$STATE")
+        [ "$fails" -ge 3 ] && append_event chanakya appstore_watch_stuck "$TAG" \
+          "{\"reason\":\"pr_merge_failed\",\"failures\":$fails,\"state\":\"$STATE\"}" 2>/dev/null || true
+        exit 1
+      fi
+    fi
+
     [ "$MARKER_SOURCE" = "json" ] && rm -f "$MARKER"
     if [ -n "$release_uuid" ]; then
       release_state=$(yq -r '.state // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null)
@@ -341,6 +432,33 @@ PY
     append_event chanakya appstore_released "$TAG" \
       "{\"final_state\":\"$STATE\",\"tag\":\"$TAG\"}" 2>/dev/null || true
     echo "[appstore-watch] finalized $TAG — marker reconciled"
+    ;;
+  PENDING_DEVELOPER_RELEASE)
+    JITTER=$(( (RANDOM % 1801) + 1800 ))
+    NEXT_ISO=$(python3 - "$JITTER" <<'PY'
+import sys, datetime
+jitter = int(sys.argv[1])
+nxt = datetime.datetime.utcnow() + datetime.timedelta(seconds=jitter)
+print(nxt.strftime('%Y-%m-%dT%H:%M:%SZ'))
+PY
+)
+    if [ "$MARKER_SOURCE" = "json" ]; then
+      python3 - "$MARKER" "$STATE" "$NOW_ISO" "$NEXT_ISO" <<'PY'
+import json, sys
+p, state, now, nxt = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+m = json.load(open(p))
+m['last_state'] = state
+m['last_check_at'] = now
+m['failures'] = 0
+m.pop('stuck', None)
+m.pop('last_error', None)
+m['next_check_at'] = nxt
+json.dump(m, open(p, 'w'), indent=2)
+PY
+    fi
+    [ -n "$release_uuid" ] && set_release_asc_poll "$release_uuid" "$STATE" "$NOW_ISO" "$NEXT_ISO" 0 false || true
+    append_event chanakya appstore_state_checked "$TAG" \
+      "{\"state\":\"$STATE\",\"note\":\"pending_developer_release_not_live\"}" 2>/dev/null || true
     ;;
   *)
     JITTER=$(( (RANDOM % 1801) + 1800 ))

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -425,7 +425,7 @@ appstore_notify_slack() {
       printf 'studio-tf-push: [dry-run] would post App Store What'\''s New as a thread reply\n' >&2
     fi
     if release_bool_enabled "${STUDIO_RELEASES_SLACK_GITHUB_REPLY:-1}"; then
-      printf 'studio-tf-push: [dry-run] would post GitHub release URL as a thread reply\n' >&2
+      printf 'studio-tf-push: [dry-run] would post App Store PR URL as a thread reply after watcher setup\n' >&2
     fi
     APPSTORE_SLACK_STATUS="dry_run"
     return 0
@@ -456,13 +456,6 @@ EOF
     if ! STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
         --channel "$channel" --thread-ts "$parent_ts" --text "$whatsnew_reply" >/dev/null; then
       printf 'studio-tf-push: warning: Slack What'\''s New thread reply failed\n' >&2
-    fi
-  fi
-
-  if release_bool_enabled "${STUDIO_RELEASES_SLACK_GITHUB_REPLY:-1}"; then
-    if ! STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
-        --channel "$channel" --thread-ts "$parent_ts" --text "$release_url" >/dev/null; then
-      printf 'studio-tf-push: warning: Slack GitHub release thread reply failed\n' >&2
     fi
   fi
 
@@ -524,6 +517,119 @@ write_appstore_pending_marker() {
     }' >"$marker_path"
   chmod 600 "$marker_path" 2>/dev/null || true
   printf 'studio-tf-push: pending App Store marker: %s\n' "$marker_path" >&2
+}
+
+update_appstore_pending_marker_pr() {
+  local pr_url="$1" pr_number="$2" source_branch="$3" notice="$4" slack_pr_reply_ts="$5"
+  local marker_path="$RELEASE_PROJECT_ROOT/.runtime/state/pending-appstore-review.json"
+  [ -f "$marker_path" ] || return 0
+  local tmp
+  tmp=$(mktemp "${marker_path}.XXXXXX") || return 1
+  jq \
+    --arg pr_url "$pr_url" \
+    --arg pr_number "$pr_number" \
+    --arg source_branch "$source_branch" \
+    --arg notice "$notice" \
+    --arg slack_pr_reply_ts "$slack_pr_reply_ts" \
+    '.github_pr_url = $pr_url |
+     .github_pr_number = ($pr_number | tonumber? // $pr_number) |
+     .source_branch = $source_branch |
+     .pending_pr_notice = $notice |
+     .slack_pr_reply_ts = $slack_pr_reply_ts |
+     .finalize_pr_merged = false' \
+    "$marker_path" >"$tmp" && mv "$tmp" "$marker_path"
+  chmod 600 "$marker_path" 2>/dev/null || true
+}
+
+notify_appstore_pending_pr_notice() {
+  local notice="$1"
+  [ -n "$notice" ] || return 0
+  printf 'studio-tf-push: %s\n' "$notice" >&2
+  if [ -n "$APPSTORE_SLACK_PARENT_TS" ] && [ -n "$APPSTORE_SLACK_CHANNEL_USED" ] && \
+     release_bool_enabled "${STUDIO_RELEASES_SLACK_WATCHER_REPLIES:-1}"; then
+    STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+      --channel "$APPSTORE_SLACK_CHANNEL_USED" \
+      --thread-ts "$APPSTORE_SLACK_PARENT_TS" \
+      --text "$notice" >/dev/null 2>&1 || \
+      printf 'studio-tf-push: warning: Slack pending-PR notice failed\n' >&2
+  fi
+}
+
+post_appstore_pr_link() {
+  local pr_url="$1"
+  APPSTORE_PR_SLACK_REPLY_TS=""
+  [ -n "$pr_url" ] || return 0
+  if [ -z "$APPSTORE_SLACK_PARENT_TS" ] || [ -z "$APPSTORE_SLACK_CHANNEL_USED" ]; then
+    return 0
+  fi
+  if ! release_bool_enabled "${STUDIO_RELEASES_SLACK_GITHUB_REPLY:-1}"; then
+    return 0
+  fi
+  if ! release_bool_enabled "${STUDIO_RELEASES_SLACK_WATCHER_REPLIES:-1}"; then
+    return 0
+  fi
+  local resp
+  if resp=$(STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" \
+      --channel "$APPSTORE_SLACK_CHANNEL_USED" \
+      --thread-ts "$APPSTORE_SLACK_PARENT_TS" \
+      --text "$pr_url" 2>&1); then
+    APPSTORE_PR_SLACK_REPLY_TS=$(printf '%s' "$resp" | jq -r '.ts // empty' 2>/dev/null || true)
+  else
+    printf 'studio-tf-push: warning: Slack App Store PR URL thread reply failed: %s\n' "$resp" >&2
+  fi
+}
+
+create_or_reuse_appstore_pr() {
+  local source_branch="$1" gh_repo="$2" tag="$3" release_url="$4"
+  APPSTORE_PR_URL=""
+  APPSTORE_PR_NUMBER=""
+  APPSTORE_PR_PENDING_NOTICE=""
+
+  local prs same_pr pending_branch pr_body pr_url pr_json
+  prs=$(with_login_home_for_github gh pr list \
+    --repo "$gh_repo" \
+    --base main \
+    --state open \
+    --json number,headRefName,title,url 2>/dev/null) || halt_failed prereq "gh pr list failed"
+
+  same_pr=$(printf '%s' "$prs" | jq -c --arg branch "$source_branch" \
+    '[.[] | select(.headRefName == $branch)] | first // empty')
+  if [ -n "$same_pr" ]; then
+    APPSTORE_PR_URL=$(printf '%s' "$same_pr" | jq -r '.url')
+    APPSTORE_PR_NUMBER=$(printf '%s' "$same_pr" | jq -r '.number')
+    printf 'studio-tf-push: reusing open App Store PR #%s from %s\n' "$APPSTORE_PR_NUMBER" "$source_branch" >&2
+    return 0
+  fi
+
+  pending_branch=$(printf '%s' "$prs" | jq -r --arg branch "$source_branch" \
+    '[.[] | select(.headRefName != $branch and (.title | startswith("App Store submission ")))] | first | .headRefName // empty')
+  if [ -n "$pending_branch" ]; then
+    APPSTORE_PR_PENDING_NOTICE="There is already a PR pending from ${pending_branch}. This new build is from ${source_branch}. Raising a separate PR."
+  fi
+
+  pr_body=$(cat <<EOF
+App Store submission for ${tag}.
+
+Release notes remain in the draft GitHub release until App Store Connect reports READY_FOR_SALE:
+${release_url}
+
+Merge policy: merge to main only after READY_FOR_SALE, using a merge commit.
+EOF
+)
+  pr_url=$(with_login_home_for_github gh pr create \
+    --repo "$gh_repo" \
+    --base main \
+    --head "$source_branch" \
+    --title "App Store submission ${tag}" \
+    --body "$pr_body" 2>/dev/null) || halt_failed prereq "gh pr create failed"
+  APPSTORE_PR_URL=$(printf '%s\n' "$pr_url" | tail -1)
+  pr_json=$(with_login_home_for_github gh pr view "$APPSTORE_PR_URL" \
+    --repo "$gh_repo" \
+    --json number,url 2>/dev/null) || halt_failed prereq "gh pr view failed after create"
+  APPSTORE_PR_NUMBER=$(printf '%s' "$pr_json" | jq -r '.number // empty')
+  APPSTORE_PR_URL=$(printf '%s' "$pr_json" | jq -r '.url // empty')
+  [ -n "$APPSTORE_PR_URL" ] || halt_failed prereq "gh pr create returned no URL"
+  printf 'studio-tf-push: App Store PR: %s\n' "$APPSTORE_PR_URL" >&2
 }
 
 cmd_push() {
@@ -1016,8 +1122,8 @@ cmd_appstore() {
     git push origin "$TAG" || exit 1
   ) || halt_failed prereq "git tag/push failed"
 
-  gh auth switch --user vishal-zaps >/dev/null 2>&1 || true
-  if ! gh release create "$TAG" \
+  with_login_home_for_github gh auth switch --user vishal-zaps >/dev/null 2>&1 || true
+  if ! with_login_home_for_github gh release create "$TAG" \
       --repo "$GH_REPO" \
       --title "$TAG" \
       --notes-file "$RELEASE_NOTES_FILE" \
@@ -1078,18 +1184,25 @@ cmd_appstore() {
   appstore_notify_slack "$BUILD" "$VERSION" "$TAG" "$RELEASE_NOTES_FILE" "$WHATSNEW_FILE" "$RELEASE_URL" "$DRY_RUN_FLAG"
   write_appstore_pending_marker "$BUILD" "$VERSION" "$TAG" "$version_id" "$build_id" "$RELEASE_URL" \
     || printf 'studio-tf-push: warning: pending App Store marker write failed; watcher will not thread lifecycle replies\n' >&2
+  create_or_reuse_appstore_pr "$appstore_branch" "$GH_REPO" "$TAG" "$RELEASE_URL"
+  notify_appstore_pending_pr_notice "$APPSTORE_PR_PENDING_NOTICE"
+  post_appstore_pr_link "$APPSTORE_PR_URL"
+  update_appstore_pending_marker_pr "$APPSTORE_PR_URL" "$APPSTORE_PR_NUMBER" "$appstore_branch" "$APPSTORE_PR_PENDING_NOTICE" "$APPSTORE_PR_SLACK_REPLY_TS" \
+    || printf 'studio-tf-push: warning: pending App Store marker PR metadata update failed\n' >&2
 
   jq -nc \
     --arg release_tag "$RELEASE_TAG" \
     --arg tag "$TAG" \
     --arg github_release_url "$RELEASE_URL" \
+    --arg github_pr_url "$APPSTORE_PR_URL" \
+    --arg github_pr_number "$APPSTORE_PR_NUMBER" \
     --arg version_id "$version_id" \
     --arg build_id "$build_id" \
     --arg slack_status "$APPSTORE_SLACK_STATUS" \
     --arg slack_channel "$APPSTORE_SLACK_CHANNEL_USED" \
     --arg slack_parent_ts "$APPSTORE_SLACK_PARENT_TS" \
     --argjson loc_count "$loc_count" \
-    '{release_tag:$release_tag, tag:$tag, github_release_url:$github_release_url, version_id:$version_id, build_id:$build_id, localizations:$loc_count, slack:{status:$slack_status, channel_id:$slack_channel, message_ts:$slack_parent_ts}}'
+    '{release_tag:$release_tag, tag:$tag, github_release_url:$github_release_url, github_pr:{url:$github_pr_url, number:($github_pr_number | tonumber? // $github_pr_number)}, version_id:$version_id, build_id:$build_id, localizations:$loc_count, slack:{status:$slack_status, channel_id:$slack_channel, message_ts:$slack_parent_ts}}'
 }
 
 case "${1:-}" in


### PR DESCRIPTION
Automated chain PR for `appstore-pr-lifecycle`.

Run by `scripts/studio-chain-runner.sh`.

Chain run: `019dfa41-bbb0-7443-aa85-e900df0468e5`
Chain-run UUID: `019dfa41-bcbf-7d0f-ac98-00c1e7b1d8f5`
Private report: local only; resolve by run ID on the machine that ran the chain.

Review gate: `scripts/pr-headless-review.sh <pr> --method auto`.