### PR TITLE
Add selective rule-pack loading chain manifest

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-06T19:52:04Z",
+  "generated_at": "2026-05-07T03:25:21Z",
   "agents": [
 
   ]

--- a/chains/selective-rule-pack-loading.yaml
+++ b/chains/selective-rule-pack-loading.yaml
@@ -1,0 +1,32 @@
+# Selective rule-pack loading chain from the 2026-05-07 studio session.
+#
+# Dry-run:
+#   scripts/studio-chain-runner.sh chains/selective-rule-pack-loading.yaml --dry-run
+#
+# Execute/resume:
+#   scripts/studio-chain-runner.sh --auto selective-rule-pack-loading
+#
+# Manager front door:
+#   /dev-studio manager work-chain selective-rule-pack-loading
+#
+# Active scope:
+# - #678 local-LLM classification is intentionally excluded and closed as not
+#   planned for now. The chain locks the deterministic path: compact rule-pack
+#   summaries, manifest-declared selection, script-enforced mechanical gates,
+#   and context-budget telemetry.
+#
+# Issue order:
+# - #673 defines the minimal always-loaded contract.
+# - #674 defines reusable pack structure and metadata.
+# - #675 adds manifest resolver behavior using that pack structure.
+# - #676 adds script-enforced gates after the resolver contract exists.
+# - #677 measures context budget once selection/enforcement surfaces exist.
+
+schema_version: 1
+chains:
+  - name: selective-rule-pack-loading
+    base: main
+    branch: feature/selective-rule-pack-loading
+    host: auto
+    phase_review: required
+    issues: [673, 674, 675, 676, 677]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T19:52:04Z",
+  "generated_at": "2026-05-07T03:25:21Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary

- add `chains/selective-rule-pack-loading.yaml` for the locked deterministic rule-pack-loading work
- exclude #678 local-LLM classification from the active chain
- sequence #673-#677 in dependency order with required phase reviews

## Verification

- `scripts/studio-chain-runner.sh chains/selective-rule-pack-loading.yaml --dry-run`
- pre-commit: `lint-architecture`, `lint-comms-boundary`, `lint-debrief-writers`, `lint-v2-bootstrap`, `lint-v2-enforcement`, `lint-chain-workflow-docs`

## Notes

The pre-commit hook regenerated `docs-surface.json` and `_shared/schemas/capability-manifest.json`, changing only `generated_at`.
