### PR TITLE
Add manager work-chain front door and PRD chain manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 /dev-studio manager ingest       # capture one idea in the current repo context; --scope studio crosses to Forge
 /dev-studio manager reconcile    # project repo: sync emitted debriefs/reports into the task ledger
 /dev-studio manager analyze      # studio repo: telemetry/log analysis plus studio feedback triage
+/dev-studio manager work-chain prd-to-chain-automation # discover/start/resume the PRD automation chain
+scripts/manager-work-chain.sh prd-to-chain-automation # repo-side wrapper for the manager work-chain front door
 /dev-studio checkpoint           # manager-shaped checkpoint routing; explicit role owns content
 /dev-studio worker checkpoint    # worker-owned compact checkpoint; does not replace worker summary
 /dev-studio worker resume-checkpoint # resume worker checkpoint via manifest.json + context.md first
@@ -82,6 +84,8 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements # unattended safe start/resume for one manifest
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview checkpoint-aware safe-boundary hooks
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show next supervisor action without state mutation
+scripts/studio-chain-runner.sh --discover # bare invocation lists runnable manifests and resumable runs
+scripts/manager-work-chain.sh prd-to-chain-automation # manager front door that discovers or launches a work-chain
 scripts/studio-chain-telemetry-digest.sh --days 7     # weekly v1 counters from private chain-run telemetry
 scripts/studio-checkpoint.sh resume --latest --role worker # compact session resume; reads manifest.json + context.md before lazy drift checks
 scripts/studio-staleness-triage.sh --json        # preview PM-surface stale/escalation/archive-candidate issue labels
@@ -193,7 +197,7 @@ scripts/                # multi-worker fleet (BETA)
   studio-pr-baseline-report.sh # PR-level timing, churn, gate, and generated-file baselines
   studio-dependency-export.sh # Mermaid graph from native GitHub blocked_by issue dependencies
   studio-weekly.sh     # weekly GitHub issue digest; scheduled workflow posts to the pinned summary issue
-  studio-chain-runner.sh   # plan/execute/auto-resume/list studio issue chains with capacity-scaled fresh sessions, UUID telemetry, optional checkpoint hooks, locks, and private run reports
+  studio-chain-runner.sh   # plan/execute/discover/auto-resume/list studio issue chains with capacity-scaled fresh sessions, UUID telemetry, optional checkpoint hooks, locks, and private run reports
   studio-chain-telemetry-digest.sh # v1 counters and weekly digest from private chain-run reports/events
   studio-checkpoint.sh # compact create/update/resume checkpoints under per-project .runtime/v2/checkpoints
   issue-body-edit.sh  # guarded GitHub issue body replacement from generated content

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T12:15:21Z",
+  "generated_at": "2026-05-06T15:00:11Z",
   "agents": [
 
   ]

--- a/chains/prd-to-chain-automation.yaml
+++ b/chains/prd-to-chain-automation.yaml
@@ -1,0 +1,31 @@
+# PRD-to-chain automation chain for the 2026-05-06 studio session.
+#
+# Discover:
+#   scripts/studio-chain-runner.sh chains/prd-to-chain-automation.yaml --discover
+#
+# Dry-run:
+#   scripts/studio-chain-runner.sh chains/prd-to-chain-automation.yaml --dry-run
+#
+# Manager front door:
+#   /dev-studio manager work-chain prd-to-chain-automation
+#
+# The chain is intentionally single-threaded at first. Each issue is small,
+# bounded, and ordered so the runner can resume without recomputing the whole
+# plan.
+
+schema_version: 1
+chains:
+  - name: prd-to-chain-automation
+    base: main
+    branch: feature/prd-to-chain-automation
+    host: auto
+    phase_review: required
+    issues:
+      - 647
+      - 650
+      - 648
+      - 649
+      - 651
+      - 652
+      - 653
+      - 654

--- a/core/v2/roles/manager.yaml
+++ b/core/v2/roles/manager.yaml
@@ -64,6 +64,8 @@ decision_rights:
   - Ask depth-first clarification before task lock-in when material assumptions affect scope, cost, user-visible behavior, verification, or role routing; keep one lightweight clarification round as the guardrail before returning needs_context or escalating.
   - During ingest, suggest missing or refined inputs from user-provided PRD, Figma, issue, plan, and repo context as shaping prompts and route candidates, not as planner-owned decomposition.
   - Route locked-in work to planner, worker, reviewer, qa-engineer, flow-tester, perf, release-manager, or host-adapter without changing their authority boundaries.
+  - For work-chain requests, shape the chain name, suggest runnable or resumable chain manifests, and route the user to the chain runner front door instead of pretending the manager executes the chain itself.
+  - "`scripts/manager-work-chain.sh` is the concrete repo-side front door for discover/start/resume routing; the `/dev-studio manager work-chain ...` phrasing should map to it."
   - Distinguish studio-internal workflows from project workflows using cwd, project profile, and explicit user wording.
   - Suggest the reusable direct command after intent locks so the next invocation can skip conversational landing.
   - For bare checkpoint or resume-checkpoint invocations, shape and route to the intended role without owning specialist role state.
@@ -89,6 +91,8 @@ verification_floor:
   - Small unambiguous requests stay lightweight; clarification is not expanded when scope, acceptance criteria, role, and verification are already clear.
   - Bare-role landings list only lightweight next moves and defer heavy docs, logs, traces, or issue sweeps until the user chooses a path.
   - Studio-internal suggestions are shown only for the studio repo or when the user explicitly asks for studio operations.
+  - Work-chain discovery should surface runnable manifests and resumable runs when the user has not picked a specific chain yet.
+  - The manager work-chain front door should point to `scripts/manager-work-chain.sh` and the manifest discovered from the selected chain name.
   - Locked-in workflows report the direct command or phrasing the user can use next time.
   - Shaped intent and summaries distinguish refactoring needed now from refactoring follow-up proposed.
   - "User-facing workflow completion summaries follow `_shared/contracts/completion-summary.md`: lead with a truthful fixed/implemented outcome, split user impact into before/after/new behavior when applicable, state PR or merge, local sync, worktree cleanup, and derived-data or stale-artifact cleanup, and use `Safe to end the session.` only when those closure facts are true."

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -76,7 +76,12 @@ inspect cheap cwd/profile context, suggest likely next moves, then report the
 direct invocation once the workflow is selected. `manager ingest` calls
 `scripts/dev-studio-ingest-resolve.sh`; `manager analyze` calls
 `scripts/manager-analyze.sh`; `manager reconcile` calls
-`scripts/manager-reconcile.sh`.
+`scripts/manager-reconcile.sh`; `manager work-chain` calls
+`scripts/manager-work-chain.sh`. For chain orchestration, bare
+`scripts/studio-chain-runner.sh` now shows runnable manifests and resumable
+runs before any plan or resume action is chosen, and `/dev-studio manager
+work-chain prd-to-chain-automation` is the manager-shaped front door for the
+new PRD automation chain.
 
 After a bare role landing, later bare subcommands may resolve through that
 active role when unambiguous in the same session. Store the resolved canonical

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -515,9 +515,11 @@
           </article>
           <article class="role">
             <h3>Parallel Chains</h3>
-            <p>Use chain manifests when the repo already has an issue chain. Dry-run first, then launch one independent chain per shell session.</p>
+            <p>Use chain manifests when the repo already has an issue chain. Bare invocation discovers runnable manifests and resumable runs; dry-run first, then launch one independent chain per shell session. The manager front door for the PRD automation arc is <code>/dev-studio manager work-chain prd-to-chain-automation</code>, which routes through the repo-side manager wrapper.</p>
             <code class="shell">scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt; --dry-run
-scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt;</code>
+scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt;
+scripts/studio-chain-runner.sh --discover
+scripts/manager-work-chain.sh prd-to-chain-automation</code>
           </article>
           <article class="role">
             <h3>Hotfix Bug</h3>
@@ -714,9 +716,11 @@ scripts/manager-analyze.sh --cwd "$PWD"</code>
           </article>
           <article class="role">
             <h3>Chain Runs</h3>
-            <p>Issue chains can run with persisted private reports and resume markers. Use dry-run first, then launch independent chains in separate shells when their write boundaries are disjoint.</p>
+            <p>Issue chains can run with persisted private reports and resume markers. Use dry-run first, or type the chain runner with no manifest to see runnable manifests and resumable runs before starting a chain. The manager wrapper mirrors the same discovery/start/resume flow for named work-chains.</p>
             <code class="shell">scripts/studio-chain-runner.sh &lt;manifest&gt; --dry-run
-scripts/studio-chain-runner.sh &lt;manifest&gt; --auto</code>
+scripts/studio-chain-runner.sh &lt;manifest&gt; --auto
+scripts/studio-chain-runner.sh --discover
+scripts/manager-work-chain.sh prd-to-chain-automation</code>
           </article>
           <article class="role">
             <h3>Fleet Work</h3>
@@ -747,15 +751,17 @@ scripts/worker-status.sh</code>
         <div class="workflow-grid">
           <article class="role">
             <h3>manager</h3>
-            <p>Shapes intent, resumes arcs, routes work, guards against repeats, captures patterns, and escalates operator decisions.</p>
+            <p>Shapes intent, resumes arcs, routes work, guards against repeats, captures patterns, and escalates operator decisions. Work-chain requests route to the repo-side manager wrapper before they reach the chain runner.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">contract-backed landing</span></div>
             <code class="shell">/dev-studio manager
 /dev-studio manager help
 /dev-studio manager resume-plan
+/dev-studio manager work-chain prd-to-chain-automation
 /dev-studio manager guard "has this shipped?"
 /dev-studio manager analyze
 /dev-studio manager reconcile
 /dev-studio manager ingest "capture this pattern"
+/dev-studio manager work-chain
 /dev-studio manager ingest --scope studio "capture this Forge workflow gap"</code>
           </article>
           <article class="role">
@@ -913,7 +919,7 @@ scripts/host-preflight.sh codex /repo</code>
         <div class="grid">
           <article class="role">
             <h3>manager</h3>
-            <p>Owns intake, prioritization, lifecycle state, dispatch, status, user escalation, and final acceptance routing. It clarifies material assumptions before lock-in and can suggest missing PRD, Figma, issue, plan, or repo inputs during ingest when those sources are already available. If key assumptions remain unresolved, it returns needs_context instead of inventing scope; it does not auto-fetch unavailable PRD or Figma sources.</p>
+            <p>Owns intake, prioritization, lifecycle state, dispatch, status, user escalation, and final acceptance routing. It clarifies material assumptions before lock-in, can suggest missing PRD, Figma, issue, plan, or repo inputs during ingest when those sources are already available, and can front work-chain discovery by surfacing runnable manifests and resumable runs. If key assumptions remain unresolved, it returns needs_context instead of inventing scope; it does not auto-fetch unavailable PRD or Figma sources.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">aliases: chanakya, coordinator, orchestrator</span></div>
           </article>
           <article class="role">

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T12:15:20Z",
+  "generated_at": "2026-05-06T15:00:11Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,8 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements --host codex --
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview role/branch-scoped checkpoint hooks
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements     # unattended start/resume when state is safe and unambiguous
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show the supervisor's next action without mutating state
+scripts/studio-chain-runner.sh --discover                                  # bare invocation lists runnable manifests and resumable runs
+scripts/manager-work-chain.sh prd-to-chain-automation                      # manager front door: discover, start, or resume a work-chain
 scripts/studio-chain-runner.sh --resume <run_id> --yes                     # resume from ~/.dev-studio/generic-dev-studio/chain-runs/<run_id>/state.json
 scripts/studio-chain-runner.sh --list                                      # list persisted chain runs and report paths
 scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution

--- a/scripts/manager-work-chain.sh
+++ b/scripts/manager-work-chain.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# manager-work-chain.sh — repo-side front door for work-chain discovery/start/resume.
+#
+# This stays thin on purpose: the manager shapes intent, then delegates the
+# actual execution and resumable-run machinery to studio-chain-runner.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+RUNNER="$SCRIPT_DIR/studio-chain-runner.sh"
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  scripts/manager-work-chain.sh [<manifest|chain-name>] [runner-flags...]
+
+When no chain is named, this defaults to discovery so the manager front door
+can suggest runnable manifests and resumable runs. All runner flags are passed
+through to scripts/studio-chain-runner.sh.
+EOF
+  exit 2
+}
+
+if [ "$#" -eq 0 ]; then
+  exec "$RUNNER" --discover
+fi
+
+case "$1" in
+  -h|--help) usage ;;
+esac
+
+exec "$RUNNER" "$@"

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -7,6 +7,7 @@
 #   scripts/studio-chain-runner.sh --explain-next <manifest|chain-name> [--only <chain>]
 #   scripts/studio-chain-runner.sh --resume <run_id> [--yes]
 #   scripts/studio-chain-runner.sh --list
+#   scripts/studio-chain-runner.sh --discover
 #
 # Manifest shape:
 #   schema_version: 1
@@ -33,14 +34,13 @@ usage() {
   exit 2
 }
 
-[ $# -ge 1 ] || usage
-
 MANIFEST=""
 ONLY_CHAIN=""
 HOST_OVERRIDE=""
 DRY_RUN=0
 YES=0
 RESUME_ID=""
+DISCOVER_MODE=0
 ALLOW_CLOSED_ISSUES=0
 PARALLEL_CHAINS="auto"
 CHECKPOINT_OVERRIDE="${STUDIO_CHAIN_CHECKPOINT:-}"
@@ -50,9 +50,14 @@ EXPLAIN_NEXT=0
 SUPERVISOR_LOCK=""
 SUPERVISOR_LOCK_ACQUIRED=0
 
+if [ $# -eq 0 ]; then
+  DISCOVER_MODE=1
+fi
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --list) LIST_RUNS=1; shift ;;
+    --discover) DISCOVER_MODE=1; shift ;;
     --auto) AUTO_MODE=1; MANIFEST="${2:?--auto requires a manifest or chain name}"; shift 2 ;;
     --auto=*) AUTO_MODE=1; MANIFEST="${1#--auto=}"; shift ;;
     --explain-next) EXPLAIN_NEXT=1; MANIFEST="${2:?--explain-next requires a manifest or chain name}"; shift 2 ;;
@@ -85,6 +90,26 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
+
+if [ "$DISCOVER_MODE" -eq 0 ] && [ "$LIST_RUNS" -eq 0 ] && [ -z "$MANIFEST" ] && [ -z "$RESUME_ID" ]; then
+  DISCOVER_MODE=1
+fi
+
+if [ "$DISCOVER_MODE" -eq 1 ] && {
+  [ "$AUTO_MODE" -eq 1 ] ||
+  [ "$EXPLAIN_NEXT" -eq 1 ] ||
+  [ "$LIST_RUNS" -eq 1 ] ||
+  [ -n "$MANIFEST" ] ||
+  [ -n "$RESUME_ID" ] ||
+  [ -n "$ONLY_CHAIN" ] ||
+  [ -n "$HOST_OVERRIDE" ] ||
+  [ "$DRY_RUN" -eq 1 ] ||
+  [ "$YES" -eq 1 ] ||
+  [ "$ALLOW_CLOSED_ISSUES" -eq 1 ] ||
+  [ "$PARALLEL_CHAINS" != "auto" ]
+}; then
+  usage
+fi
 
 if [ "$AUTO_MODE" -eq 1 ] && [ "$EXPLAIN_NEXT" -eq 1 ]; then
   printf 'studio-chain-runner: --auto and --explain-next are mutually exclusive\n' >&2
@@ -127,6 +152,91 @@ list_persisted_runs() {
 
 if [ "$LIST_RUNS" -eq 1 ]; then
   list_persisted_runs
+  exit 0
+fi
+
+discover_persisted_runs() {
+  local parent_home project_root chain_root state_count state run_id status manifest next_command
+  command -v jq >/dev/null 2>&1 || { printf 'studio-chain-runner: jq required\n' >&2; exit 2; }
+  parent_home=$(resolve_parent_home_for_github)
+  project_root=$(HOME="$parent_home" resolve_project_root_for generic-dev-studio)
+  chain_root="$project_root/chain-runs"
+
+  printf '## Resumable Runs\n\n'
+  if [ ! -d "$chain_root" ]; then
+    printf -- '- No persisted chain runs found under `%s`.\n' "$chain_root"
+    return 0
+  fi
+
+  state_count=$(find "$chain_root" -mindepth 2 -maxdepth 2 -name state.json -type f 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$state_count" -eq 0 ]; then
+    printf -- '- No persisted chain runs found under `%s`.\n' "$chain_root"
+    return 0
+  fi
+
+  printf '| Run ID | Status | Manifest | Suggested command |\n'
+  printf '|---|---|---|---|\n'
+  while IFS= read -r state; do
+    [ -n "$state" ] || continue
+    [ -r "$state" ] || continue
+    run_id=$(jq -r '.run_id // "unknown"' "$state" 2>/dev/null || printf 'unknown')
+    status=$(jq -r '.status // "unknown"' "$state" 2>/dev/null || printf 'unknown')
+    [ "$status" = "completed" ] && continue
+    manifest=$(jq -r '.manifest // "unknown"' "$state" 2>/dev/null || printf 'unknown')
+    next_command=$(jq -r --arg run_id "$run_id" '
+      (.halt_records // []) as $halts
+      | if ($halts | length) > 0 and (($halts | last | .next_command // "") != "") then ($halts | last | .next_command)
+        elif ($halts | length) > 0 and (($halts | last | .halt_class // "") == "fatal") then "inspect halt record"
+        else "scripts/studio-chain-runner.sh --resume \($run_id) --yes"
+        end
+    ' "$state" 2>/dev/null || printf 'scripts/studio-chain-runner.sh --resume %s --yes' "$run_id")
+    printf '| `%s` | `%s` | `%s` | `%s` |\n' "$run_id" "$status" "$manifest" "$next_command"
+  done <<EOF
+$(find "$chain_root" -mindepth 2 -maxdepth 2 -name state.json -type f 2>/dev/null | sort)
+EOF
+}
+
+discover_chain_manifests() {
+  local manifest chain_count idx name issues command rel_manifest
+  command -v yq >/dev/null 2>&1 || { printf 'studio-chain-runner: yq required\n' >&2; exit 2; }
+  printf '\n## Available Chain Manifests\n\n'
+  if [ ! -d "$REPO_ROOT/chains" ]; then
+    printf -- '- No chain manifests found under `%s`.\n' "$REPO_ROOT/chains"
+    return 0
+  fi
+
+  printf '| Manifest | Chain | Issues | Suggested command |\n'
+  printf '|---|---|---|---|\n'
+  while IFS= read -r manifest; do
+    [ -n "$manifest" ] || continue
+    [ -f "$manifest" ] || continue
+    rel_manifest=${manifest#"$REPO_ROOT/"}
+    chain_count=$(yq -r '.chains | length' "$manifest" 2>/dev/null || printf '0')
+    case "$chain_count" in
+      ''|null|*[!0-9]*|0) continue ;;
+    esac
+    for ((idx = 0; idx < chain_count; idx++)); do
+      name=$(yq -r ".chains[$idx].name" "$manifest")
+      issues=$(yq -r ".chains[$idx].issues | join(\",\")" "$manifest")
+      command="scripts/studio-chain-runner.sh $rel_manifest --only $name --dry-run"
+      printf '| `%s` | `%s` | `%s` | `%s` |\n' "$rel_manifest" "$name" "${issues:-"-"}" "$command"
+    done
+  done <<EOF
+$(find "$REPO_ROOT/chains" -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | sort)
+EOF
+}
+
+print_discovery() {
+  printf '# Studio Chain Discovery\n\n'
+  printf -- '- Bare invocation lists runnable manifests and resumable runs.\n'
+  printf -- '- Use `--discover` explicitly when you want the same non-mutating menu.\n'
+  discover_persisted_runs
+  discover_chain_manifests
+  printf '\n'
+}
+
+if [ "$DISCOVER_MODE" -eq 1 ]; then
+  print_discovery
   exit 0
 fi
 

--- a/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
+++ b/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Verifies bare chain-runner invocation discovers resumable runs and runnable manifests.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t studio-chain-discover.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+HOME_DIR="$TMPROOT/home"
+RUN_ROOT="$HOME_DIR/.dev-studio/generic-dev-studio/chain-runs"
+mkdir -p "$RUN_ROOT/run-discovery-1"
+
+cat > "$RUN_ROOT/run-discovery-1/state.json" <<'JSON'
+{
+  "schema_version": 1,
+  "run_id": "run-discovery-1",
+  "manifest": "chains/workflow-measurement-improvements.yaml",
+  "status": "paused",
+  "started_at": "2026-05-03T00:00:00Z",
+  "updated_at": "2026-05-03T00:01:00Z",
+  "report": "/tmp/report-discovery.md",
+  "halt_records": []
+}
+JSON
+
+HOME="$HOME_DIR" "$ROOT/scripts/studio-chain-runner.sh" > "$TMPROOT/out" 2>&1
+
+grep -q '^# Studio Chain Discovery$' "$TMPROOT/out" || {
+  printf 'missing discovery heading\n' >&2
+  cat "$TMPROOT/out" >&2
+  exit 1
+}
+grep -q 'run-discovery-1' "$TMPROOT/out" || {
+  printf 'missing resumable run row\n' >&2
+  cat "$TMPROOT/out" >&2
+  exit 1
+}
+grep -q 'scripts/studio-chain-runner.sh --resume run-discovery-1 --yes' "$TMPROOT/out" || {
+  printf 'missing resume suggestion\n' >&2
+  cat "$TMPROOT/out" >&2
+  exit 1
+}
+grep -q 'chains/workflow-measurement-improvements.yaml' "$TMPROOT/out" || {
+  printf 'missing runnable manifest row\n' >&2
+  cat "$TMPROOT/out" >&2
+  exit 1
+}
+grep -q 'scripts/studio-chain-runner.sh chains/workflow-measurement-improvements.yaml --only field-telemetry-mvp --dry-run' "$TMPROOT/out" || {
+  printf 'missing runnable chain suggestion\n' >&2
+  cat "$TMPROOT/out" >&2
+  exit 1
+}
+
+printf 'PASS: chain-runner discovery mode\n'

--- a/scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
+++ b/scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression fixture: manager work-chain is a thin discovery/start/resume wrapper.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUN="$ROOT/scripts/manager-work-chain.sh"
+TMPROOT=$(mktemp -d -t manager-work-chain.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq required"
+if ! command -v yq >/dev/null 2>&1; then
+  printf 'SKIP: yq required for manager work-chain fixture\n'
+  exit 0
+fi
+
+[ -x "$RUN" ] || fail "scripts/manager-work-chain.sh is not executable"
+
+HOME="$TMPROOT/home" "$RUN" >"$TMPROOT/discover.out"
+grep -q '# Studio Chain Discovery' "$TMPROOT/discover.out" \
+  || fail "bare manager work-chain should default to discovery"
+grep -q 'prd-to-chain-automation' "$TMPROOT/discover.out" \
+  || fail "discovery should surface the PRD automation chain"
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  issue="$3"
+  cat <<JSON
+{
+  "number": $issue,
+  "title": "Manager work-chain fixture $issue",
+  "body": "Exercise work-chain front-door behavior.",
+  "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/$issue",
+  "state": "OPEN"
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "$BIN/gh"
+
+PATH="$BIN:$PATH" HOME="$TMPROOT/home" "$RUN" prd-to-chain-automation --dry-run >"$TMPROOT/plan.out" 2>&1
+grep -q '# Studio Chain Plan' "$TMPROOT/plan.out" \
+  || fail "named manager work-chain should forward to the runner"
+grep -q 'prd-to-chain-automation' "$TMPROOT/plan.out" \
+  || fail "named manager work-chain should preserve the chain name"
+
+printf 'PASS: manager work-chain front door\n'


### PR DESCRIPTION
Adds a repo-side manager work-chain wrapper, a discoverable PRD automation chain manifest, and discovery UX for runnable/resumable chains.

Verification:
- bash -n scripts/manager-work-chain.sh
- bash scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
- bash scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
- bash scripts/test-fixtures/395-chain-control-plane/test-plan-state-and-validation.sh

Includes docs sync for README, scripts/README, manager role contract, and dev-studio skill docs.