### PR TITLE
Harden manager task clarification

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T11:34:11Z",
+  "generated_at": "2026-05-06T12:15:21Z",
   "agents": [
 
   ]

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -61,6 +61,12 @@ supplies the task context and runtime slug.
 5. Execute the matched role workflow by following the router and role contract:
    - `manager` -> shaping, status, resume, ingest, guard, audit, or a
      cwd-aware landing when no subcommand/request is present.
+     Manager asks depth-first clarification before lock-in when material
+     assumptions affect scope, cost, user-visible behavior, verification, or
+     role routing. Manager ingest may suggest missing/refined inputs from
+     PRD, Figma, issue, plan, or repo context already provided in the
+     session/repo; it does not auto-fetch unavailable sources or decompose
+     planner-owned work.
    - `worker` -> bounded task contract in an isolated worktree.
    - `reviewer` -> plan, outcome, diff, PR, or release-packet review.
    - `perf` -> performance, battery, memory, thermal, network, or instrumentation evidence.

--- a/core/v2/roles/manager.yaml
+++ b/core/v2/roles/manager.yaml
@@ -16,6 +16,9 @@ inputs:
   - kind: repo-context
     required: false
     description: Current working repository, project profile, visible diff, issue state, and studio/runtime artifacts needed to route safely.
+  - kind: product-context
+    required: false
+    description: User-provided PRD, Figma context, issue text, design notes, or acceptance hints already present in the session or repo.
   - kind: prior-usage
     required: false
     description: Recent or commonly used role workflows when available, used only to improve landing suggestions without blocking intake.
@@ -54,8 +57,12 @@ non_goals:
   - Chanakya does not run builds or test suites as implementation verification.
   - Chanakya does not make merge decisions on the user's behalf.
   - Chanakya does not own release operations such as TestFlight upload or App Store submission; those belong to the release-manager role.
+  - Chanakya does not auto-fetch PRD or Figma sources that the user has not provided or made available in the repo/session context.
+  - Chanakya does not decompose full implementation plans during ingest; that remains planner-owned after intent is shaped.
 decision_rights:
   - Ask lightweight clarifying questions or offer role-specific next moves when intent is underspecified.
+  - Ask depth-first clarification before task lock-in when material assumptions affect scope, cost, user-visible behavior, verification, or role routing; keep one lightweight clarification round as the guardrail before returning needs_context or escalating.
+  - During ingest, suggest missing or refined inputs from user-provided PRD, Figma, issue, plan, and repo context as shaping prompts and route candidates, not as planner-owned decomposition.
   - Route locked-in work to planner, worker, reviewer, qa-engineer, flow-tester, perf, release-manager, or host-adapter without changing their authority boundaries.
   - Distinguish studio-internal workflows from project workflows using cwd, project profile, and explicit user wording.
   - Suggest the reusable direct command after intent locks so the next invocation can skip conversational landing.
@@ -72,10 +79,14 @@ failure_semantics:
   - For a bare non-manager role routed through manager, preserve the selected role and return landing options for the missing target or review kind.
   - Checkpoint artifacts do not replace worker summaries, reviewer verdicts, release packets, QA or flow checklists, perf verdicts, or event logs.
   - Return needs_context with exact missing inputs instead of inventing issue state, project profile details, or release readiness.
+  - Return needs_context rather than locking a brief when material assumptions remain unresolved after the lightweight clarification round.
   - Stop before side effects when the request is ambiguous across studio-internal and project-runtime boundaries.
 verification_floor:
   - Shaped intent names the selected route, target repo/profile, in-scope work, non-goals, acceptance criteria, and blocked state if any.
   - "Shaped plans follow `_shared/contracts/engineering-principles.md`: challenge vague, brittle, oversized, or unverifiable requests before dispatch; include measurable acceptance criteria, task size, risk level, churn layer, and recommended verification."
+  - Before dispatch, unresolved material assumptions are surfaced explicitly when they affect scope, cost, user-visible behavior, verification, or role routing.
+  - Manager ingest suggestions cite the provided source context they came from, or state the missing PRD, Figma, issue, plan, or repo input needed to shape safely.
+  - Small unambiguous requests stay lightweight; clarification is not expanded when scope, acceptance criteria, role, and verification are already clear.
   - Bare-role landings list only lightweight next moves and defer heavy docs, logs, traces, or issue sweeps until the user chooses a path.
   - Studio-internal suggestions are shown only for the studio repo or when the user explicitly asks for studio operations.
   - Locked-in workflows report the direct command or phrasing the user can use next time.

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -913,7 +913,7 @@ scripts/host-preflight.sh codex /repo</code>
         <div class="grid">
           <article class="role">
             <h3>manager</h3>
-            <p>Owns intake, prioritization, lifecycle state, dispatch, status, user escalation, and final acceptance routing.</p>
+            <p>Owns intake, prioritization, lifecycle state, dispatch, status, user escalation, and final acceptance routing. It clarifies material assumptions before lock-in and can suggest missing PRD, Figma, issue, plan, or repo inputs during ingest when those sources are already available. If key assumptions remain unresolved, it returns needs_context instead of inventing scope; it does not auto-fetch unavailable PRD or Figma sources.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">aliases: chanakya, coordinator, orchestrator</span></div>
           </article>
           <article class="role">

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T11:34:11Z",
+  "generated_at": "2026-05-06T12:15:20Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
+++ b/scripts/test-fixtures/526-role-contracts/test-role-contracts.sh
@@ -38,6 +38,11 @@ for role in manager worker reviewer qa-engineer flow-tester perf release-manager
 done
 
 grep -Fq 'For bare checkpoint or resume-checkpoint invocations' "$ROOT/core/v2/roles/manager.yaml" || fail "manager does not own bare checkpoint shaping"
+grep -Fq 'kind: product-context' "$ROOT/core/v2/roles/manager.yaml" || fail "manager product-context input missing"
+grep -Fq 'material assumptions affect scope, cost, user-visible behavior, verification, or role routing' "$ROOT/core/v2/roles/manager.yaml" || fail "manager clarification materiality rule missing"
+grep -Fq 'does not auto-fetch PRD or Figma sources' "$ROOT/core/v2/roles/manager.yaml" || fail "manager PRD/Figma source boundary missing"
+grep -Fq 'Return needs_context rather than locking a brief when material assumptions remain unresolved' "$ROOT/core/v2/roles/manager.yaml" || fail "manager unresolved-assumption needs_context rule missing"
+grep -Fq 'Small unambiguous requests stay lightweight' "$ROOT/core/v2/roles/manager.yaml" || fail "manager lightweight-task guard missing"
 grep -Fq 'Worker checkpoint use is optional' "$ROOT/core/v2/roles/worker.yaml" || fail "worker checkpoint optionality not documented"
 
 [ "$("$CMD" --resolve --role chanakya)" = "core/v2/roles/manager.yaml" ] || fail "chanakya alias did not resolve to manager contract"


### PR DESCRIPTION
## Summary
- require manager to surface material assumptions before task lock-in
- allow manager ingest to suggest missing/refined inputs from provided PRD, Figma, issue, plan, and repo context
- preserve one lightweight clarification round and the lightweight path for small unambiguous tasks
- clarify that manager does not auto-fetch unavailable PRD/Figma sources or decompose planner-owned work during ingest

## Verification
- `git diff --check`
- `scripts/test-fixtures/526-role-contracts/test-role-contracts.sh`
- `scripts/lint-skill-prose.sh core/v2/skills/dev-studio/SKILL.md`
- pre-commit hook: lint-architecture 0 errors / 1 existing warning, lint-comms-boundary, lint-debrief-writers, lint-v2-bootstrap, lint-v2-enforcement
- opened `file:///tmp/studio-644-manager-clarification/core/v2/skills/dev-studio/docs.html`

## Phase review
- Plan review clean: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-06-issue-644-manager-clarification-plan-review.md`
- Outcome review clean: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-06-issue-644-manager-clarification-outcome-review.md`

Closes #644
