### PR TITLE
Harden chain runner follow-up telemetry and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,10 +291,11 @@ git clone <this-repo> && cd generic-dev-studio
 ### Fleet prerequisites (only if you'll use multi-worker mode)
 
 ```bash
-brew install fswatch coreutils yq jq
+brew install fswatch coreutils yq jq shellcheck
 ```
 
 `yq` (v4+) drives post-2.6 YAML artifacts (`scripts/rebuild-index.sh`, `scripts/query-plans.sh`, `scripts/query-tasks.sh`, `scripts/detect-edits.sh`). `jq` drives event-log normalization in `scripts/migrate-ledger.sh` and dedupe in `scripts/read-events.sh`. Without either, `scripts/migrate-ledger.sh` fails pre-flight.
+`shellcheck` lint-checks Bash scripts before script changes land.
 
 ### Git hooks (contributors only)
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T16:46:27Z",
+  "generated_at": "2026-05-06T19:44:38Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T16:46:27Z",
+  "generated_at": "2026-05-06T19:44:38Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,7 @@ per project. Cross-project one-offs: `ACHILLES_PROJECT=<slug>`.
 ## Setup
 
 ```sh
-brew install fswatch coreutils yq jq   # coreutils gives gtimeout; yq drives post-2.6 YAML reads; jq drives event normalization + read-events.sh
+brew install fswatch coreutils yq jq shellcheck   # coreutils gives gtimeout; yq drives post-2.6 YAML reads; jq drives event normalization + read-events.sh; shellcheck lint-checks scripts
 pip install check-jsonschema           # JSON Schema contract validation (validate-contract.sh); pip3 works too
 chmod +x scripts/*.sh
 ```

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -956,6 +956,36 @@ write_halt_record() {
   printf '%s\n' "$file"
 }
 
+supersede_completed_halt_records() {
+  local resolved_at tmp
+  [ "$DRY_RUN" -eq 0 ] || return 0
+  [ -f "$RUN_STATE_JSON" ] || return 0
+  resolved_at=$(iso_ts_now)
+  tmp="$RUN_STATE_JSON.halts.$$"
+  jq \
+    --arg resolved_at "$resolved_at" \
+    --arg attempt_id "$ATTEMPT_ID" \
+    '(.halt_records // []) as $records
+     | .halt_records = ($records | map(
+         if (.status // "") == "paused" then
+           . + {
+             status: "superseded",
+             next_command: null,
+             superseded_at: $resolved_at,
+             superseded_by_attempt_id: $attempt_id,
+             resolution: "run_completed_after_resume"
+           }
+         else . end
+       ))
+     | .halt_record_resolution = {
+         resolved_at: $resolved_at,
+         attempt_id: $attempt_id,
+         active_count: ([.halt_records[]? | select((.status // "") == "paused" or (.status // "") == "terminated")] | length),
+         superseded_count: ([.halt_records[]? | select((.status // "") == "superseded")] | length)
+       }' "$RUN_STATE_JSON" > "$tmp"
+  mv "$tmp" "$RUN_STATE_JSON"
+}
+
 default_review_deadline() {
   local epoch
   epoch=$(( $(now_epoch) + 604800 ))
@@ -1394,16 +1424,86 @@ $(jq -r '.telemetry_gaps[]? | if type == "object" then (.gap_kind // .kind // em
 EOF
 }
 
+codex_home_for_worker() {
+  local launch_home="$1"
+  if [ -n "${CODEX_WORKER_HOME:-}" ]; then
+    printf '%s\n' "$CODEX_WORKER_HOME"
+  elif [ -n "${CODEX_HOME:-}" ]; then
+    printf '%s\n' "$CODEX_HOME"
+  elif [ -n "$launch_home" ] && [ -d "$launch_home/.codex" ]; then
+    printf '%s\n' "$launch_home/.codex"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/.codex" ]; then
+    printf '%s\n' "$HOME/.codex"
+  fi
+}
+
+collect_codex_worker_session_telemetry() {
+  local host="$1" worktree="$2" started_at="$3" launch_home="$4"
+  local codex_home session_dir best_file="" best_mtime=0 candidate mtime
+  case "$host" in
+    codex*|*codex*) ;;
+    *) printf '{}\n'; return 0 ;;
+  esac
+  codex_home=$(codex_home_for_worker "$launch_home")
+  session_dir="$codex_home/sessions"
+  [ -n "$codex_home" ] && [ -d "$session_dir" ] || { printf '{}\n'; return 0; }
+
+  while IFS= read -r -d '' candidate; do
+    mtime=$(stat -f %m "$candidate" 2>/dev/null || printf '')
+    case "$mtime" in
+      ''|*[!0-9]*) continue ;;
+    esac
+    [ "$mtime" -ge "$started_at" ] || continue
+    if jq -e --arg cwd "$worktree" '
+      select((.type == "session_meta" or .type == "turn_context") and .payload.cwd == $cwd)
+    ' "$candidate" >/dev/null 2>&1; then
+      if [ -z "$best_file" ] || [ "$mtime" -ge "$best_mtime" ]; then
+        best_file="$candidate"
+        best_mtime="$mtime"
+      fi
+    fi
+  done < <(find "$session_dir" -type f -name '*.jsonl' -print0 2>/dev/null)
+
+  [ -n "$best_file" ] || { printf '{}\n'; return 0; }
+  jq -rs '
+    ([ .[] | select(.type == "turn_context") | {model:(.payload.model // null), effort:(.payload.effort // null)} ] | last) as $ctx
+    | ([ .[]
+        | select(.type == "event_msg" and .payload.type == "token_count" and (.payload.info.total_token_usage // null) != null)
+        | .payload.info.total_token_usage
+      ] | last) as $usage
+    | {
+        source: "codex_session_log",
+        model: ($ctx.model // null),
+        model_version: ($ctx.model // null),
+        effort: ($ctx.effort // null),
+        tokens: (if $usage == null then null else {
+          total: ($usage.total_tokens // null),
+          total_tokens: ($usage.total_tokens // null),
+          input: ($usage.input_tokens // 0),
+          output: ($usage.output_tokens // 0),
+          cache_read: ($usage.cached_input_tokens // 0),
+          reasoning_output: ($usage.reasoning_output_tokens // 0),
+          source: "codex_session_log"
+        } end)
+      }
+    | with_entries(select(.value != null))
+  ' "$best_file" 2>/dev/null || printf '{}\n'
+}
+
 ingest_worker_summary() {
-  local chain_name="$1" issue="$2" host="$3" worktree="$4" before="$5" after="$6" exit_code="$7" started_at="$8" chain_run_id="$9" issue_run_id="${10}"
+  local chain_name="$1" issue="$2" host="$3" worktree="$4" before="$5" after="$6" exit_code="$7" started_at="$8" chain_run_id="$9" issue_run_id="${10}" telemetry_file="${11:-}"
   local summary_path="$worktree/.studio/chain-worker-summary.json"
   local dest="$SUMMARY_ROOT/${chain_name}-issue-${issue}-${issue_run_id}.json"
-  local ended_at created_at duration_s stats changed_artifacts
+  local ended_at created_at duration_s stats changed_artifacts session_telemetry_json
   ended_at=$(now_epoch)
   created_at=$(iso_ts_now)
   duration_s=$(duration_since "$started_at" "$ended_at")
   stats=$(diff_stats_json "$worktree" "$before" "$after")
   changed_artifacts=$(changed_artifacts_json "$worktree" "$before" "$after")
+  session_telemetry_json="{}"
+  if [ -n "$telemetry_file" ] && [ -f "$telemetry_file" ] && jq -e . "$telemetry_file" >/dev/null 2>&1; then
+    session_telemetry_json=$(jq -c . "$telemetry_file")
+  fi
 
   if [ -f "$summary_path" ] && jq -e . "$summary_path" >/dev/null 2>&1; then
     jq -c \
@@ -1418,8 +1518,23 @@ ingest_worker_summary() {
       --argjson duration_s "$duration_s" \
       --argjson stats "$stats" \
       --argjson changed_artifacts "$changed_artifacts" \
-      'def has_model: ((.model // .model_name // .model_version // null) != null);
+      --argjson session_telemetry "$session_telemetry_json" \
+      '($session_telemetry.tokens // null) as $telemetry_tokens
+       | ($session_telemetry.model // $session_telemetry.model_version // null) as $telemetry_model
+       | ($session_telemetry.model_version // $session_telemetry.model // null) as $telemetry_model_version
+       | ($session_telemetry.effort // $session_telemetry.reasoning_effort // null) as $telemetry_effort
+       | (.tokens // $telemetry_tokens) as $final_tokens
+       | (.model // .model_name // .model_version // $telemetry_model) as $final_model
+       | (.model_version // $telemetry_model_version) as $final_model_version
+       | (.effort // .reasoning_effort // $telemetry_effort) as $final_effort
+       | def has_model: ($final_model != null);
        def has_checks: (((.tests // []) | length) + ((.lints // []) | length) + ((.builds // []) | length)) > 0;
+       def gap_active($gap):
+         if $gap == "tokens" or $gap == "token_usage" then $final_tokens == null
+         elif $gap == "model" then (has_model | not)
+         elif $gap == "model_version" then $final_model_version == null
+         elif $gap == "effort" or $gap == "reasoning_effort" then $final_effort == null
+         else true end;
        . + {
         schema_version: (.schema_version // 1),
         kind: (.kind // "completion"),
@@ -1442,14 +1557,18 @@ ingest_worker_summary() {
         tests: (.tests // []),
         lints: (.lints // []),
         builds: (.builds // []),
-        tokens: (.tokens // null),
+        tokens: $final_tokens,
+        model: (.model // .model_name // $telemetry_model),
+        model_version: $final_model_version,
+        effort: $final_effort,
+        telemetry_sources: (((.telemetry_sources // []) + (if (($session_telemetry.source // "") == "") then [] else [$session_telemetry.source] end)) | unique),
         functionality_delivered: (.functionality_delivered // null),
         carryover: (.carryover // null),
         lessons: (.lessons // null),
         telemetry_gaps: (((.telemetry_gaps // [])
-          + (if (.tokens // null) == null then ["tokens"] else [] end)
+          + (if $final_tokens == null then ["tokens"] else [] end)
           + (if has_model then [] else ["model"] end)
-          + (if has_checks then [] else ["tests_lints_builds"] end)) | unique)
+          + (if has_checks then [] else ["tests_lints_builds"] end)) | unique | map(select(gap_active(.))))
       }' "$summary_path" > "$dest"
     emit_chain_event chain_worker_summary_ingested "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" completed "$duration_s" \
       "$(jq -cn --arg summary "$dest" '{summary:$summary, validation:"valid"}')"
@@ -1475,6 +1594,7 @@ ingest_worker_summary() {
       --argjson stats "$stats" \
       --argjson changed_artifacts "$changed_artifacts" \
       --arg summary_gap "$summary_gap" \
+      --argjson session_telemetry "$session_telemetry_json" \
       '{
         schema_version: 1,
         kind: "completion",
@@ -1499,13 +1619,18 @@ ingest_worker_summary() {
         tests: [],
         lints: [],
         builds: [],
-        tokens: null,
-        model: null,
+        tokens: ($session_telemetry.tokens // null),
+        model: ($session_telemetry.model // null),
+        model_version: ($session_telemetry.model_version // $session_telemetry.model // null),
+        effort: ($session_telemetry.effort // null),
         model_recommendation: null,
+        telemetry_sources: (if (($session_telemetry.source // "") == "") then [] else [$session_telemetry.source] end),
         functionality_delivered: null,
         carryover: null,
         lessons: null,
-        telemetry_gaps: [$summary_gap, "model", "tokens", "tests_lints_builds"]
+        telemetry_gaps: ([$summary_gap, "tests_lints_builds"]
+          + (if ($session_telemetry.model // $session_telemetry.model_version // null) == null then ["model"] else [] end)
+          + (if ($session_telemetry.tokens // null) == null then ["tokens"] else [] end))
       }' > "$dest"
     emit_chain_event chain_artifact_validation_failed "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" failed "$duration_s" \
       "$(jq -cn --arg artifact "chain-worker-summary" --arg reason "$summary_gap" --arg summary "$dest" '{artifact:$artifact, reason_id:$reason, summary:$summary}')"
@@ -1790,7 +1915,26 @@ generate_run_report() {
     printf '\n## Halt Records\n\n'
     halt_count=0
     [ -n "$halt_dir" ] && halt_count=$(find "$halt_dir" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
-    if [ "$halt_count" -gt 0 ]; then
+    if [ -n "${RUN_STATE_JSON:-}" ] && [ -f "$RUN_STATE_JSON" ] && [ "$(jq '(.halt_records // []) | length' "$RUN_STATE_JSON" 2>/dev/null || printf 0)" -gt 0 ]; then
+      jq -r '
+        (.halt_records // []) as $records
+        | ($records | map(select((.status // "") == "paused" or (.status // "") == "terminated"))) as $active
+        | ($records | map(select((.status // "") == "superseded"))) as $superseded
+        | if ($active | length) > 0 then
+            ["| Reason | Class | Status | Next Command | Artifact |",
+             "|---|---|---|---|---|"],
+            ($active[] | "| \(.reason_id) | \(.halt_class) | \(.status) | \(.next_command // "hard stop") | \(.path // "missing") |")
+          elif ($superseded | length) > 0 then
+            "No active halt records. Superseded halt records: \($superseded | length) (run completed after resume).",
+            "",
+            "| Reason | Class | Status | Resolution | Artifact |",
+            "|---|---|---|---|---|",
+            ($superseded[] | "| \(.reason_id) | \(.halt_class) | \(.status) | \(.resolution // "run_completed_after_resume") | \(.path // "missing") |")
+          else
+            "No active halt records."
+          end
+      ' "$RUN_STATE_JSON"
+    elif [ "$halt_count" -gt 0 ]; then
       jq -r -s '
         ["| Reason | Class | Status | Next Command | Summary |",
          "|---|---|---|---|---|"],
@@ -1861,6 +2005,9 @@ finish_run() {
     return 0
   fi
   write_run_state "$status" "$reason"
+  if [ "$status" = "completed" ]; then
+    supersede_completed_halt_records
+  fi
   generate_run_report "$status" "$reason"
   duration_s=$(duration_since "$RUN_STARTED_AT")
   emit_chain_event chain_run_completed "" "$RUN_ID" "" "" "$status" "$duration_s" \
@@ -2934,6 +3081,7 @@ Private telemetry report: local only; resolve by run ID on the machine that ran 
 Public-safe telemetry: run/chain UUIDs and abstract gap names only."; then
     abort_run "PR telemetry comment failed for $pr_url"
   fi
+  detach_chain_worktree_for_merge_cleanup "$chain_branch" "$chain_worktree"
 
   review_started_at=$(now_epoch)
   review_out="$CHAIN_RUN_ROOT/review-$pr_number.out"
@@ -2956,6 +3104,27 @@ Public-safe telemetry: run/chain UUIDs and abstract gap names only."; then
       "$(jq -cn --arg pr_url "$pr_url" --argjson exit_code "$review_rc" --arg verdict "$review_verdict" --arg model "$review_model" --arg effort "$review_effort" --arg review_host "$review_host" --arg parent_host "$review_parent_host" --arg output "$review_out" '{pr_url:$pr_url, exit_code:$exit_code, verdict:(if $verdict == "" then null else $verdict end), model:(if $model == "" then null else $model end), effort:(if $effort == "" then null else $effort end), review_host:(if $review_host == "" then null else $review_host end), parent_host:(if $parent_host == "" then null else $parent_host end), wrapper_output:$output}')"
     abort_run "PR review failed for $pr_url"
   fi
+}
+
+detach_chain_worktree_for_merge_cleanup() {
+  local chain_branch="$1" chain_worktree="$2" current_branch
+  [ "$DRY_RUN" -eq 0 ] || {
+    printf 'DRY-RUN git -C %q checkout --detach HEAD\n' "$chain_worktree"
+    return 0
+  }
+  [ -d "$chain_worktree/.git" ] || [ -f "$chain_worktree/.git" ] || return 0
+  current_branch=$(git -C "$chain_worktree" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ "$current_branch" = "$chain_branch" ] || return 0
+  log "detaching $chain_worktree from $chain_branch before PR merge cleanup"
+  run git -C "$chain_worktree" checkout --detach HEAD
+}
+
+chain_worktree_registered() {
+  local chain_worktree="$1"
+  git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | awk -v target="$chain_worktree" '
+    /^worktree / && substr($0, 10) == target { found=1 }
+    END { exit found ? 0 : 1 }
+  '
 }
 
 write_issue_phase_plan_artifact() {
@@ -3053,7 +3222,7 @@ write_issue_phase_outcome_artifact() {
 run_issue_job() {
   local name="$1" branch="$2" chain_worktree="$3" issue="$4" host="$5" git_metadata_strategy="$6" issue_worktree="$7" issue_branch="$8" chain_run_id="$9" issue_run_id="${10}" result_file="${11}" phase_review_mode="${12:-auto}" issue_count_for_review="${13:-1}"
   local before after worker_rc child_worker_rc summary_file issue_duration summary_payload issue_started_at child_reason_id child_blocked_reason parent_finalized effective_worker_rc
-  local phase_context boundary_id phase_plan_artifact phase_outcome_artifact phase_review_rc phase_review_reason
+  local phase_context boundary_id phase_plan_artifact phase_outcome_artifact phase_review_rc phase_review_reason worker_telemetry_file worker_launch_home
   issue_started_at=$(now_epoch)
   parent_finalized=false
 
@@ -3124,7 +3293,10 @@ run_issue_job() {
   fi
 
   after=$(git -C "$issue_worktree" rev-parse HEAD)
-  summary_file=$(ingest_worker_summary "$name" "$issue" "$host" "$issue_worktree" "$before" "$after" "$worker_rc" "$issue_started_at" "$chain_run_id" "$issue_run_id")
+  worker_telemetry_file="$CHAIN_RUN_ROOT/worker-telemetry-$issue_run_id.json"
+  worker_launch_home=$(host_launch_home)
+  collect_codex_worker_session_telemetry "$host" "$issue_worktree" "$issue_started_at" "$worker_launch_home" > "$worker_telemetry_file" || printf '{}\n' > "$worker_telemetry_file"
+  summary_file=$(ingest_worker_summary "$name" "$issue" "$host" "$issue_worktree" "$before" "$after" "$worker_rc" "$issue_started_at" "$chain_run_id" "$issue_run_id" "$worker_telemetry_file")
   effective_worker_rc=$(chain_git_parent_finalize_effective_worker_rc "$worker_rc" "$summary_file")
   write_decision_escrows_from_summary "$summary_file" || log "decision escrow extraction failed for $summary_file"
   issue_duration=$(duration_since "$issue_started_at")
@@ -3603,7 +3775,11 @@ PR: $FINAL_PR_URL"
   if [ "$DRY_RUN" -eq 0 ]; then
     run_retryable_or_abort network_partition "fetch origin failed during chain cleanup" \
       with_login_home_for_github git -C "$REPO_ROOT" fetch origin --prune
-    git -C "$REPO_ROOT" worktree remove "$chain_worktree" || true
+    if chain_worktree_registered "$chain_worktree"; then
+      git -C "$REPO_ROOT" worktree remove "$chain_worktree" || true
+    else
+      log "chain worktree already removed: $chain_worktree"
+    fi
     git -C "$REPO_ROOT" branch -D "$branch" 2>/dev/null || true
   else
     printf 'DRY-RUN git -C %q fetch origin --prune\n' "$REPO_ROOT"

--- a/scripts/test-fixtures/656-chain-runner-followups/test-chain-runner-followups.sh
+++ b/scripts/test-fixtures/656-chain-runner-followups/test-chain-runner-followups.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Verifies parent-side chain-runner follow-ups for telemetry and halt reporting.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-runner-followups.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+RUN_ID="019df000-1111-7000-8000-111111111111"
+CHAIN_RUN_ID="019df000-2222-7000-8000-222222222222"
+ISSUE_RUN_ID="019df000-3333-7000-8000-333333333333"
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+ATTEMPT_ID="019df000-4444-7000-8000-444444444444"
+
+WORK="$TMPROOT/work"
+SUMMARY_ROOT="$TMPROOT/summaries"
+HALT_ROOT="$TMPROOT/halts"
+ESCROW_ROOT="$TMPROOT/escrows"
+EVENTS_JSONL="$TMPROOT/events.jsonl"
+RUN_STATE_JSON="$TMPROOT/state.json"
+RUN_REPORT="$TMPROOT/report.md"
+CHAIN_RUN_ROOT="$TMPROOT/run"
+CODEX_HOME="$TMPROOT/codex"
+mkdir -p "$WORK/.studio" "$SUMMARY_ROOT" "$HALT_ROOT" "$ESCROW_ROOT" "$CHAIN_RUN_ROOT" "$CODEX_HOME/sessions/2026/05/07"
+
+awk '/^codex_home_for_worker\(\)/,/^worker_summary_tracked\(\)/ { if ($0 !~ /^worker_summary_tracked\(\)/) print }' \
+  "$ROOT/scripts/studio-chain-runner.sh" > "$TMPROOT/summary-functions.sh"
+awk '/^supersede_completed_halt_records\(\)/,/^default_review_deadline\(\)/ { if ($0 !~ /^default_review_deadline\(\)/) print }' \
+  "$ROOT/scripts/studio-chain-runner.sh" > "$TMPROOT/halt-functions.sh"
+awk '/^generate_run_report\(\)/,/^finish_run\(\)/ { if ($0 !~ /^finish_run\(\)/) print }' \
+  "$ROOT/scripts/studio-chain-runner.sh" > "$TMPROOT/report-functions.sh"
+
+iso_ts_now() { printf '2026-05-07T00:00:20Z\n'; }
+now_epoch() { printf '120\n'; }
+duration_since() { printf '%s\n' "$(( ${2:-120} - $1 ))"; }
+diff_stats_json() { printf '{"files_changed":0,"additions":0,"deletions":0,"generated_file_count":0}\n'; }
+changed_artifacts_json() { printf '[]\n'; }
+emit_chain_event() { :; }
+emit_summary_telemetry_gaps() { :; }
+
+# shellcheck source=/dev/null
+. "$TMPROOT/summary-functions.sh"
+# shellcheck source=/dev/null
+. "$TMPROOT/halt-functions.sh"
+# shellcheck source=/dev/null
+. "$TMPROOT/report-functions.sh"
+
+cat > "$WORK/.studio/chain-worker-summary.json" <<JSON
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "chain": "followups",
+  "issue_number": 656,
+  "host": "codex",
+  "exit_code": 0,
+  "tests": [{"command":"fixture","outcome":"pass"}],
+  "lints": [],
+  "builds": [],
+  "tokens": null,
+  "model": null,
+  "model_version": null,
+  "effort": null,
+  "telemetry_gaps": ["tokens", "model", "model_version", "effort"]
+}
+JSON
+
+cat > "$CODEX_HOME/sessions/2026/05/07/rollout-telemetry.jsonl" <<JSONL
+{"type":"session_meta","payload":{"cwd":"$WORK","timestamp":"2026-05-07T00:00:01Z"}}
+{"type":"turn_context","payload":{"cwd":"$WORK","model":"gpt-5.5","effort":"medium"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5,"total_tokens":130}}}}
+JSONL
+
+telemetry_file="$TMPROOT/telemetry.json"
+collect_codex_worker_session_telemetry codex "$WORK" 0 "$TMPROOT/home" > "$telemetry_file"
+summary_file=$(ingest_worker_summary followups 656 codex "$WORK" before after 0 100 "$CHAIN_RUN_ID" "$ISSUE_RUN_ID" "$telemetry_file")
+
+jq -e '
+  .tokens.total == 130
+  and .model == "gpt-5.5"
+  and .model_version == "gpt-5.5"
+  and .effort == "medium"
+  and (.telemetry_sources | index("codex_session_log"))
+  and ((.telemetry_gaps // []) | index("tokens") | not)
+  and ((.telemetry_gaps // []) | index("model") | not)
+  and ((.telemetry_gaps // []) | index("model_version") | not)
+  and ((.telemetry_gaps // []) | index("effort") | not)
+' "$summary_file" >/dev/null || {
+  printf 'parent telemetry enrichment failed\n' >&2
+  cat "$summary_file" >&2
+  exit 1
+}
+
+cat > "$RUN_STATE_JSON" <<JSON
+{
+  "schema_version": 1,
+  "run_id": "$RUN_ID",
+  "status": "running",
+  "halt_records": [
+    {
+      "path": "$HALT_ROOT/halt.json",
+      "reason_id": "child_crash",
+      "halt_class": "recoverable",
+      "status": "paused",
+      "next_command": "scripts/studio-chain-runner.sh --resume $RUN_ID --yes"
+    }
+  ]
+}
+JSON
+
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+DRY_RUN=0
+supersede_completed_halt_records
+jq -e '
+  .halt_records[0].status == "superseded"
+  and .halt_records[0].next_command == null
+  and .halt_records[0].resolution == "run_completed_after_resume"
+  and .halt_record_resolution.superseded_count == 1
+' "$RUN_STATE_JSON" >/dev/null || {
+  printf 'halt supersession failed\n' >&2
+  cat "$RUN_STATE_JSON" >&2
+  exit 1
+}
+
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+MANIFEST="chains/followups.yaml"
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+RUN_STATUS="completed"
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+RUN_FAILURE_REASON=""
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+RUN_STARTED_AT=100
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+RUN_STARTED_TS="2026-05-07T00:00:00Z"
+# shellcheck disable=SC2034 # consumed by sourced chain-runner functions.
+FINAL_PR_URL=""
+: > "$EVENTS_JSONL"
+generate_run_report completed ""
+
+grep -q "No active halt records. Superseded halt records: 1" "$RUN_REPORT" || {
+  printf 'completed report did not suppress active halted state\n' >&2
+  cat "$RUN_REPORT" >&2
+  exit 1
+}
+if grep -q -- "--resume $RUN_ID" "$RUN_REPORT"; then
+  printf 'completed report still advertised stale resume command\n' >&2
+  cat "$RUN_REPORT" >&2
+  exit 1
+fi
+
+printf 'PASS: chain-runner follow-up telemetry and halt supersession\n'

--- a/scripts/tools.yaml
+++ b/scripts/tools.yaml
@@ -142,6 +142,22 @@ tools:
     duration: "<30s"
     alternatives: ""
 
+  - id: shellcheck
+    name: ShellCheck
+    category: toolchain
+    tier: recommended
+    roles: [manager, dual]
+    why: "Shell linter — catches Bash portability and quoting defects before script changes land"
+    details: "Static analyzer for shell scripts. Studio script changes use it to catch quoting bugs, unreachable branches, bad source paths, and portability mistakes before review."
+    check_type: command
+    check_target: shellcheck
+    version_cmd: "shellcheck --version 2>/dev/null | awk '/^version:/ {print $2}'"
+    min_version: ""
+    install_type: brew
+    install_target: shellcheck
+    duration: "<1 min"
+    alternatives: "manual review only; higher risk for shell-script changes"
+
   - id: git
     name: git
     category: vcs


### PR DESCRIPTION
## Summary

- Supersede paused halt records in completed chain run state/report output so final reports do not advertise stale resume commands.
- Enrich worker summaries from private Codex session telemetry when workers omit token/model/effort fields.
- Detach chain worktrees before PR review/merge cleanup and tolerate already-removed worktrees during final cleanup.
- Add ShellCheck to the bootstrap tool registry and setup docs.

Closes #658

## Verification

- `scripts/test-fixtures/656-chain-runner-followups/test-chain-runner-followups.sh`
- `scripts/test-fixtures/480-chain-run-telemetry/test-chain-run-telemetry.sh`
- `scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `scripts/test-fixtures/648-chain-execution-policy/test-chain-execution-policy.sh`
- `scripts/test-fixtures/651-chain-artifact-hygiene/test-chain-artifact-hygiene.sh`
- `scripts/test-fixtures/652-chain-run-efficiency/test-chain-run-efficiency.sh`
- `scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh`
- `scripts/test-fixtures/396-chain-telemetry/test-chain-runner-dry-run-telemetry.sh`
- `scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh`
- `shellcheck scripts/test-fixtures/656-chain-runner-followups/test-chain-runner-followups.sh`
- `shellcheck -x -e SC2016,SC1091,SC2094,SC2034,SC2221,SC2222 scripts/studio-chain-runner.sh scripts/test-fixtures/656-chain-runner-followups/test-chain-runner-followups.sh`
- `scripts/bootstrap.sh --quick --dry-run --no-log`
- `.githooks/pre-commit`
