### PR TITLE
Print checkpoint IDs for resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 scripts/manager-work-chain.sh prd-to-chain-automation # repo-side wrapper for the manager work-chain front door
 scripts/prd-intake-normalize.sh prd.md # normalize a PRD/transcript/issue brief into a planner-ready requirement packet
 scripts/prd-task-graph-synthesize.sh packet.md # turn a requirement packet into a validated scheduler graph
-/dev-studio checkpoint           # manager-shaped checkpoint routing; explicit role owns content
+/dev-studio checkpoint           # manager-shaped checkpoint routing; stdout is the checkpoint id for resume
 /dev-studio worker checkpoint    # worker-owned compact checkpoint; does not replace worker summary
 /dev-studio worker resume-checkpoint # resume worker checkpoint via manifest.json + context.md first
 /studio-help                     # open the v2 router docs
@@ -93,7 +93,7 @@ scripts/studio-chain-runner.sh --resume <run_id> --yes # resume state; reconcile
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview checkpoint-aware safe-boundary hooks
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show next supervisor action without state mutation
 scripts/studio-chain-telemetry-digest.sh --days 7     # weekly v1 counters, efficiency ratios, and bottlenecks from private chain-run telemetry
-scripts/studio-checkpoint.sh resume --latest --role worker # compact session resume; reads manifest.json + context.md before lazy drift checks
+scripts/studio-checkpoint.sh resume --checkpoint-id <id> --role worker # compact session resume by id; add --latest for branch-scoped lookup
 scripts/studio-staleness-triage.sh --json        # preview PM-surface stale/escalation/archive-candidate issue labels
 STUDIO_TRACK=<track>             # session-start shortcut for v2 track work
 /dev-studio host-adapter nodes   # day-2 fleet management — status, add, remove, health, sync, schedule

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -36,8 +36,10 @@ conversation context, not on-disk state.
 
 `checkpoint` and `resume-checkpoint` route through the selected role. Bare
 checkpoint invocations land in `manager`; role-qualified invocations are owned
-by that role. Checkpoints do not replace summaries, verdicts, release packets,
-QA/flow checklists, perf verdicts, or event logs.
+by that role. Create/update checkpoint commands print the checkpoint id, and
+that id is enough for `resume-checkpoint`. Checkpoints do not replace
+summaries, verdicts, release packets, QA/flow checklists, perf verdicts, or
+event logs.
 
 <!-- v2-dev-studio:manager-analyze -->
 ## Manager Analyze Routing

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -543,7 +543,7 @@ scripts/manager-work-chain.sh prd-to-chain-automation</code>
           </article>
           <article class="role">
             <h3>Checkpoint Resume</h3>
-            <p>Use bare checkpoint only for manager-shaped routing. Put the role before checkpoint when the role already owns the state; checkpoint artifacts do not replace summaries, verdicts, packets, checklists, or event logs.</p>
+            <p>Use bare checkpoint only for manager-shaped routing. Put the role before checkpoint when the role already owns the state; checkpoint artifacts do not replace summaries, verdicts, packets, checklists, or event logs. Create/update print the checkpoint id, and that id is enough for resume-checkpoint.</p>
             <code class="shell">/dev-studio checkpoint
 /dev-studio worker checkpoint
 /dev-studio reviewer resume-checkpoint</code>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,8 +85,8 @@ scripts/studio-chain-runner.sh --list                                      # lis
 scripts/studio-chain-runner.sh workflow-measurement-improvements --only chain-a --dry-run  # one manual shell per independent chain; dry-run before parallel execution
 scripts/studio-chain-telemetry-digest.sh --days 7                          # v1 counters, efficiency ratios, bottlenecks, and weekly digest from private chain-run telemetry
 scripts/lint-chain-workflow-docs.sh --staged                               # guard chain launcher docs, usage text, and fixtures; bypass with STUDIO_BYPASS_CHAIN_WORKFLOW_DOCS=1
-scripts/studio-checkpoint.sh create --role worker --goal "..." --next "..." # compact private checkpoint under per-project .runtime/v2/checkpoints
-scripts/studio-checkpoint.sh resume --latest --role worker                  # load manifest.json + context.md first, then inspect drift lazily
+scripts/studio-checkpoint.sh create --role worker --goal "..." --next "..." # compact private checkpoint; stdout prints the checkpoint id
+scripts/studio-checkpoint.sh resume --checkpoint-id <id> --role worker      # load manifest.json + context.md first, then inspect drift lazily
 scripts/codex-worker-exec.sh "<prompt>"                                    # internal Codex worker launcher: workspace-write + ~/.dev-studio + ephemeral + no prompts
 # Chain dry-runs show the selected git metadata strategy; sandboxed hosts use issue-local clones so commits stay inside the worker root.
 # Chain worktrees/results are namespaced under the run UUID; resume continues only the selected run, reconciles stale running issues from completed private summaries after required outcome review, and surfaces skipped/integrated/pending issue semantics.

--- a/scripts/studio-checkpoint.sh
+++ b/scripts/studio-checkpoint.sh
@@ -499,7 +499,7 @@ cmd_create_or_update() {
   write_index_entry "$index" "$project" "$checkpoint_id" "$now" "$role" "$default_bytes" "$default_tokens" "$from_id"
   pointer=$(latest_pointer_path "$latest_dir" "$role" "$branch")
   write_latest_pointer "$pointer" "$checkpoint_id" "$now" "$project" "$role" "$branch" "$head"
-  printf '%s\n' "$dir"
+  printf '%s\n' "$checkpoint_id"
 }
 
 cmd_resume() {

--- a/scripts/test-fixtures/568-checkpoint-runtime/test-checkpoint-runtime.sh
+++ b/scripts/test-fixtures/568-checkpoint-runtime/test-checkpoint-runtime.sh
@@ -26,7 +26,8 @@ run_checkpoint() {
   (cd "$REPO" && HOME="$HOME" ACHILLES_PROJECT=test-project "$ROOT/scripts/studio-checkpoint.sh" "$@")
 }
 
-created_dir=$(run_checkpoint create \
+root="$HOME/.dev-studio/test-project/.runtime/v2/checkpoints"
+created_id=$(run_checkpoint create \
   --role worker \
   --goal "Implement compact checkpoint runtime" \
   --completed "Path helpers added" \
@@ -34,11 +35,12 @@ created_dir=$(run_checkpoint create \
   --evidence "$REPO/file.txt" \
   --checkpoint-id ckpt-runtime-create)
 
+[ "$created_id" = "ckpt-runtime-create" ] || fail "create did not print checkpoint id"
+created_dir="$root/sessions/$created_id"
 [ -f "$created_dir/manifest.json" ] || fail "create did not write manifest"
 [ -f "$created_dir/context.md" ] || fail "create did not write context"
 [ ! -f "$created_dir/transcript.txt" ] || fail "checkpoint stored transcript"
 
-root="$HOME/.dev-studio/test-project/.runtime/v2/checkpoints"
 jq -e '.kind == "studio-v2-checkpoint-index" and (.checkpoints[] | select(.checkpoint_id == "ckpt-runtime-create"))' "$root/index.json" >/dev/null \
   || fail "index missing created checkpoint"
 jq -e '.checkpoint_id == "ckpt-runtime-create"' "$root/latest/worker/feature_test.json" >/dev/null \
@@ -56,13 +58,15 @@ if command -v check-jsonschema >/dev/null 2>&1; then
     || fail "created evidence failed schema validation"
 fi
 
-updated_dir=$(run_checkpoint update \
+updated_id=$(run_checkpoint update \
   --role worker \
   --goal "Continue compact checkpoint runtime" \
   --completed "Create flow works" \
   --next "Verify resume drift" \
   --checkpoint-id ckpt-runtime-update)
 
+[ "$updated_id" = "ckpt-runtime-update" ] || fail "update did not print checkpoint id"
+updated_dir="$root/sessions/$updated_id"
 jq -e '.role_state.supersedes == "ckpt-runtime-create"' "$updated_dir/state.json" >/dev/null \
   || fail "update did not record lineage"
 jq -e '.checkpoints[] | select(.checkpoint_id == "ckpt-runtime-create" and .status == "superseded")' "$root/index.json" >/dev/null \
@@ -82,7 +86,7 @@ printf '%s\n' "$drift_output" | grep -Eq 'Drift: (possible|confirmed)' || fail "
 jq -e 'select(.event == "checkpoint_resumed" and .drift.status != "unknown")' "$updated_dir/telemetry.jsonl" >/dev/null \
   || fail "resume drift telemetry missing"
 
-budget_dir=$(run_checkpoint create \
+budget_id=$(run_checkpoint create \
   --role worker \
   --goal "Budget warning checkpoint" \
   --completed "This deliberately creates a compact but warning-level default load." \
@@ -90,6 +94,7 @@ budget_dir=$(run_checkpoint create \
   --checkpoint-id ckpt-runtime-budget \
   --budget-max-bytes 120 \
   --budget-max-tokens 30 2>"$TMPROOT/budget.err")
+budget_dir="$root/sessions/$budget_id"
 grep -Fq 'largest section:' "$TMPROOT/budget.err" || fail "budget warning did not list largest sections"
 jq -e 'select(.event == "checkpoint_budget_warning")' "$budget_dir/telemetry.jsonl" >/dev/null \
   || fail "budget warning telemetry missing"
@@ -99,12 +104,13 @@ jq -e 'select(.event == "checkpoint_usefulness_recorded" and .usefulness.resume_
   || fail "usefulness telemetry missing"
 
 git -C "$REPO" checkout -q -b feature/chain
-manager_chain_dir=$(run_checkpoint create \
+manager_chain_id=$(run_checkpoint create \
   --role manager \
   --goal "Chain automation checkpoint" \
   --completed "Manager checkpoint for the active chain branch" \
   --next "Resume the chain branch" \
   --checkpoint-id ckpt-manager-chain)
+manager_chain_dir="$root/sessions/$manager_chain_id"
 run_checkpoint create \
   --role worker \
   --goal "Unrelated worker checkpoint" \


### PR DESCRIPTION
## Summary\n- Make  print the checkpoint ID instead of the checkpoint directory path.\n- Update the checkpoint usage docs and the runtime fixture to treat the ID as the resume token.\n\n## Verification\n- bash scripts/test-fixtures/568-checkpoint-runtime/test-checkpoint-runtime.sh\n- scripts/lint-skill-prose.sh --staged