### PR TITLE
Detach PR head before merge finalize

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T19:44:38Z",
+  "generated_at": "2026-05-06T19:49:15Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T19:44:38Z",
+  "generated_at": "2026-05-06T19:49:15Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -133,6 +133,21 @@ $cleanup_paths
 EOF
 }
 
+detach_current_head_worktree_before_merge() {
+  local current_branch
+  current_branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  [ "$current_branch" = "$head_ref" ] || return 0
+  if [ -n "$(git status --porcelain)" ]; then
+    cleanup_failed=1
+    cleanup_notes="${cleanup_notes}head_worktree_detach_skipped_dirty;"
+    return 0
+  fi
+  if ! git -c advice.detachedHead=false checkout --detach HEAD >/dev/null; then
+    cleanup_failed=1
+    cleanup_notes="${cleanup_notes}head_worktree_detach_failed;"
+  fi
+}
+
 json=$(with_login_home_for_github gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,headRepositoryOwner,baseRefName,url,commits) \
   || { printf 'pr-merge-finalize: failed to read PR %s\n' "$PR" >&2; exit 1; }
 
@@ -212,6 +227,8 @@ if [ "$METHOD" = "auto" ]; then
     METHOD="rebase"
   fi
 fi
+
+detach_current_head_worktree_before_merge
 
 printf 'Merging PR via GitHub: %s\n' "$url"
 remote_merge_warning=""

--- a/scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
+++ b/scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
@@ -90,10 +90,31 @@ run_case() {
     "jq -e 'select(.event==\"pr_merge_finalize_completed\" and .data.duration_s >= 0 and .data.cleanup_failed == true)' '$EVENT_LOG' >/dev/null"
 }
 
+run_head_worktree_case() {
+  local out main_wt branch_after
+  out="$TMPROOT/out-head-worktree.txt"
+  main_wt="$TMPROOT/main-worktree"
+  git -C "$WORK" branch -f feature HEAD
+  git -C "$WORK" checkout -q feature
+  git -C "$WORK" worktree add -q "$main_wt" main
+  : > "$MERGE_LOG"
+  BASE_REF=main COMMIT_COUNT=1 \
+    bash "$ROOT/scripts/pr-merge-finalize.sh" 123 --method auto \
+      --bypass-review --user-approved-bypass https://github.com/owner/repo/pull/123 \
+      > "$out" 2>"$out.err"
+  branch_after=$(git -C "$WORK" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  assert "head worktree case detaches before gh merge" "[ -z '$branch_after' ]"
+  assert "head worktree case reports merge success" "grep -q 'PR_MERGED=1' '$out'"
+  assert "head worktree case avoided detach failure" "! grep -q 'head_worktree_detach_.*failed\\|head_worktree_detach_skipped_dirty' '$out'"
+  git -C "$WORK" worktree remove -f "$main_wt"
+  git -C "$WORK" checkout -q main
+}
+
 cd "$WORK" || exit 1
 run_case main 3 rebase
 run_case main 4 merge
 run_case feature 4 rebase
+run_head_worktree_case
 
 if [ "$failures" -ne 0 ]; then
   printf 'FAIL: %s assertion(s)\n' "$failures" >&2


### PR DESCRIPTION
## Summary

- Detach the current worktree when it is on the PR head branch before invoking `gh pr merge --delete-branch`.
- Extend the PR merge method fixture to cover a head-worktree run with `main` checked out in a separate worktree.

Follow-up to #658.

## Verification

- `scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `bash -n scripts/pr-merge-finalize.sh scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `shellcheck -x -e SC1091,SC2329 scripts/pr-merge-finalize.sh scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `git diff --check`
- `.githooks/pre-commit`
