### PR TITLE
chore: add control-plane context substrate chain

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T17:25:52Z",
+  "generated_at": "2026-05-07T18:14:19Z",
   "agents": [
 
   ]

--- a/chains/control-plane-context-substrate.yaml
+++ b/chains/control-plane-context-substrate.yaml
@@ -1,0 +1,25 @@
+# Control-plane context substrate chain.
+#
+# Parent issue:
+#   #710 Control-plane context substrate: canonical Studio home, host profiles,
+#   and path/auth enforcement.
+#
+# Dry-run:
+#   scripts/studio-chain-runner.sh chains/control-plane-context-substrate.yaml --dry-run
+#
+# Execute/resume the spec chain:
+#   scripts/studio-chain-runner.sh chains/control-plane-context-substrate.yaml --only control-plane-context-spec --attended
+#
+# Scope note:
+#   This manifest intentionally starts with the spec/inventory chain only. Add
+#   resolver, enforcement, and migration chains after #711/#712 produce reviewed
+#   contract and inventory outputs.
+
+schema_version: 1
+chains:
+  - name: control-plane-context-spec
+    base: main
+    branch: feature/control-plane-context-spec
+    host: auto
+    phase_review: required
+    issues: [711, 712]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T17:25:52Z",
+  "generated_at": "2026-05-07T18:14:19Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Problem
#710 has the substrate arc, but the first spec/inventory phase was not runnable through the chain runner.

## Solution
Add `chains/control-plane-context-substrate.yaml` with a single narrow chain for #711 and #712. The manifest keeps implementation phases out until the contract and inventory outputs are reviewed.

## Verification
- `scripts/studio-chain-runner.sh chains/control-plane-context-substrate.yaml --dry-run`
- `git diff --check`
- pre-commit hooks

## Notes
The phase intake plan was reviewed cleanly by `claude-reviewer` before creating issues/manifest. Review artifact: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-07-control-plane-context-intake-plan-review.md`.