### PR TITLE
Default manager work-chain to auto-run named chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 /dev-studio manager ingest       # capture one idea in the current repo context; --scope studio crosses to Forge
 /dev-studio manager reconcile    # project repo: sync emitted debriefs/reports into the task ledger
 /dev-studio manager analyze      # studio repo: telemetry/log analysis plus studio feedback triage
-/dev-studio manager work-chain prd-to-chain-automation # discover/start/resume the PRD automation chain
+/dev-studio manager work-chain prd-to-chain-automation # auto-run the PRD automation chain; bare call discovers available chains
 scripts/manager-work-chain.sh prd-to-chain-automation # repo-side wrapper for the manager work-chain front door
 /dev-studio checkpoint           # manager-shaped checkpoint routing; explicit role owns content
 /dev-studio worker checkpoint    # worker-owned compact checkpoint; does not replace worker summary

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T15:00:11Z",
+  "generated_at": "2026-05-06T15:11:27Z",
   "agents": [
 
   ]

--- a/core/v2/roles/manager.yaml
+++ b/core/v2/roles/manager.yaml
@@ -65,7 +65,7 @@ decision_rights:
   - During ingest, suggest missing or refined inputs from user-provided PRD, Figma, issue, plan, and repo context as shaping prompts and route candidates, not as planner-owned decomposition.
   - Route locked-in work to planner, worker, reviewer, qa-engineer, flow-tester, perf, release-manager, or host-adapter without changing their authority boundaries.
   - For work-chain requests, shape the chain name, suggest runnable or resumable chain manifests, and route the user to the chain runner front door instead of pretending the manager executes the chain itself.
-  - "`scripts/manager-work-chain.sh` is the concrete repo-side front door for discover/start/resume routing; the `/dev-studio manager work-chain ...` phrasing should map to it."
+  - "`scripts/manager-work-chain.sh` is the concrete repo-side front door for discover/start/resume routing; named `/dev-studio manager work-chain ...` invocations should auto-run by default, while bare invocations land in discovery."
   - Distinguish studio-internal workflows from project workflows using cwd, project profile, and explicit user wording.
   - Suggest the reusable direct command after intent locks so the next invocation can skip conversational landing.
   - For bare checkpoint or resume-checkpoint invocations, shape and route to the intended role without owning specialist role state.

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -80,8 +80,8 @@ direct invocation once the workflow is selected. `manager ingest` calls
 `scripts/manager-work-chain.sh`. For chain orchestration, bare
 `scripts/studio-chain-runner.sh` now shows runnable manifests and resumable
 runs before any plan or resume action is chosen, and `/dev-studio manager
-work-chain prd-to-chain-automation` is the manager-shaped front door for the
-new PRD automation chain.
+work-chain prd-to-chain-automation` auto-runs the new PRD automation chain
+while bare `manager work-chain` still lands in discovery.
 
 After a bare role landing, later bare subcommands may resolve through that
 active role when unambiguous in the same session. Store the resolved canonical

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -515,7 +515,7 @@
           </article>
           <article class="role">
             <h3>Parallel Chains</h3>
-            <p>Use chain manifests when the repo already has an issue chain. Bare invocation discovers runnable manifests and resumable runs; dry-run first, then launch one independent chain per shell session. The manager front door for the PRD automation arc is <code>/dev-studio manager work-chain prd-to-chain-automation</code>, which routes through the repo-side manager wrapper.</p>
+            <p>Use chain manifests when the repo already has an issue chain. Bare invocation discovers runnable manifests and resumable runs; dry-run first, then launch one independent chain per shell session. The manager front door for the PRD automation arc is <code>/dev-studio manager work-chain prd-to-chain-automation</code>, which auto-runs the chain through the repo-side manager wrapper.</p>
             <code class="shell">scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt; --dry-run
 scripts/studio-chain-runner.sh &lt;manifest&gt; --only &lt;chain&gt;
 scripts/studio-chain-runner.sh --discover
@@ -716,7 +716,7 @@ scripts/manager-analyze.sh --cwd "$PWD"</code>
           </article>
           <article class="role">
             <h3>Chain Runs</h3>
-            <p>Issue chains can run with persisted private reports and resume markers. Use dry-run first, or type the chain runner with no manifest to see runnable manifests and resumable runs before starting a chain. The manager wrapper mirrors the same discovery/start/resume flow for named work-chains.</p>
+            <p>Issue chains can run with persisted private reports and resume markers. Use dry-run first, or type the chain runner with no manifest to see runnable manifests and resumable runs before starting a chain. The manager wrapper mirrors the same discovery flow for bare invocations and auto-runs named work-chains by default.</p>
             <code class="shell">scripts/studio-chain-runner.sh &lt;manifest&gt; --dry-run
 scripts/studio-chain-runner.sh &lt;manifest&gt; --auto
 scripts/studio-chain-runner.sh --discover
@@ -751,7 +751,7 @@ scripts/worker-status.sh</code>
         <div class="workflow-grid">
           <article class="role">
             <h3>manager</h3>
-            <p>Shapes intent, resumes arcs, routes work, guards against repeats, captures patterns, and escalates operator decisions. Work-chain requests route to the repo-side manager wrapper before they reach the chain runner.</p>
+            <p>Shapes intent, resumes arcs, routes work, guards against repeats, captures patterns, and escalates operator decisions. Work-chain requests route to the repo-side manager wrapper before they reach the chain runner, and named work-chains auto-run unless the user chooses a discovery or resume flag.</p>
             <div class="meta"><span class="pill status-live">direct use</span><span class="pill">contract-backed landing</span></div>
             <code class="shell">/dev-studio manager
 /dev-studio manager help

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T15:00:11Z",
+  "generated_at": "2026-05-06T15:11:26Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,7 +73,7 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint au
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements     # unattended start/resume when state is safe and unambiguous
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show the supervisor's next action without mutating state
 scripts/studio-chain-runner.sh --discover                                  # bare invocation lists runnable manifests and resumable runs
-scripts/manager-work-chain.sh prd-to-chain-automation                      # manager front door: discover, start, or resume a work-chain
+scripts/manager-work-chain.sh prd-to-chain-automation                      # manager front door: auto-run a named work-chain; bare call discovers
 scripts/studio-chain-runner.sh --resume <run_id> --yes                     # resume from ~/.dev-studio/generic-dev-studio/chain-runs/<run_id>/state.json
 scripts/studio-chain-runner.sh --list                                      # list persisted chain runs and report paths
 scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution

--- a/scripts/manager-work-chain.sh
+++ b/scripts/manager-work-chain.sh
@@ -9,6 +9,18 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 RUNNER="$SCRIPT_DIR/studio-chain-runner.sh"
 
+has_explicit_mode_flag() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --auto|--auto=*|--discover|--list|--resume|--resume=*|--explain-next|--explain-next=*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
 usage() {
   cat <<'EOF' >&2
 Usage:
@@ -28,5 +40,9 @@ fi
 case "$1" in
   -h|--help) usage ;;
 esac
+
+if [ "${1#-}" = "$1" ] && ! has_explicit_mode_flag "$@"; then
+  exec "$RUNNER" --auto "$@"
+fi
 
 exec "$RUNNER" "$@"

--- a/scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
+++ b/scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
@@ -53,8 +53,10 @@ SH
 chmod +x "$BIN/gh"
 
 PATH="$BIN:$PATH" HOME="$TMPROOT/home" "$RUN" prd-to-chain-automation --dry-run >"$TMPROOT/plan.out" 2>&1
-grep -q '# Studio Chain Plan' "$TMPROOT/plan.out" \
-  || fail "named manager work-chain should forward to the runner"
+grep -q '"action":"start"' "$TMPROOT/plan.out" \
+  || fail "named manager work-chain should default to auto execution"
+grep -q 'DRY-RUN git worktree add' "$TMPROOT/plan.out" \
+  || fail "named manager work-chain should reach the auto execution path"
 grep -q 'prd-to-chain-automation' "$TMPROOT/plan.out" \
   || fail "named manager work-chain should preserve the chain name"
 


### PR DESCRIPTION
Makes named /dev-studio manager work-chain ... invocations auto-run by default while keeping bare invocations on discovery.

Verification:
- bash -n scripts/manager-work-chain.sh
- bash scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
- bash scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
- bash scripts/test-fixtures/481-chain-supervisor/test-chain-supervisor.sh

Includes docs sync for README, scripts/README, manager role contract, and dev-studio skill docs.
