### PR TITLE
bugfix-wip: load project env before GitHub home normalization

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T18:14:19Z",
+  "generated_at": "2026-05-07T18:23:55Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T18:14:19Z",
+  "generated_at": "2026-05-07T18:23:55Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-paths.sh
+++ b/scripts/lib-paths.sh
@@ -179,6 +179,7 @@ resolve_parent_home_for_github() {
 
 with_login_home_for_github() {
   [ "$#" -gt 0 ] || return 2
+  _lp_load_project_env 2>/dev/null || true
   local original_home="${HOME:-}" parent_home parent_host
   parent_home=$(resolve_parent_home_for_github)
   if [ -n "$parent_home" ] && [ "$parent_home" != "$original_home" ]; then

--- a/scripts/test-fixtures/464-parent-home-host/test-parent-home-host.sh
+++ b/scripts/test-fixtures/464-parent-home-host/test-parent-home-host.sh
@@ -62,6 +62,23 @@ if grep -q 'HOME normalized' "$TMPROOT/bypass.err"; then
   exit 1
 fi
 
+mkdir -p "$SYNTH_HOME/.dev-studio/generic-dev-studio/state"
+cat > "$SYNTH_HOME/.dev-studio/generic-dev-studio/state/env.sh" <<'SH'
+STUDIO_BYPASS_PARENT_HOME_FLIP=1
+SH
+
+: > "$GH_HOME_LOG"
+PATH="$BIN:$PATH" HOME="$SYNTH_HOME" ACHILLES_PROJECT=generic-dev-studio bash -c "
+  . '$ROOT/scripts/lib-paths.sh'
+  with_login_home_for_github gh auth status
+" >"$TMPROOT/project-env.out" 2>"$TMPROOT/project-env.err"
+
+grep -qx "$SYNTH_HOME" "$GH_HOME_LOG"
+if grep -q 'HOME normalized' "$TMPROOT/project-env.err"; then
+  printf 'project env bypass still emitted HOME normalization log\n' >&2
+  exit 1
+fi
+
 if command -v zsh >/dev/null 2>&1; then
   PATH="$BIN:$PATH" HOME="$SYNTH_HOME" zsh -c ". '$ROOT/scripts/lib-paths.sh'; resolve_current_studio_host" >"$TMPROOT/zsh.out"
   grep -qx 'codex' "$TMPROOT/zsh.out"


### PR DESCRIPTION
## Summary
- Load per-project env before GitHub HOME normalization runs.
- Add regression coverage for project env bypass under synthetic Codex HOME.
- Include hook-refreshed generated metadata timestamps.

## Verification
- scripts/test-fixtures/464-parent-home-host/test-parent-home-host.sh
- zsh -c 'source scripts/lib-paths.sh && resolve_current_studio_host unknown'
- git diff --check HEAD^ HEAD

## Review
- REVIEW.md walked before commit; no block/ask findings.
- shellcheck scripts/lib-paths.sh scripts/test-fixtures/464-parent-home-host/test-parent-home-host.sh reports two pre-existing informational findings in untouched lib-paths lines.