### PR TITLE
Avoid gh local branch cleanup warnings

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T19:49:15Z",
+  "generated_at": "2026-05-06T19:52:04Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T19:49:15Z",
+  "generated_at": "2026-05-06T19:52:04Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/pr-merge-finalize.sh
+++ b/scripts/pr-merge-finalize.sh
@@ -148,6 +148,18 @@ detach_current_head_worktree_before_merge() {
   fi
 }
 
+delete_remote_head_branch_after_merge() {
+  [ -n "$head_ref" ] || return 0
+  [ "$head_ref" != "$base_ref" ] || return 0
+  if with_login_home_for_github git push origin --delete "$head_ref" >/dev/null 2>&1; then
+    return 0
+  fi
+  if with_login_home_for_github git ls-remote --exit-code --heads origin "$head_ref" >/dev/null 2>&1; then
+    cleanup_failed=1
+    cleanup_notes="${cleanup_notes}remote_branch_delete_failed;"
+  fi
+}
+
 json=$(with_login_home_for_github gh pr view "$PR" --json number,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,headRepositoryOwner,baseRefName,url,commits) \
   || { printf 'pr-merge-finalize: failed to read PR %s\n' "$PR" >&2; exit 1; }
 
@@ -233,9 +245,9 @@ detach_current_head_worktree_before_merge
 printf 'Merging PR via GitHub: %s\n' "$url"
 remote_merge_warning=""
 case "$METHOD" in
-  merge)  merge_cmd=(with_login_home_for_github gh pr merge "$PR" --merge --delete-branch) ;;
-  squash) merge_cmd=(with_login_home_for_github gh pr merge "$PR" --squash --delete-branch) ;;
-  rebase) merge_cmd=(with_login_home_for_github gh pr merge "$PR" --rebase --delete-branch) ;;
+  merge)  merge_cmd=(with_login_home_for_github gh pr merge "$PR" --merge) ;;
+  squash) merge_cmd=(with_login_home_for_github gh pr merge "$PR" --squash) ;;
+  rebase) merge_cmd=(with_login_home_for_github gh pr merge "$PR" --rebase) ;;
 esac
 if ! "${merge_cmd[@]}"; then
   merged_state=$(with_login_home_for_github gh pr view "$PR" --json state --jq '.state' 2>/dev/null || true)
@@ -245,6 +257,7 @@ if ! "${merge_cmd[@]}"; then
   fi
   remote_merge_warning="gh_merge_returned_nonzero_after_remote_merge"
 fi
+delete_remote_head_branch_after_merge
 
 current_path=$(current_worktree_path)
 control_path=""

--- a/scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
+++ b/scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh
@@ -85,6 +85,7 @@ run_case() {
       > "$out" 2>"$out.err"
   assert "auto $base $count commits reports $expected" "grep -q 'MERGE_METHOD=$expected' '$out'"
   assert "auto $base $count commits calls gh --$expected" "grep -q -- '--$expected' '$MERGE_LOG'"
+  assert "auto $base $count commits leaves branch cleanup to git" "! grep -q -- '--delete-branch' '$MERGE_LOG'"
   assert "auto $base $count commits exits zero" "grep -q 'PR_MERGED=1' '$out'"
   assert "auto $base $count commits emits merge-finalize duration" \
     "jq -e 'select(.event==\"pr_merge_finalize_completed\" and .data.duration_s >= 0 and .data.cleanup_failed == true)' '$EVENT_LOG' >/dev/null"


### PR DESCRIPTION
## Summary

- Stop passing `--delete-branch` to `gh pr merge`; it performs local branch probing that warns in detached/head-worktree cases.
- Delete the remote feature branch explicitly after the merge, then let repo-owned cleanup handle local refs/worktrees.
- Extend the merge method fixture to assert `gh` is not asked to do local branch cleanup.

Follow-up to #658.

## Verification

- `scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `bash -n scripts/pr-merge-finalize.sh scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `shellcheck -x -e SC1091,SC2329 scripts/pr-merge-finalize.sh scripts/test-fixtures/325-pr-merge-method/test-pr-merge-method.sh`
- `git diff --check`
- `.githooks/pre-commit`
