### PR TITLE
Clarify dev-studio active role help

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 ```
 # Studio v2 router — canonical role dispatch
 /dev-studio manager              # bare role landing — suggests next moves, then reports the direct command
+/dev-studio help                 # router-level role index; active-role help after a role is selected
+/dev-studio <role> help          # available commands and examples for one role
 /dev-studio manager resume-plan  # "where were we" — load ROADMAP + ARCHITECTURE + pending memory
 /dev-studio reviewer review      # walk REVIEW.md against the pending diff
 /dev-studio release-manager      # draft release notes per RELEASES.md (never auto-tags)
@@ -146,15 +148,17 @@ scripts/recommend-model.sh --size s --kind impl --cross-file-count 3 --novelty-s
 
 **Minimal-intervention by default.** Studio v2 routes through canonical roles under `/dev-studio`. The former top-level v1 agent surfaces were removed by A10; compatibility names such as `chanakya`, `achilles`, `argus`, and `apollo` now live as v2 role aliases.
 
+**Session-local role shortcuts.** After a bare role landing such as `/dev-studio manager`, unqualified commands like `status`, `ingest`, `reconcile`, `guard`, or `audit` may resolve through that role while the session context is clear. Explicit `/dev-studio <role> ...` always wins; bare `/dev-studio` re-lands in manager.
+
 ---
 
 ## What's in the Repo
 
 ```
 core/v2/skills/dev-studio/
-  SKILL.md         # v2 umbrella role router
-  docs.html        # self-contained /dev-studio docs page
-  routing.yaml     # /dev-studio invocation metadata
+  SKILL.md         # v2 umbrella role router; active-role and help intent rules
+  docs.html        # self-contained /dev-studio docs page with per-role help
+  routing.yaml     # /dev-studio invocation metadata and help triggers
   forwarders.yaml  # post-A10 compatibility-alias state
 
 core/v2/roles/

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-05T23:33:27Z",
+  "generated_at": "2026-05-06T09:54:43Z",
   "agents": [
 
   ]

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -37,9 +37,25 @@ supplies the task context and runtime slug.
    - Empty arguments route to the lightweight `manager` landing.
    - A canonical role or compatibility alias in the first token routes through
      `$STUDIO_REPO/scripts/v2-role-resolve.sh`.
+   - Store any session-local active role only in the host conversation context,
+     using the resolved canonical role after alias resolution. Do not write
+     active-role state to disk or env vars.
+   - If no role token is present and the current session has a clear active
+     role, resolve unambiguous bare subcommands through that active role.
+     Explicit `/dev-studio <role> ...` always wins and replaces the active role
+     for that invocation. Bare `/dev-studio` re-lands in `manager` and clears
+     any assumed active-role shortcut.
+   - Bare `help` with no active role shows the router-level role index. Bare
+     `help` with an active role shows that role's help. `<role> help` always
+     shows that role's available commands, examples, aliases, and shared
+     lifecycle actions.
    - A role token with no remaining request starts that role's lightweight
      landing. Load the role contract, inspect only cheap cwd/profile context,
      and offer next moves instead of running a heavy default action.
+   - Bare `/dev-studio checkpoint` and `/dev-studio resume-checkpoint` always
+     land in `manager`; role-qualified lifecycle commands are owned by the
+     named role. Do not let active-role shortcuts swallow those bare slash
+     invocations.
    - Unknown role tokens fail before side effects.
 
 5. Execute the matched role workflow by following the router and role contract:
@@ -52,6 +68,33 @@ supplies the task context and runtime slug.
    - `release-manager configure` -> project-scoped release notification setup;
      call `$STUDIO_REPO/scripts/release-manager-configure.sh` after shaping
      quick/custom/descriptive Slack options with the user.
+   - `host-adapter` -> nodes, sync, host capability, and host skill refresh.
+   - `operator` -> human authority marker only; surface an explicit decision
+     instead of pretending to execute a runnable role.
+
+   Bare subcommand ownership:
+
+   | Command | Owner | Example |
+   |---|---|---|
+   | `help` | router or active role | `/dev-studio help`, `/dev-studio manager help` |
+   | `status` | manager | `status` after `/dev-studio manager` |
+   | `resume-plan` | manager | `/dev-studio manager resume-plan` |
+   | `ingest` | manager | `ingest "capture this"` |
+   | `guard` | manager | `guard "has this shipped?"` |
+   | `audit` | manager | `audit` |
+   | `analyze` | manager | `/dev-studio manager analyze` |
+   | `reconcile` | manager | `reconcile` in a project repo |
+   | `add` | manager | `/dev-studio manager add <url>` |
+   | `sync` | host-adapter | `/dev-studio host-adapter sync` |
+   | `nodes` | host-adapter | `/dev-studio host-adapter nodes` |
+   | `review` | reviewer | `/dev-studio reviewer review` |
+   | `plan` | planner | `/dev-studio planner plan issue 123` |
+   | `profile` | perf | `/dev-studio perf profile editor startup` |
+   | `qa` | qa-engineer | `/dev-studio qa-engineer help` |
+   | `flow`, `flow-test` | flow-tester | `/dev-studio flow-tester help` |
+   | `release`, `tf-push` | release-manager | `/dev-studio release-manager tf-push --background` |
+   | `configure` | release-manager only when active or prefixed | `/dev-studio release-manager configure` |
+   | `checkpoint`, `resume-checkpoint` | lifecycle special | `/dev-studio worker checkpoint` |
 
 6. Keep project state under `~/.dev-studio/$PROJECT_SLUG/` unless the user
    explicitly names another project slug. For `manager ingest`, call
@@ -83,6 +126,32 @@ supplies the task context and runtime slug.
 
    Then say: "Studio v2 router docs opened. Path in the repo:
    `core/v2/skills/dev-studio/docs.html`."
+
+   If the user asks for role help in chat instead of opening docs, summarize
+   from this index:
+
+   - `manager`: `status`, `resume-plan`, `ingest`, `guard`, `audit`,
+     `analyze`, `reconcile`, `add`; examples: `/dev-studio manager ingest
+     "capture this"`, `/dev-studio manager reconcile`.
+   - `worker`: bounded contract execution plus `checkpoint` and
+     `resume-checkpoint`; example: `/dev-studio worker T123`.
+   - `reviewer`: `review`, plan/outcome/diff/PR/release-packet review plus
+     lifecycle actions; example: `/dev-studio reviewer review`.
+   - `perf`: `profile` and metric investigation requests plus lifecycle
+     actions; example: `/dev-studio perf profile editor startup`.
+   - `planner`: `plan` and decomposition requests plus lifecycle actions;
+     example: `/dev-studio planner plan issue 123`.
+   - `qa-engineer`: QA target and test-contract requests plus lifecycle
+     actions; example: `/dev-studio qa-engineer write QA targets for T123`.
+   - `flow-tester`: exploratory flow scenarios and checklists plus lifecycle
+     actions; example: `/dev-studio flow-tester check onboarding on build 456`.
+   - `release-manager`: `release`, `configure`, `tf-push`, release packets,
+     and lifecycle actions; examples: `/dev-studio release-manager configure`,
+     `/dev-studio release-manager tf-push --background`.
+   - `host-adapter`: `nodes`, `sync`, host capability checks; example:
+     `/dev-studio host-adapter nodes`.
+   - `operator`: decision authority only; surface an approval request rather
+     than running a role.
 
 ## Notes
 

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -26,6 +26,11 @@ Canonical roles: `manager`, `worker`, `reviewer`, `perf`, `planner`,
 `qa-engineer`, `flow-tester`, `release-manager`, `host-adapter`, `operator`.
 Compatibility aliases resolve through `scripts/v2-role-resolve.sh`.
 
+Role help: bare `help` shows the router-level role index unless a session-local
+active role is already clear; `<role> help` shows that role's commands,
+examples, aliases, and shared lifecycle actions. The active role is only host
+conversation context, not on-disk state.
+
 <!-- v2-dev-studio:lifecycle -->
 ## Lifecycle Actions
 
@@ -73,12 +78,19 @@ direct invocation once the workflow is selected. `manager ingest` calls
 `scripts/manager-analyze.sh`; `manager reconcile` calls
 `scripts/manager-reconcile.sh`.
 
+After a bare role landing, later bare subcommands may resolve through that
+active role when unambiguous in the same session. Store the resolved canonical
+role after alias resolution. Explicit `/dev-studio <role> ...` always wins and
+replaces the active role for that invocation; bare `/dev-studio` re-lands in
+manager and clears any assumed active-role shortcut. Ambiguous commands require
+the role prefix or a lightweight clarification.
+
 <!-- v2-dev-studio:intent -->
 ## Intent detection
 
 Priority: explicit canonical role, compatibility alias, former top-level name,
-bare role landing, then manager landing. Unknown role tokens fail before side
-effects.
+session-local active-role command when unambiguous, bare role landing, then
+manager landing. Unknown role tokens fail before side effects.
 
 <!-- v2-dev-studio:forwarders -->
 ## Forwarders

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -459,6 +459,8 @@
             role's landing instead of running a heavy default action.
           </p>
           <code class="shell">/dev-studio manager
+/dev-studio help
+/dev-studio manager help
 /dev-studio reviewer
 /dev-studio release-manager
 /dev-studio manager resume-plan
@@ -543,6 +545,22 @@ scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt;</code>
             <code class="shell">/dev-studio checkpoint
 /dev-studio worker checkpoint
 /dev-studio reviewer resume-checkpoint</code>
+          </article>
+          <article class="role">
+            <h3>Active Role Shortcuts</h3>
+            <p>After a bare role landing, unqualified commands may keep using that role while the session context is clear. Explicit role prefixes always override the shortcut.</p>
+            <code class="shell">/dev-studio manager
+status
+ingest "capture this pattern"
+reconcile
+/dev-studio reviewer review</code>
+          </article>
+          <article class="role">
+            <h3>Role Help</h3>
+            <p>Use router help for the role index, or role help for available commands, examples, aliases, and checkpoint/resume availability.</p>
+            <code class="shell">/dev-studio help
+/dev-studio manager help
+/dev-studio release-manager help</code>
           </article>
         </div>
       </div>
@@ -732,6 +750,7 @@ scripts/worker-status.sh</code>
             <p>Shapes intent, resumes arcs, routes work, guards against repeats, captures patterns, and escalates operator decisions.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">contract-backed landing</span></div>
             <code class="shell">/dev-studio manager
+/dev-studio manager help
 /dev-studio manager resume-plan
 /dev-studio manager guard "has this shipped?"
 /dev-studio manager analyze
@@ -743,14 +762,16 @@ scripts/worker-status.sh</code>
             <h3>planner</h3>
             <p>Turns shaped work into executable scope, dependencies, acceptance criteria, and worker contracts.</p>
             <div class="meta"><span class="pill status-contract">contract-backed</span><span class="pill">handoff: planner-output</span></div>
-            <code class="shell">/dev-studio planner plan issue 123
+            <code class="shell">/dev-studio planner help
+/dev-studio planner plan issue 123
 /dev-studio planner split this feature into worker contracts</code>
           </article>
           <article class="role">
             <h3>worker</h3>
             <p>Implements one bounded contract in an isolated worktree and returns typed completion evidence.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">fleet scripts</span></div>
-            <code class="shell">/dev-studio worker T123
+            <code class="shell">/dev-studio worker help
+/dev-studio worker T123
 scripts/achilles-worker.sh
 scripts/achilles-queue.sh drain</code>
           </article>
@@ -758,7 +779,8 @@ scripts/achilles-queue.sh drain</code>
             <h3>reviewer</h3>
             <p>Reviews plans, diffs, outcomes, PRs, and release packets for blockers, warnings, and missing evidence.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">headless review wrappers</span></div>
-            <code class="shell">/dev-studio reviewer
+            <code class="shell">/dev-studio reviewer help
+/dev-studio reviewer
 /dev-studio reviewer review
 scripts/phase-review.sh --kind plan --input phase-plan.md
 scripts/pr-headless-review.sh &lt;pr&gt;</code>
@@ -767,38 +789,104 @@ scripts/pr-headless-review.sh &lt;pr&gt;</code>
             <h3>qa-engineer</h3>
             <p>Builds automated QA contracts and stable target checks beyond the worker's local verification.</p>
             <div class="meta"><span class="pill status-contract">contract-backed</span><span class="pill">handoff: qa-contract</span></div>
-            <code class="shell">/dev-studio qa-engineer write QA targets for T123
+            <code class="shell">/dev-studio qa-engineer help
+/dev-studio qa-engineer write QA targets for T123
 scripts/v2-multispawn-pilot.sh run</code>
           </article>
           <article class="role">
             <h3>flow-tester</h3>
             <p>Defines exploratory user-flow scenarios, severity thresholds, pass/fail state, and merge-block rules.</p>
             <div class="meta"><span class="pill status-contract">contract-backed</span><span class="pill">handoff: flow-test-checklist</span></div>
-            <code class="shell">/dev-studio flow-tester check onboarding on build 456
+            <code class="shell">/dev-studio flow-tester help
+/dev-studio flow-tester check onboarding on build 456
 /dev-studio flow-tester write a release smoke checklist</code>
           </article>
           <article class="role">
             <h3>perf</h3>
             <p>Investigates memory, CPU, thermal, battery, network, signpost, and trace evidence without taking functional acceptance authority.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">metric evidence gate</span></div>
-            <code class="shell">/dev-studio perf profile editor startup
+            <code class="shell">/dev-studio perf help
+/dev-studio perf profile editor startup
 /dev-studio perf compare baseline and post-fix traces</code>
           </article>
           <article class="role">
             <h3>release-manager</h3>
             <p>Assembles release readiness, blocker state, notes, tag state, TestFlight/App Store state, and approval gates.</p>
             <div class="meta"><span class="pill status-contract">approval-gated</span><span class="pill">handoff: release-packet</span></div>
-            <code class="shell">/dev-studio release-manager
+            <code class="shell">/dev-studio release-manager help
+/dev-studio release-manager
 /dev-studio release-manager prepare beta readiness
+/dev-studio release-manager configure
 /dev-studio release-manager tf-push --background</code>
           </article>
           <article class="role">
             <h3>host-adapter</h3>
             <p>Represents host capability and sync operations. It is infrastructure, not a general implementation agent.</p>
             <div class="meta"><span class="pill status-registry">registry-only</span><span class="pill">sync scripts</span></div>
-            <code class="shell">scripts/sync-host-skills.sh --all
+            <code class="shell">/dev-studio host-adapter help
+/dev-studio host-adapter nodes
+/dev-studio host-adapter sync
+scripts/sync-host-skills.sh --all
 scripts/host-preflight.sh codex /repo</code>
           </article>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Role help</th>
+                <th>Commands shown</th>
+                <th>Examples</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>/dev-studio manager help</code></td>
+                <td><code>status</code>, <code>resume-plan</code>, <code>ingest</code>, <code>guard</code>, <code>audit</code>, <code>analyze</code>, <code>reconcile</code>, <code>add</code></td>
+                <td><code>/dev-studio manager ingest "capture this"</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio worker help</code></td>
+                <td>bounded contract execution, <code>checkpoint</code>, <code>resume-checkpoint</code></td>
+                <td><code>/dev-studio worker T123</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio reviewer help</code></td>
+                <td><code>review</code>, plan/outcome/diff/PR/release-packet review, lifecycle actions</td>
+                <td><code>/dev-studio reviewer review</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio perf help</code></td>
+                <td><code>profile</code>, metric investigation, lifecycle actions</td>
+                <td><code>/dev-studio perf profile editor startup</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio planner help</code></td>
+                <td><code>plan</code>, decomposition, acceptance criteria, lifecycle actions</td>
+                <td><code>/dev-studio planner plan issue 123</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio qa-engineer help</code></td>
+                <td>QA target design, test contracts, lifecycle actions</td>
+                <td><code>/dev-studio qa-engineer write QA targets for T123</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio flow-tester help</code></td>
+                <td>exploratory scenarios, checklists, lifecycle actions</td>
+                <td><code>/dev-studio flow-tester check onboarding on build 456</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio release-manager help</code></td>
+                <td><code>release</code>, <code>configure</code>, <code>tf-push</code>, release packets, lifecycle actions</td>
+                <td><code>/dev-studio release-manager configure</code></td>
+              </tr>
+              <tr>
+                <td><code>/dev-studio host-adapter help</code></td>
+                <td><code>nodes</code>, <code>sync</code>, host capability checks</td>
+                <td><code>/dev-studio host-adapter nodes</code></td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </details>
@@ -891,8 +979,11 @@ scripts/host-preflight.sh codex /repo</code>
             <li>Explicit canonical role routes directly, such as <code>/dev-studio worker &lt;contract&gt;</code>.</li>
             <li>Compatibility alias resolves through <code>scripts/v2-role-resolve.sh</code>, such as <code>/dev-studio achilles &lt;contract&gt;</code>.</li>
             <li>Former top-level names remain aliases only when placed under <code>/dev-studio</code>.</li>
+            <li>A bare subcommand may route through the session-local active role when the current conversation clearly selected one.</li>
             <li>A bare role token opens that role's lightweight landing.</li>
             <li>No role token opens the <code>manager</code> landing.</li>
+            <li>Bare <code>/dev-studio</code> clears any assumed active-role shortcut and re-lands in manager.</li>
+            <li>Bare <code>/dev-studio checkpoint</code> and <code>/dev-studio resume-checkpoint</code> land in manager; role-qualified lifecycle commands stay role-owned.</li>
             <li>Unknown role tokens fail before side effects.</li>
           </ol>
         </div>
@@ -970,6 +1061,11 @@ scripts/host-preflight.sh codex /repo</code>
           invocations land in manager for shaping; explicit role invocations keep
           checkpoint content owned by that role and follow the compact shared
           checkpoint contract.
+        </p>
+        <p>
+          Active-role shortcuts are conversation-local only. They are not stored
+          in runtime files, env vars, or router metadata, and explicit role
+          prefixes remain the user-controlled override.
         </p>
         <p>
           This page is the studio-layer command surface. It intentionally does not

--- a/core/v2/skills/dev-studio/routing.yaml
+++ b/core/v2/skills/dev-studio/routing.yaml
@@ -13,6 +13,10 @@ invocation:
     - "/dev-studio resume-checkpoint"
     - "/dev-studio <role> checkpoint"
     - "/dev-studio <role> resume-checkpoint"
+    - "/dev-studio help"
+    - "/dev-studio <role> help"
+    - "active dev-studio role"
+    - "session-local dev-studio role"
 domains:
   - studio-v2
   - forge

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-05T23:33:27Z",
+  "generated_at": "2026-05-06T09:54:43Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- document session-local active-role shortcuts after a bare `/dev-studio <role>` landing
- add `/dev-studio help` and `/dev-studio <role> help` semantics with per-role examples
- add the bare subcommand ownership map in the command wrapper and docs page
- preserve the existing bare checkpoint rule: `/dev-studio checkpoint` and `/dev-studio resume-checkpoint` still land in manager; role-qualified lifecycle actions remain role-owned

## Example trace
```text
/dev-studio manager
help
status
/dev-studio reviewer help
```

## Verification
- `git diff --check`
- `scripts/lint-skill-prose.sh core/v2/skills/dev-studio/SKILL.md`
- `scripts/test-fixtures/517-router-contract/test-router-contract.sh`
- `scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- pre-commit hook: `lint-architecture` 0 errors / 1 existing warning, `lint-skill-prose`, `lint-comms-boundary`, `lint-debrief-writers`, `lint-v2-bootstrap`, `lint-v2-enforcement`
- opened `file:///tmp/studio-641-sticky-role-help/core/v2/skills/dev-studio/docs.html`

## Phase review
- Plan review clean: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-06-issue-641-sticky-role-help-plan-review-2.md`
- Outcome review clean: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-06-issue-641-sticky-role-help-outcome-review.md`

Closes #641
