### PR TITLE
Reconcile chain summaries on resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ scripts/manager-work-chain.sh prd-to-chain-automation --dry-run # preview the na
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements # unattended safe start/resume for one manifest
 scripts/studio-chain-runner.sh workflow-measurement-improvements --attended --yes # attended run with explicit confirmation bypass
 scripts/studio-chain-runner.sh workflow-measurement-improvements --unattended --yes # no routine continue prompts; typed blockers halt
+scripts/studio-chain-runner.sh --resume <run_id> --yes # resume state; reconcile completed worker summaries before dependents
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview checkpoint-aware safe-boundary hooks
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show next supervisor action without state mutation
 scripts/studio-chain-telemetry-digest.sh --days 7     # weekly v1 counters, efficiency ratios, and bottlenecks from private chain-run telemetry

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T04:04:33Z",
+  "generated_at": "2026-05-07T04:32:50Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T04:04:33Z",
+  "generated_at": "2026-05-07T04:32:49Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,7 +80,7 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements --unattended --
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show the supervisor's next action without mutating state
 scripts/prd-intake-normalize.sh prd.md                                     # normalize PRD/transcript/issue brief language into a requirement packet
 scripts/prd-task-graph-synthesize.sh packet.md                             # synthesize deterministic scheduler graph; flags missing prereqs and write races
-scripts/studio-chain-runner.sh --resume <run_id> --yes                     # resume from ~/.dev-studio/generic-dev-studio/chain-runs/<run_id>/state.json
+scripts/studio-chain-runner.sh --resume <run_id> --yes                     # resume from state.json; reconciles completed worker summaries before scheduling dependents
 scripts/studio-chain-runner.sh --list                                      # list persisted chain runs and report paths
 scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution
 scripts/studio-chain-telemetry-digest.sh --days 7                          # v1 counters, efficiency ratios, bottlenecks, and weekly digest from private chain-run telemetry
@@ -89,7 +89,7 @@ scripts/studio-checkpoint.sh create --role worker --goal "..." --next "..." # co
 scripts/studio-checkpoint.sh resume --latest --role worker                  # load manifest.json + context.md first, then inspect drift lazily
 scripts/codex-worker-exec.sh "<prompt>"                                    # internal Codex worker launcher: workspace-write + ~/.dev-studio + ephemeral + no prompts
 # Chain dry-runs show the selected git metadata strategy; sandboxed hosts use issue-local clones so commits stay inside the worker root.
-# Chain worktrees/results are namespaced under the run UUID; resume continues only the selected run and surfaces skipped/integrated/pending issue semantics.
+# Chain worktrees/results are namespaced under the run UUID; resume continues only the selected run, reconciles stale running issues from completed private summaries after required outcome review, and surfaces skipped/integrated/pending issue semantics.
 # Chain startup sweeps stale state locks, old temporary run roots, and oversized private artifacts; tune with STUDIO_CHAIN_TMP_RETENTION_DAYS, STUDIO_CHAIN_RUN_RETENTION_DAYS, and STUDIO_CHAIN_ARTIFACT_MAX_BYTES.
 # Chain reports include compact efficiency metrics, test/lint/build outcomes, typed halt records, and decision escrow when automation pauses or continues on a low-risk default.
 scripts/studio-chain-reviewed.sh v2-transition --host codex --review-host claude-reviewer  # pre-run phase review, then chain PRs reviewed by the selected reviewer

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -3551,6 +3551,138 @@ process_completed_issue_result() {
   return 0
 }
 
+summary_for_issue_run() {
+  local chain_name="$1" issue="$2" issue_run_id="$3" expected summary
+  expected="$SUMMARY_ROOT/${chain_name}-issue-${issue}-${issue_run_id}.json"
+  if [ -f "$expected" ]; then
+    printf '%s\n' "$expected"
+    return 0
+  fi
+  [ -d "$SUMMARY_ROOT" ] || return 1
+  while IFS= read -r summary; do
+    [ -n "$summary" ] || continue
+    if jq -e --arg issue_run_id "$issue_run_id" '.issue_run_id == $issue_run_id' "$summary" >/dev/null 2>&1; then
+      printf '%s\n' "$summary"
+      return 0
+    fi
+  done < <(find "$SUMMARY_ROOT" -type f -name '*.json' 2>/dev/null | sort)
+  return 1
+}
+
+summary_completed_successfully() {
+  local summary_file="$1" issue_run_id="$2"
+  jq -e --arg issue_run_id "$issue_run_id" '
+    .issue_run_id == $issue_run_id
+    and (.status // "") == "completed"
+    and ((.exit_code // 1) == 0)
+    and ((.commit_after // "") != "")
+    and ((.commit_after // "") != "null")
+  ' "$summary_file" >/dev/null 2>&1
+}
+
+summary_commit_is_recoverable() {
+  local issue_worktree="$1" commit_after="$2" head
+  [ -n "$commit_after" ] && [ "$commit_after" != "null" ] || return 1
+  git_checkout_exists "$issue_worktree" || return 1
+  git -C "$issue_worktree" cat-file -e "$commit_after^{commit}" 2>/dev/null || return 1
+  head=$(git -C "$issue_worktree" rev-parse HEAD 2>/dev/null || true)
+  [ "$head" = "$commit_after" ]
+}
+
+summary_reconciliation_payload() {
+  local summary_file="$1" commit_after="$2"
+  jq -c \
+    --arg summary "$summary_file" \
+    --arg after "$commit_after" \
+    'def bad_outcome: ((.outcome // .status // "") | tostring | test("fail|error|flaky"; "i"));
+     def bad_count($arr): [($arr // [])[]? | select(bad_outcome)] | length;
+     {
+       summary:$summary,
+       commit_after:$after,
+       exit_code:(.exit_code // 0),
+       child_exit_code:(.exit_code // 0),
+       worker_duration_s:(.duration_s // 0),
+       parent_finalized:(.parent_finalized // false),
+       reconciled_from_summary:true,
+       check_counts:{
+         tests:{total:((.tests // []) | length), bad:bad_count(.tests)},
+         lints:{total:((.lints // []) | length), bad:bad_count(.lints)},
+         builds:{total:((.builds // []) | length), bad:bad_count(.builds)}
+       },
+       token_telemetry:(if (.tokens // null) == null then "missing" else "present" end),
+       telemetry_gaps:(.telemetry_gaps // [])
+     }' "$summary_file"
+}
+
+reconcile_resume_issue_summary() {
+  local chain_name="$1" chain_run_id="$2" issue="$3" issue_run_id="$4" issue_worktree="$5" phase_review_mode="$6" issue_count_for_review="$7"
+  local summary_file before after duration_s payload boundary_id phase_outcome_artifact phase_review_rc phase_review_reason
+
+  summary_file=$(summary_for_issue_run "$chain_name" "$issue" "$issue_run_id" || true)
+  [ -n "$summary_file" ] || return 1
+  summary_completed_successfully "$summary_file" "$issue_run_id" || return 1
+
+  before=$(jq -r '.commit_before // ""' "$summary_file")
+  after=$(jq -r '.commit_after // ""' "$summary_file")
+  summary_commit_is_recoverable "$issue_worktree" "$after" || return 1
+
+  duration_s=$(jq -r '.duration_s // 0' "$summary_file")
+  case "$duration_s" in ''|*[!0-9]*) duration_s=0 ;; esac
+  payload=$(summary_reconciliation_payload "$summary_file" "$after")
+
+  if phase_review_required_for_issue "$phase_review_mode" "$issue_count_for_review"; then
+    boundary_id="$chain_run_id-$issue_run_id"
+    phase_outcome_artifact="$PHASE_REVIEW_ROOT/$boundary_id-outcome.md"
+    write_issue_phase_outcome_artifact "$phase_outcome_artifact" "$chain_name" "$issue" "$issue_run_id" "$before" "$after" "$summary_file"
+    set +e
+    run_phase_review_gate outcome "$boundary_id" "$phase_outcome_artifact" "$chain_run_id" "$issue_run_id" "$chain_name" "$issue"
+    phase_review_rc=$?
+    set -e
+    if [ "$phase_review_rc" -ne 0 ]; then
+      case "$phase_review_rc" in
+        70) phase_review_reason="reviewer_host_ineligible" ;;
+        71) phase_review_reason="reviewer_blocked" ;;
+        72) phase_review_reason="reviewer_ambiguous" ;;
+        *) phase_review_reason="required_review_failed" ;;
+      esac
+      emit_chain_event chain_issue_completed "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" failed "$duration_s" "$payload"
+      mark_issue_state "$issue_run_id" failed "$before" "$after" "$summary_file" "phase_review_failed"
+      SCHEDULER_FAILURE_REASON="$phase_review_reason"
+      return 2
+    fi
+  fi
+
+  log "resume reconciled completed issue #$issue from worker summary"
+  emit_chain_event chain_issue_completed "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" completed "$duration_s" "$payload"
+  mark_issue_state "$issue_run_id" completed "$before" "$after" "$summary_file"
+  return 0
+}
+
+reconcile_resume_issue_summaries() {
+  local chain_idx="$1" chain_name="$2" chain_run_id="$3" phase_review_mode="$4" issue_count="$5"
+  local i issue issue_run_id issue_status issue_worktree rc
+  [ -n "$RESUME_ID" ] || return 0
+  [ "$DRY_RUN" -eq 0 ] || return 0
+
+  for ((i = 0; i < issue_count; i++)); do
+    issue=$(jq -r ".chains[$chain_idx].issues[$i].number" "$PLAN_JSON")
+    issue_worktree=$(jq -r ".chains[$chain_idx].issues[$i].issue_worktree" "$PLAN_JSON")
+    issue_run_id=$(jq -r ".chains[$chain_idx].issues[$i].issue_run_id" "$PLAN_JSON")
+    issue_status=$(jq -r --arg id "$issue_run_id" '.chains[].issues[] | select(.issue_run_id == $id) | .status // "pending"' "$RUN_STATE_JSON" 2>/dev/null || printf 'pending')
+    [ "$issue_status" = "running" ] || continue
+
+    set +e
+    reconcile_resume_issue_summary "$chain_name" "$chain_run_id" "$issue" "$issue_run_id" "$issue_worktree" "$phase_review_mode" "$issue_count"
+    rc=$?
+    set -e
+    case "$rc" in
+      0|1) ;;
+      *) return 1 ;;
+    esac
+  done
+  return 0
+}
+
 issue_dependencies_satisfied() {
   local chain_idx="$1" issue_idx="$2"
   jq -e --argjson chain_idx "$chain_idx" --argjson issue_idx "$issue_idx" '
@@ -3643,6 +3775,8 @@ run_chain_issue_scheduler() {
   ISSUE_CHAIN_RUN_IDS=()
   ISSUE_RUN_IDS=()
   SCHEDULER_FAILURE_REASON=""
+
+  reconcile_resume_issue_summaries "$chain_idx" "$chain_name" "$chain_run_id" "$phase_review_mode" "$issue_count" || abort_run "$SCHEDULER_FAILURE_REASON"
 
   while :; do
     collect_finished_issue_jobs "$chain_name" "$branch" "$chain_worktree" "$git_metadata_strategy" "$checkpoint_mode" || {

--- a/scripts/test-fixtures/683-chain-resume-summary-reconcile/test-chain-resume-summary-reconcile.sh
+++ b/scripts/test-fixtures/683-chain-resume-summary-reconcile/test-chain-resume-summary-reconcile.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Verifies resume can reconcile a stale running issue from a completed worker summary.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-resume-summary-reconcile.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+helper_block=$(awk '
+  /^git_checkout_exists\(\)/ { capture=1 }
+  /^issue_dependencies_satisfied\(\)/ { capture=0 }
+  capture { print }
+' "$ROOT/scripts/studio-chain-runner.sh")
+
+eval "$helper_block"
+
+log() { printf 'log: %s\n' "$*" >> "$EVENTS"; }
+
+phase_review_required_for_issue() {
+  [ "$1" = "required" ]
+}
+
+write_issue_phase_outcome_artifact() {
+  local artifact="$1"
+  mkdir -p "$(dirname "$artifact")"
+  printf 'outcome artifact\n' > "$artifact"
+}
+
+run_phase_review_gate() {
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$REVIEWS"
+  return 0
+}
+
+emit_chain_event() {
+  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$4" "$5" "$6" "${8:-}" >> "$EVENTS"
+}
+
+mark_issue_state() {
+  local issue_run_id="$1" status="$2" before="${3:-}" after="${4:-}" summary="${5:-}" reason="${6:-}"
+  jq \
+    --arg issue_run_id "$issue_run_id" \
+    --arg status "$status" \
+    --arg before "$before" \
+    --arg after "$after" \
+    --arg summary "$summary" \
+    --arg reason "$reason" \
+    '(.chains[].issues[] | select(.issue_run_id == $issue_run_id) | .status) = $status
+     | if $before == "" then . else (.chains[].issues[] | select(.issue_run_id == $issue_run_id) | .commit_before) = $before end
+     | if $after == "" then . else (.chains[].issues[] | select(.issue_run_id == $issue_run_id) | .commit_after) = $after end
+     | if $summary == "" then . else (.chains[].issues[] | select(.issue_run_id == $issue_run_id) | .summary) = $summary end
+     | if $reason == "" then . else (.chains[].issues[] | select(.issue_run_id == $issue_run_id) | .failure_reason) = $reason end' \
+    "$RUN_STATE_JSON" > "$RUN_STATE_JSON.tmp"
+  mv "$RUN_STATE_JSON.tmp" "$RUN_STATE_JSON"
+}
+
+RUN_ID="run-683"
+# shellcheck disable=SC2034 # Consumed by functions extracted from studio-chain-runner.sh.
+RESUME_ID="$RUN_ID"
+# shellcheck disable=SC2034 # Consumed by functions extracted from studio-chain-runner.sh.
+DRY_RUN=0
+SUMMARY_ROOT="$TMPROOT/worker-summaries"
+PHASE_REVIEW_ROOT="$TMPROOT/phase-reviews"
+RUN_STATE_JSON="$TMPROOT/state.json"
+PLAN_JSON="$TMPROOT/plan.json"
+EVENTS="$TMPROOT/events.tsv"
+REVIEWS="$TMPROOT/reviews.tsv"
+# shellcheck disable=SC2034 # Set by the extracted scheduler recovery helpers on fatal review failures.
+SCHEDULER_FAILURE_REASON=""
+mkdir -p "$SUMMARY_ROOT" "$PHASE_REVIEW_ROOT"
+
+ISSUE_WORKTREE="$TMPROOT/issue-worktree"
+git init -q "$ISSUE_WORKTREE"
+git -C "$ISSUE_WORKTREE" config user.name "Fixture"
+git -C "$ISSUE_WORKTREE" config user.email "fixture@example.com"
+printf 'base\n' > "$ISSUE_WORKTREE/file.txt"
+git -C "$ISSUE_WORKTREE" add file.txt
+git -C "$ISSUE_WORKTREE" commit -q -m "base"
+before=$(git -C "$ISSUE_WORKTREE" rev-parse HEAD)
+printf 'after\n' > "$ISSUE_WORKTREE/file.txt"
+git -C "$ISSUE_WORKTREE" commit -aq -m "after"
+after=$(git -C "$ISSUE_WORKTREE" rev-parse HEAD)
+
+cat > "$PLAN_JSON" <<JSON
+{
+  "chains": [
+    {
+      "name": "resume-fixture",
+      "chain_run_id": "chain-683",
+      "issues": [
+        {
+          "number": 68301,
+          "issue_run_id": "issue-683",
+          "issue_worktree": "$ISSUE_WORKTREE"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+cat > "$RUN_STATE_JSON" <<JSON
+{
+  "chains": [
+    {
+      "name": "resume-fixture",
+      "chain_run_id": "chain-683",
+      "issues": [
+        {
+          "number": 68301,
+          "issue_run_id": "issue-683",
+          "status": "running",
+          "issue_worktree": "$ISSUE_WORKTREE"
+        }
+      ]
+    }
+  ],
+  "phase_reviews": []
+}
+JSON
+
+summary="$SUMMARY_ROOT/resume-fixture-issue-68301-issue-683.json"
+cat > "$summary" <<JSON
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "completed",
+  "exit_code": 0,
+  "run_id": "$RUN_ID",
+  "chain_run_id": "chain-683",
+  "issue_run_id": "issue-683",
+  "issue_number": 68301,
+  "commit_before": "$before",
+  "commit_after": "$after",
+  "duration_s": 3,
+  "tests": [],
+  "lints": [],
+  "builds": []
+}
+JSON
+
+reconcile_resume_issue_summaries 0 "resume-fixture" "chain-683" "required" 1 \
+  || fail "reconciliation unexpectedly failed"
+
+jq -e --arg summary "$summary" --arg after "$after" '
+  .chains[0].issues[0].status == "completed"
+  and .chains[0].issues[0].summary == $summary
+  and .chains[0].issues[0].commit_after == $after
+' "$RUN_STATE_JSON" >/dev/null || fail "state was not reconciled from summary"
+
+grep -q '^outcome	chain-683-issue-683	' "$REVIEWS" \
+  || fail "required outcome review was not run during reconciliation"
+
+grep -q 'reconciled_from_summary' "$EVENTS" \
+  || fail "completion event did not record summary reconciliation"
+
+git -C "$ISSUE_WORKTREE" reset -q --hard "$before"
+mark_issue_state "issue-683" running "" "" "" ""
+: > "$EVENTS"
+if reconcile_resume_issue_summaries 0 "resume-fixture" "chain-683" "required" 1; then
+  :
+else
+  fail "unrecoverable summary should be skipped, not treated as fatal"
+fi
+
+jq -e '.chains[0].issues[0].status == "running"' "$RUN_STATE_JSON" >/dev/null \
+  || fail "unreachable summary commit should not mark the issue completed"
+
+printf 'PASS: chain resume summary reconciliation\n'


### PR DESCRIPTION
## Summary

- reconcile stale `running` chain issues from completed worker summaries during `--resume`
- preserve required outcome phase review before marking recovered issues complete
- document resume behavior and add fixture coverage for the recovery path

Closes #683

## Verification

- `bash scripts/test-fixtures/683-chain-resume-summary-reconcile/test-chain-resume-summary-reconcile.sh`
- `bash -n scripts/studio-chain-runner.sh scripts/test-fixtures/683-chain-resume-summary-reconcile/test-chain-resume-summary-reconcile.sh`
- `bash scripts/test-fixtures/649-chain-scheduler/test-chain-scheduler.sh`
- `bash scripts/test-fixtures/454-phase-review/test-phase-review.sh`
- `shellcheck -S error -x -P scripts scripts/studio-chain-runner.sh scripts/test-fixtures/683-chain-resume-summary-reconcile/test-chain-resume-summary-reconcile.sh`
- `scripts/lint-chain-workflow-docs.sh --staged`
- `scripts/lint-v2-bootstrap.sh --staged`
- `scripts/lint-host-agnostic.sh --staged` (existing `W_ARGUS_SECRET_SCOPE` warning)
- `scripts/lint-field-review-surfaces.sh --staged`
- pre-commit staged-diff review: `codex-reviewer` approved; `claude-reviewer` failed before review because temp payload file access was denied under `dontAsk`