### PR TITLE
studio chain: release-approval-schema

### DIFF
--- a/_shared/README.md
+++ b/_shared/README.md
@@ -35,7 +35,7 @@ Post Phase 2.5 Commit C, layout is frozen: later phases land new files in existi
 | `task-lifecycle.md` | Proposed → briefed → dispatched → in-progress → reviewed → merged → verified / rejected → archived. |
 | `brief-lifecycle.md` | Draft → ready → dispatched → debriefed → superseded / archived. |
 | `review-lifecycle.md` | Pending → in-progress → approved / flagged / blocked → acknowledged. |
-| `release-lifecycle.md` | Drafted → submitted → in-review → pending-developer-release → released / rejected / cancelled → archived. Phase 2.6. |
+| `release-lifecycle.md` | Drafted → submitted → approved → in-review → pending-developer-release → released / rejected / cancelled → archived. |
 | `feedback-lifecycle.md` | Ingested → triaged → linked → resolved / dismissed → archived. Minimal landing in 2.6; knowledge-layer expansion in 2.7. |
 
 ## `schemas/` — structured data shapes

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T08:50:54Z",
+  "generated_at": "2026-05-07T16:51:05Z",
   "agents": [
 
   ]

--- a/_shared/schemas/release.md
+++ b/_shared/schemas/release.md
@@ -4,11 +4,11 @@ description: YAML shape for TestFlight / App Store release artifacts under plans
 type: reference
 ---
 
-# Release Schema (`release@1.3.0`)
+# Release Schema (`release@1.4.0`)
 
 Per-release artifact written to `~/.dev-studio/<project>/plans/releases/<release-id>.yaml`. One file per build submitted to a release channel (TestFlight or App Store). Authored by `/achilles push-tf` or `/achilles app-store`; updated by `scripts/appstore-watch.sh` as the release transitions states.
 
-Version 1.3.0 is non-breaking — adds `withdrawn` and `superseded` lifecycle states plus optional replacement-lineage fields for withdrawn-build hotfixes and post-release corrections. `min_reader: 1.0.0` keeps the entire active fleet compatible.
+Version 1.4.0 is non-breaking - adds an explicit `approved` lifecycle state plus approval metadata (`approved_at`, `approved_by`, `approval_review_head_sha`, `approval_review_comment_url`) so the release artifact can carry the studio approval gate without a parallel file. Existing 1.3.0 artifacts remain readable because the new fields are optional and default to `null`. `min_reader: 1.0.0` keeps the entire active fleet compatible.
 
 Release state transitions governed by `state-machines/release-lifecycle.md` (landed alongside this schema in Phase 2.6 Commit B).
 
@@ -22,7 +22,7 @@ schema_version:
   deprecated_at: null
 id: 0190f52a-9000-7f01-8aaa-77fe8fa99bbb        # UUIDv7
 channel: testflight                              # testflight | appstore
-state: submitted                                 # drafted | submitted | in-review | pending-developer-release | released | withdrawn | superseded | rejected | cancelled | archived
+state: submitted                                 # drafted | submitted | approved | in-review | pending-developer-release | released | withdrawn | superseded | rejected | cancelled | archived
 build_number: 3047
 version: "1.12.0"
 tag: "TF-3047"                                   # GitHub release tag
@@ -30,6 +30,10 @@ commit_sha: "a1b2c3d4e5f60718293a4b5c6d7e8f90"
 submitted_at: 2026-04-22T14:00:00Z
 last_state_checked_at: 2026-04-22T14:32:11Z
 released_at: null
+approved_at: null
+approved_by: null
+approval_review_head_sha: null
+approval_review_comment_url: null
 replaced_by: null                                # 1.1.0; release-id of the build that replaced this one (cancel→replace flow); null otherwise
 cancelled_reason: null                           # 1.1.0; free-text reason populated when state == cancelled; null otherwise
 replaces: null                                   # 1.3.0; release-id this build replaces; null for first submission in a lineage
@@ -75,6 +79,10 @@ notes: null
 | `submitted_at` | RFC3339 UTC | yes | When the build was submitted to ASC. |
 | `last_state_checked_at` | RFC3339 UTC \| null | yes | Null until first watcher poll. |
 | `released_at` | RFC3339 UTC \| null | yes | Set when state transitions to `released`. |
+| `approved_at` | RFC3339 UTC \| null | no (1.4.0) | Set when state transitions to `approved`; null until the studio approval gate passes. |
+| `approved_by` | string \| null | no (1.4.0) | Writer identity that recorded the approval transition. Use the release-manager or operator handle that marked the release approved. |
+| `approval_review_head_sha` | string \| null | no (1.4.0) | HEAD SHA reviewed by the approval gate. |
+| `approval_review_comment_url` | string \| null | no (1.4.0) | Canonical URL for the review-gate comment, or an equivalent stable audit reference. |
 | `tasks` | array of UUIDv7 | yes | Task-ids shipped in this release. Bidirectional with `task.links.release`. |
 | `reviews` | array of UUIDv7 | yes | Pre-release review artifacts (e.g. release-gate reviews). |
 | `github_pr` | object \| null | no | App Store source PR opened from the submitted branch to `main`; merged with a merge commit only after `READY_FOR_SALE`. Null for TestFlight and for legacy artifacts. |
@@ -90,30 +98,34 @@ notes: null
 
 ### `testflight`
 
-External / internal testing. State machine typically: `drafted → submitted → released` (TestFlight processes builds without review). `appstore_state` field from ASC is still meaningful (build-processing states — `PROCESSING`, `INVALID_BINARY`, etc.).
+External / internal testing. State machine typically: `drafted → submitted → approved → released` (TestFlight processes builds without formal App Store review once the studio approval gate has passed). `appstore_state` field from ASC is still meaningful (build-processing states — `PROCESSING`, `INVALID_BINARY`, etc.).
 
 ### `appstore`
 
-Production submission. Full state machine including `in-review`, `pending-developer-release`, `rejected`. `scripts/appstore-watch.sh` polls and drives state transitions.
+Production submission. Full state machine including `approved`, `in-review`, `pending-developer-release`, `rejected`. `scripts/appstore-watch.sh` polls and drives state transitions.
 
 ## Lifecycle
 
 See `state-machines/release-lifecycle.md`. Summary:
 
 ```
-drafted → submitted → in-review → pending-developer-release → released
+drafted → submitted → approved → in-review → pending-developer-release → released
                                                                 → superseded
                                                                 → archived
 submitted → withdrawn  (developer withdrew before approval; terminal for that artifact)
+submitted → approved   (release-manager records the studio approval gate)
+approved → released    (TestFlight may skip formal App Store review after approval)
                                 → rejected
 any non-terminal → cancelled
-submitted → released   (TestFlight processes without formal review)
+approved → in-review   (App Store review begins after studio approval)
 any terminal → archived (compact sweep)
 ```
 
 Transitions emit `release_state_changed` (new event catalog entry landing alongside the state machine).
 
 ## Replacement lineage
+
+`approved` is the studio approval gate. It is written by the release-manager after the approval review comment records the green light, and it is distinct from Apple's own `pending-developer-release` wording.
 
 Use `withdrawn` for a build the developer intentionally pulls before approval. This is distinct from `rejected` (Apple rejected it) and `cancelled` (local/user abort before the release train reached ASC terminal semantics). A withdrawn artifact remains audit-visible; the replacement artifact sets `replaces: <withdrawn-release-id>`, and the withdrawn artifact sets `superseded_by: <replacement-release-id>`.
 
@@ -157,6 +169,7 @@ Active watcher state files (`pending-appstore-review.json`) migrate into the per
 
 | Version | Landed | Changes |
 |---|---|---|
+| 1.4.0 | 2026-05-07 | Non-breaking: add `approved` plus approval metadata (`approved_at`, `approved_by`, `approval_review_head_sha`, `approval_review_comment_url`) so release artifacts can carry the studio approval gate in-file (#700). |
 | 1.3.0 | 2026-05-06 | Non-breaking: add `withdrawn` and `superseded` states plus optional `replaces` / `superseded_by` lineage fields for withdrawn-build hotfixes and released-build corrections (#190). |
 | 1.2.0 | 2026-05-05 | Non-breaking: add optional `github_pr`, `asc_metadata.finalize_pr_merged`, and `slack.pr_reply_ts` fields for App Store submission PR lifecycle (#164). |
 | 1.1.0 | 2026-04-27 | Non-breaking: add optional `replaced_by` (release-id pointer) and `cancelled_reason` (free text) fields for the cancel-and-replace flow that Nabu (#214) consumes (#247 Stage C deliverable 2). |

--- a/_shared/state-machines/release-lifecycle.md
+++ b/_shared/state-machines/release-lifecycle.md
@@ -14,8 +14,9 @@ Every release routed through the studio — TestFlight or App Store — traverse
 |---|---|---|
 | `drafted` | Release artifact created but not yet submitted to ASC. | Achilles `push-tf` / `app-store` modes pre-upload. |
 | `submitted` | Build uploaded to App Store Connect; ASC processing begins. | Achilles release modes post-upload. |
+| `approved` | Studio approval recorded for the submitted release. This is the release-manager gate, not Apple review. | `release-manager` after the approval review gate records the green light and approval metadata. |
 | `in-review` | Apple has started formal review (App Store channel only). | `scripts/appstore-watch.sh` on ASC state `IN_REVIEW`. |
-| `pending-developer-release` | Apple approved; awaiting developer release (App Store channel only). This is not live and must not merge the source PR. | `scripts/appstore-watch.sh` on ASC state `PENDING_DEVELOPER_RELEASE`. |
+| `pending-developer-release` | Apple has approved the submission in ASC; awaiting the developer release action. This is the Apple holdpoint, not the studio approval gate. | `scripts/appstore-watch.sh` on ASC state `PENDING_DEVELOPER_RELEASE`. |
 | `released` | Live on the channel. TestFlight: processed + available to testers. App Store: shipped to production. App Store source PR merge and GitHub release publication happen only here. | `scripts/appstore-watch.sh` on ASC state `READY_FOR_SALE` (App Store) or `PROCESSED` for TestFlight. |
 | `withdrawn` | Developer withdrew the submitted build before approval or release. The artifact is terminal but remains the audit anchor for a replacement. | Explicit withdrawal by release-manager/user after ASC submission. |
 | `superseded` | Previously released artifact preserved for audit after a later release replaces the active pointer. | Release-manager correction path after the replacement is live. |
@@ -27,8 +28,9 @@ Every release routed through the studio — TestFlight or App Store — traverse
 
 ```
 drafted               → submitted                 : build uploaded to ASC.
-submitted             → in-review                 : ASC state IN_REVIEW (App Store only).
-submitted             → released                  : ASC state PROCESSED / READY_FOR_SALE.
+submitted             → approved                  : release-manager records the studio approval gate.
+approved              → in-review                 : ASC state IN_REVIEW (App Store only).
+approved              → released                  : ASC state PROCESSED / READY_FOR_SALE (TestFlight only).
 submitted             → withdrawn                 : developer withdrew before approval/release.
 in-review             → pending-developer-release : ASC state PENDING_DEVELOPER_RELEASE.
 in-review             → rejected                  : ASC state DEVELOPER_REJECTED / REJECTED.
@@ -45,14 +47,19 @@ superseded            → archived                  : compact sweep.
 
 **Channel-specific notes:**
 
-- **TestFlight channel** typically transitions `drafted → submitted → released`. ASC may emit build-processing states (`PROCESSING`, `INVALID_BINARY`) during `submitted`; these stay inside `submitted` until a terminal TF state is observed.
-- **App Store channel** has the full review flow. `pending-developer-release` is the holdpoint where the release awaits the developer to push the "Release" button; it is not a merge signal. `READY_FOR_SALE` is the first unambiguous live signal and triggers the source PR merge with `gh pr merge --merge`.
+- **TestFlight channel** typically transitions `drafted → submitted → approved → released`. ASC may emit build-processing states (`PROCESSING`, `INVALID_BINARY`) during `submitted`; these stay inside `submitted` until a terminal TF state is observed.
+- **App Store channel** has the full review flow. `approved` records the studio gate before App Store review begins. `pending-developer-release` is the holdpoint where ASC has approved the build and the developer must push the "Release" button; it is not a merge signal. `READY_FOR_SALE` is the first unambiguous live signal and triggers the source PR merge with `gh pr merge --merge`.
 
 ## App Store PR Lifecycle
 
 `/fullSendToAppStore` creates or reuses a PR from the submitted source branch to `main` immediately after the watcher marker is armed. PR creation is idempotent per source branch. If a different source branch already has a pending App Store PR, the submission continues and the user is notified that a separate PR is being raised.
 
 The watcher keeps the PR open through `PENDING_DEVELOPER_RELEASE`. On `READY_FOR_SALE`, it publishes the draft GitHub release, updates the Slack thread link from the PR URL to the GitHub release URL when possible, includes `release_notes_summary` in the final Slack reply when the marker has one, then merges the PR with a merge commit. If `gh pr merge --merge` fails, the watcher posts `PR merge failed — conflicts detected. Manual resolution needed.` to the Slack thread and stops without attempting a rebase.
+
+`submitted → approved` owns the studio approval side effects:
+
+- Release-manager writes `approved_at`, `approved_by`, `approval_review_head_sha`, and `approval_review_comment_url` into the release artifact.
+- The approval review comment must identify the gate result and the release head SHA that was reviewed.
 
 ## Required fields per transition event
 
@@ -100,8 +107,9 @@ Announcement continuity: update the existing announcement parent/thread when a b
 stateDiagram-v2
   [*] --> drafted
   drafted --> submitted: upload complete
-  submitted --> in_review: ASC IN_REVIEW
-  submitted --> released: TF PROCESSED / AS READY_FOR_SALE
+  submitted --> approved: studio approval gate recorded
+  approved --> in_review: ASC IN_REVIEW
+  approved --> released: TF PROCESSED / AS READY_FOR_SALE
   submitted --> withdrawn: developer withdrew
   in_review --> pending_developer_release: ASC PENDING_DEVELOPER_RELEASE
   in_review --> rejected: ASC DEVELOPER_REJECTED

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T08:50:54Z",
+  "generated_at": "2026-05-07T16:51:04Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/190-release-replacement-lifecycle/test-release-replacement-lifecycle.sh
+++ b/scripts/test-fixtures/190-release-replacement-lifecycle/test-release-replacement-lifecycle.sh
@@ -11,12 +11,19 @@ fail() {
   exit 1
 }
 
-grep -Fq 'release@1.3.0' "$SCHEMA" || fail "release schema version was not bumped"
+grep -Fq 'release@1.4.0' "$SCHEMA" || fail "release schema version was not bumped"
+grep -Fq 'approved_at' "$SCHEMA" || fail "schema does not document approval timestamp"
+grep -Fq 'approved_by' "$SCHEMA" || fail "schema does not document approval writer"
+grep -Fq 'approval_review_head_sha' "$SCHEMA" || fail "schema does not document approval review head sha"
+grep -Fq 'approval_review_comment_url' "$SCHEMA" || fail "schema does not document approval review comment reference"
 grep -Fq 'withdrawn' "$SCHEMA" || fail "schema does not document withdrawn state"
 grep -Fq 'superseded' "$SCHEMA" || fail "schema does not document superseded state"
 grep -Fq 'replaces' "$SCHEMA" || fail "schema does not document replacement forward pointer"
 grep -Fq 'superseded_by' "$SCHEMA" || fail "schema does not document replacement back pointer"
 
+grep -Fq 'submitted             → approved' "$LIFECYCLE" || fail "missing submitted to approved transition"
+grep -Fq 'approved              → in-review' "$LIFECYCLE" || fail "missing approved to in-review transition"
+grep -Fq 'studio approval gate' "$LIFECYCLE" || fail "missing studio approval gate wording"
 grep -Fq 'submitted             → withdrawn' "$LIFECYCLE" || fail "missing submitted to withdrawn transition"
 grep -Fq 'released              → superseded' "$LIFECYCLE" || fail "missing released to superseded transition"
 grep -Fq '[WITHDRAWN] <tag>' "$LIFECYCLE" || fail "missing GitHub release withdrawal title convention"


### PR DESCRIPTION
Automated chain PR for `release-approval-schema`.

Run by `scripts/studio-chain-runner.sh`.

Chain run: `019e0327-d667-73e8-a324-d57a708e2675`
Chain-run UUID: `019e0327-d945-78b1-ae68-a023d3a4b4b3`
Private report: local only; resolve by run ID on the machine that ran the chain.

Review gate: `scripts/pr-headless-review.sh <pr> --method auto`.