### PR TITLE
bugfix-shipped: normalize studio feedback home

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T17:14:26Z",
+  "generated_at": "2026-05-07T17:25:52Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T17:14:26Z",
+  "generated_at": "2026-05-07T17:25:52Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-paths.sh
+++ b/scripts/lib-paths.sh
@@ -494,6 +494,30 @@ _lp_load_project_env() {
   . "$env_file"
 }
 
+# Resolve the stable home for studio-self feedback/analysis artifacts. Host
+# launchers may run with a synthetic HOME (for example ~/.codex-homes/...), but
+# manager-analyze runs from the login home so feedback writers must land there
+# too. Tests and intentional isolation runs can opt out.
+resolve_feedback_data_home() {
+  case "${STUDIO_BYPASS_FEEDBACK_LOGIN_HOME:-0}" in
+    1|true|TRUE|yes|YES)
+      printf '%s\n' "${HOME:-}"
+      return 0
+      ;;
+  esac
+
+  if studio_home_is_synthetic "${HOME:-}"; then
+    local login_home
+    login_home=$(resolve_user_login_home 2>/dev/null || true)
+    if [ -n "$login_home" ] && [ -d "$login_home" ]; then
+      printf '%s\n' "$login_home"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "${HOME:-}"
+}
+
 # Studio-self feedback inbox for a given source-project slug. Feedback records
 # authored in any project route here (see CLAUDE.md "Analysis sessions and
 # privacy"); generic-dev-studio is the destination because that's where the
@@ -505,13 +529,13 @@ resolve_feedback_inbox_for() {
 
 # Root of the studio-self feedback inbox (parent of per-source subfolders).
 resolve_feedback_inbox_root() {
-  printf '%s\n' "$(resolve_project_root_for generic-dev-studio)/feedback-inbox"
+  printf '%s\n' "$(resolve_feedback_data_home)/.dev-studio/generic-dev-studio/feedback-inbox"
 }
 
 # Studio-self analysis root — private, never-committed reports (see CLAUDE.md
 # "Analysis sessions and privacy" → "Detailed analysis report").
 resolve_analysis_root() {
-  printf '%s\n' "$(resolve_project_root_for generic-dev-studio)/analysis"
+  printf '%s\n' "$(resolve_feedback_data_home)/.dev-studio/generic-dev-studio/analysis"
 }
 
 # Friendly display name. Auto-derived in this order:

--- a/scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
+++ b/scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
@@ -6,6 +6,7 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 RUN="$ROOT/scripts/dev-studio-ingest-resolve.sh"
 TMPROOT=$(mktemp -d -t ingest-resolver.XXXXXX)
 trap 'rm -rf "$TMPROOT"' EXIT
+export STUDIO_BYPASS_FEEDBACK_LOGIN_HOME=1
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -23,6 +24,12 @@ make_repo() {
 make_repo "$TMPROOT/generic-dev-studio"
 make_repo "$TMPROOT/sample-app"
 printf 'workflow gap\n' > "$TMPROOT/message.md"
+mkdir -p "$TMPROOT/bin" "$TMPROOT/login-home" "$TMPROOT/.codex-homes/personal"
+cat > "$TMPROOT/bin/dscl" <<EOF
+#!/usr/bin/env bash
+printf 'NFSHomeDirectory: %s\n' "$TMPROOT/login-home"
+EOF
+chmod +x "$TMPROOT/bin/dscl"
 
 studio_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/generic-dev-studio")
 printf '%s\n' "$studio_json" | jq -e \
@@ -76,6 +83,20 @@ printf '%s\n' "$cross_to_json" | jq -e \
    and .requires_privacy_scrub == true' >/dev/null || {
   printf '%s\n' "$cross_to_json" >&2
   fail "--to generic-dev-studio did not route cross-context to Forge"
+}
+
+synthetic_home_json=$(
+  env -u STUDIO_BYPASS_FEEDBACK_LOGIN_HOME \
+    HOME="$TMPROOT/.codex-homes/personal" \
+    PATH="$TMPROOT/bin:$PATH" \
+    "$RUN" --cwd "$TMPROOT/sample-app" --scope studio
+)
+printf '%s\n' "$synthetic_home_json" | jq -e \
+  --arg login_home "$TMPROOT/login-home" \
+  '.scope == "studio"
+   and .artifact_root == ($login_home + "/.dev-studio/generic-dev-studio/feedback-inbox/sample-app")' >/dev/null || {
+  printf '%s\n' "$synthetic_home_json" >&2
+  fail "synthetic HOME studio feedback did not resolve through login home"
 }
 
 explicit_project_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --to other-app)

--- a/scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
+++ b/scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
@@ -7,6 +7,7 @@ FIXTURE_DIR="$ROOT/scripts/test-fixtures/608-feedback-analyze-ingest"
 RUN="$ROOT/scripts/analyze-feedback-ingest.sh"
 TMPROOT=$(mktemp -d -t feedback-analyze-ingest.XXXXXX)
 trap 'rm -rf "$TMPROOT"' EXIT
+export STUDIO_BYPASS_FEEDBACK_LOGIN_HOME=1
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2

--- a/scripts/test-fixtures/609-ingest-feedback-consolidation/test-ingest-feedback-consolidation.sh
+++ b/scripts/test-fixtures/609-ingest-feedback-consolidation/test-ingest-feedback-consolidation.sh
@@ -16,6 +16,7 @@ fail() {
 [ -x "$RUN" ] || fail "scripts/ingest-feedback.sh is not executable"
 
 export HOME="$TMPROOT/home"
+export STUDIO_BYPASS_FEEDBACK_LOGIN_HOME=1
 export ACHILLES_PROJECT=generic-dev-studio
 INBOX="$HOME/.dev-studio/generic-dev-studio/feedback-inbox/sample-project"
 mkdir -p "$INBOX"

--- a/scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh
+++ b/scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh
@@ -24,6 +24,7 @@ fi
 
 export HOME="$TMPROOT/home"
 export STUDIO_BYPASS_ANALYZE_LOGIN_HOME=1
+export STUDIO_BYPASS_FEEDBACK_LOGIN_HOME=1
 PROJECT_CWD="$TMPROOT/sample-app"
 PROJECT_ROOT="$HOME/.dev-studio/sample-app"
 STUDIO_INBOX="$HOME/.dev-studio/generic-dev-studio/feedback-inbox/sample-app"


### PR DESCRIPTION
## Problem
Codex sessions can run with a synthetic HOME and route studio-feedback records into ~/.codex-homes/.../.dev-studio, while manager analyze normalizes to the login home and misses them.

## Solution
Normalize studio-self feedback inbox and analysis roots through the login home when HOME is synthetic. Keep STUDIO_BYPASS_FEEDBACK_LOGIN_HOME for isolated fixtures/debugging.

## Verification
- scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
- scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
- scripts/test-fixtures/609-ingest-feedback-consolidation/test-ingest-feedback-consolidation.sh
- scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh
- git diff --check
- bash -n on touched shell scripts
- zsh source smoke for scripts/lib-paths.sh
- scripts/lint-host-agnostic.sh --all (0 errors, existing .codex/capabilities.yaml warning)

## Notes
The two synthetic-home records from turnip-ios were manually ingested and matched to #705 before this PR.