### PR TITLE
Add commit discipline chain manifest

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T06:03:08Z",
+  "generated_at": "2026-05-07T06:46:23Z",
   "agents": [
 
   ]

--- a/chains/commit-discipline-taxonomy.yaml
+++ b/chains/commit-discipline-taxonomy.yaml
@@ -1,0 +1,37 @@
+# Commit discipline and release-taxonomy chain from the 2026-05-07 studio session.
+#
+# Discover:
+#   scripts/studio-chain-runner.sh --discover commit-discipline-taxonomy
+#
+# Dry-run:
+#   scripts/studio-chain-runner.sh commit-discipline-taxonomy --dry-run
+#
+# Reviewed dry-run:
+#   scripts/studio-chain-reviewed.sh commit-discipline-taxonomy --dry-run
+#
+# Manager front door:
+#   /dev-studio manager work-chain commit-discipline-taxonomy
+#
+# Scope:
+# - #689 is the umbrella and is intentionally excluded; the runner closes leaf
+#   issues after reviewed PR merges.
+# - #694 is a PM-surface reader bug discovered during verification and is
+#   intentionally outside this chain.
+# - #690 defines the policy vocabulary. #691, #692, and #693 depend on that
+#   vocabulary but can proceed independently after #690 lands.
+
+schema_version: 1
+chains:
+  - name: commit-discipline-taxonomy
+    base: main
+    branch: feature/commit-discipline-taxonomy
+    host: auto
+    phase_review: required
+    issues:
+      - 690
+      - number: 691
+        dependencies: [690]
+      - number: 692
+        dependencies: [690]
+      - number: 693
+        dependencies: [690]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T06:03:08Z",
+  "generated_at": "2026-05-07T06:46:22Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- Add `chains/commit-discipline-taxonomy.yaml` for #690-#693.
- Make #690 the policy vocabulary root; #691, #692, and #693 depend on it.
- Exclude umbrella #689 and side bug #694 from execution.

## Verification
- `scripts/studio-chain-runner.sh commit-discipline-taxonomy --dry-run`

## Notes
- Discovery currently renders object-form issue entries poorly in the compact issue column (`690,,,`), but the dry-run plan resolves all four issues and dependencies correctly.
- Pre-commit regenerated timestamp-only metadata in `docs-surface.json` and `_shared/schemas/capability-manifest.json`.
