### PR TITLE
Fix stale chain issue state after PR finalization

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T16:51:05Z",
+  "generated_at": "2026-05-07T17:14:26Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T16:51:04Z",
+  "generated_at": "2026-05-07T17:14:26Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -668,6 +668,19 @@ mark_issue_integrated() {
     '(.chains[].issues[] | select(.issue_run_id == $issue_run_id) | .integrated) = true'
 }
 
+mark_chain_issues_completed_after_pr() {
+  local chain_run_id="$1" commit_after="${2:-}"
+  update_state_jq \
+    --arg chain_run_id "$chain_run_id" \
+    --arg after "$commit_after" \
+    '(.chains[] | select(.chain_run_id == $chain_run_id) | .issues[]) |= (
+       .status = "completed"
+       | .integrated = true
+       | if $after == "" then . else .commit_after = $after end
+       | del(.failure_reason)
+     )'
+}
+
 sanitize_checkpoint_component() {
   printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_' | sed 's/^_*//; s/_*$//; s/__/_/g'
 }
@@ -4068,7 +4081,9 @@ for ((idx = 0; idx < chain_count; idx++)); do
 
   finalize_chain_pr "$name" "$branch" "$chain_worktree" "$base" "$chain_run_id" "$host"
   chain_duration=$(duration_since "$chain_started_at")
+  final_chain_head=$(git -C "$chain_worktree" rev-parse HEAD 2>/dev/null || true)
   mark_chain_state "$chain_run_id" completed "$FINAL_PR_URL"
+  mark_chain_issues_completed_after_pr "$chain_run_id" "$final_chain_head"
   emit_chain_event chain_completed "" "$RUN_ID" "$chain_run_id" "" completed "$chain_duration" \
     "$(jq -cn --arg name "$name" --arg pr_url "$FINAL_PR_URL" '{chain:$name, pr_url:(if $pr_url == "" then null else $pr_url end)}')"
 

--- a/scripts/test-fixtures/700-chain-pr-finalize-state/test-chain-pr-finalize-state.sh
+++ b/scripts/test-fixtures/700-chain-pr-finalize-state/test-chain-pr-finalize-state.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verifies successful chain PR finalization repairs stale per-issue failure state.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-pr-finalize-state.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+helper_block=$(awk '
+  /^update_state_jq\(\)/ { capture=1 }
+  /^sanitize_checkpoint_component\(\)/ { capture=0 }
+  capture { print }
+' "$ROOT/scripts/studio-chain-runner.sh")
+
+eval "$helper_block"
+
+iso_ts_now() { printf '2026-05-07T00:00:00Z\n'; }
+
+RUN_STATE_JSON="$TMPROOT/state.json"
+after="defd4d78216a89f368eb7945e28a9fa08d7a04d5"
+
+cat > "$RUN_STATE_JSON" <<JSON
+{
+  "schema_version": 1,
+  "run_id": "run-700",
+  "updated_at": "2026-05-07T00:00:00Z",
+  "chains": [
+    {
+      "name": "release-approval-schema",
+      "chain_run_id": "chain-700",
+      "status": "completed",
+      "pr_url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/pull/704",
+      "issues": [
+        {
+          "number": 700,
+          "issue_run_id": "issue-700",
+          "status": "failed",
+          "integrated": false,
+          "commit_before": "5b411e425c036733026c78329bb3cf6eef176243",
+          "commit_after": "5b411e425c036733026c78329bb3cf6eef176243",
+          "failure_reason": "worker_exited_1"
+        }
+      ]
+    }
+  ]
+}
+JSON
+
+mark_chain_issues_completed_after_pr "chain-700" "$after"
+
+jq -e --arg after "$after" '
+  .chains[0].issues[0].status == "completed"
+  and .chains[0].issues[0].integrated == true
+  and .chains[0].issues[0].commit_after == $after
+  and (.chains[0].issues[0] | has("failure_reason") | not)
+' "$RUN_STATE_JSON" >/dev/null || fail "finalized PR did not repair stale issue state"
+
+printf 'PASS: chain PR finalization repairs issue state\n'


### PR DESCRIPTION
## Problem
A recovered chain can merge its chain PR and close the GitHub issue while the persisted per-issue state still says the earlier child attempt failed. That is what happened in run `019e0327-d667-73e8-a324-d57a708e2675`: PR #704 merged and closed #700, but `state.json` still reported `#700=failed`.

## Solution
- Mark all issues in a successfully finalized chain as `completed` and `integrated` after the chain PR finalizes.
- Stamp the final chain head into `commit_after` and clear stale `failure_reason` values.
- Add a focused regression fixture for the stale failed issue shape.

## Verification
- `bash scripts/test-fixtures/700-chain-pr-finalize-state/test-chain-pr-finalize-state.sh`
- `bash scripts/test-fixtures/683-chain-resume-summary-reconcile/test-chain-resume-summary-reconcile.sh`
- `bash -n scripts/studio-chain-runner.sh scripts/test-fixtures/700-chain-pr-finalize-state/test-chain-pr-finalize-state.sh`
- `git diff --check`

## Notes
This fixes future finalization writes. The already-running local run may still need a resume after stale-lock cleanup so its existing state file gets rewritten.