### PR TITLE
chore: prefer dev-studio work-chain guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,9 +310,17 @@ worktrees/branches) and keep dependency-ordered work sequential.
 Do not auto-spawn user shell sessions. Do not suggest parallelizing across:
 unclean phase-gate reviews, dependent phases, shared branch/index mutations,
 or work that has not been shaped enough to know its write boundaries. For
-studio chains, suggest `scripts/studio-chain-runner.sh <manifest> --only
-<chain> --dry-run` per shell first, then the non-dry-run command after the user
-accepts the shape.
+studio chains, prefer `/dev-studio manager work-chain <manifest-or-chain>
+--only <chain> --dry-run` per shell first, then the matching `/dev-studio
+manager work-chain ... --attended --yes` or default manager work-chain command
+after the user accepts the shape. Include script equivalents only as secondary
+automation/debug paths.
+
+When an attended or ingest session produces a plan work-chain, end with the
+next `/dev-studio manager work-chain ...` command the user can run. After each
+chain task completes, surface a compact progress recap: previous task, just
+completed task, what changed, next task/command, overall progress, and the
+current chain direction/goal.
 
 ## Auto-apply tiers (reduce user touchpoints)
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ For the long-running tracks, see [`THEMES.md`](THEMES.md). For longer-term visio
 /dev-studio manager reconcile    # project repo: sync emitted debriefs/reports into the task ledger
 /dev-studio manager analyze      # studio repo: telemetry/log analysis plus studio feedback triage
 /dev-studio manager work-chain prd-to-chain-automation # auto-run the PRD automation chain; bare call discovers available chains
+/dev-studio manager work-chain prd-to-chain-automation --dry-run # preferred preview path for attended planning
+/dev-studio manager work-chain --resume <run_id> --yes # preferred resume path from chain summaries/halt records
 scripts/manager-work-chain.sh prd-to-chain-automation # repo-side wrapper for the manager work-chain front door
 scripts/prd-intake-normalize.sh prd.md # normalize a PRD/transcript/issue brief into a planner-ready requirement packet
 scripts/prd-task-graph-synthesize.sh packet.md # turn a requirement packet into a validated scheduler graph

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T18:23:55Z",
+  "generated_at": "2026-05-07T18:40:28Z",
   "agents": [
 
   ]

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -66,7 +66,10 @@ supplies the task context and runtime slug.
      role routing. Manager ingest may suggest missing/refined inputs from
      PRD, Figma, issue, plan, or repo context already provided in the
      session/repo; it does not auto-fetch unavailable sources or decompose
-     planner-owned work.
+     planner-owned work. For `manager work-chain`, prefer the
+     `/dev-studio manager work-chain ...` command in user-facing next steps,
+     especially after ingest or attended planning; script paths are secondary
+     automation/debug equivalents.
    - `worker` -> bounded task contract in an isolated worktree.
    - `reviewer` -> plan, outcome, diff, PR, or release-packet review.
    - `perf` -> performance, battery, memory, thermal, network, or instrumentation evidence.

--- a/core/v2/skills/dev-studio/SKILL.md
+++ b/core/v2/skills/dev-studio/SKILL.md
@@ -62,13 +62,8 @@ the studio feedback inbox and do not replace the rest of the prompt.
 ## Release Manager Configure
 
 `/dev-studio release-manager configure` routes to the release-manager role and
-uses `scripts/release-manager-configure.sh` for project-scoped release
-notification setup. Slack is the first supported integration. Quick setup writes
-defaults the user can change later: TestFlight uses no `<!here>` by default,
-a brief parent message, threaded tester details, module grouping when useful,
-and technical notes at the end only when they affect testing. App Store release
-announcements remain optional and post to the configured releases channel when
-present.
+uses `scripts/release-manager-configure.sh` for project-scoped Slack release
+notification setup. Defaults stay editable and avoid TestFlight `<!here>`.
 
 <!-- v2-dev-studio:landing -->
 ## Bare Role Landing
@@ -79,14 +74,14 @@ direct invocation once the workflow is selected. `manager ingest` calls
 `scripts/dev-studio-ingest-resolve.sh`; `manager analyze` calls
 `scripts/manager-analyze.sh`; `manager reconcile` calls
 `scripts/manager-reconcile.sh`; `manager work-chain` calls
-`scripts/manager-work-chain.sh`. For chain orchestration, bare
-`scripts/studio-chain-runner.sh` now shows runnable chains, resumable runs, and
-next-action commands before any plan or resume action is chosen. Use
-`--discover <manifest|chain-name>` for filtered discovery; `/dev-studio manager
-work-chain prd-to-chain-automation` auto-runs the new PRD automation chain
-while bare `manager work-chain` still lands in discovery. Chain execution
-supports explicit `--attended` and `--unattended` modes; unattended runs avoid
-routine continue prompts and stop only on typed blockers after finite retries.
+`scripts/manager-work-chain.sh`. Bare `scripts/studio-chain-runner.sh` shows
+runnable chains, resumable runs, and next actions. Prefer `/dev-studio manager
+work-chain ...` in user-facing guidance; script commands are secondary
+automation/debug equivalents. Use `--discover <manifest|chain-name>` for
+filtered discovery; `/dev-studio manager work-chain prd-to-chain-automation`
+auto-runs that chain while bare `manager work-chain` lands in discovery. Chain
+execution supports `--attended` and `--unattended`; end attended/ingest
+work-chain planning with the next `/dev-studio manager work-chain ...` command.
 
 After a bare role landing, later bare subcommands may resolve through that
 active role when unambiguous in the same session. Store the resolved canonical

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T18:23:55Z",
+  "generated_at": "2026-05-07T18:40:28Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,6 +73,8 @@ scripts/studio-chain-runner.sh my-chain --dry-run                          # obj
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview role/branch-scoped checkpoint hooks
 scripts/studio-chain-runner.sh --discover                                  # bare invocation lists runnable chains, resumable runs, and next actions
 scripts/studio-chain-runner.sh --discover prd-to-chain-automation          # filtered discovery for one chain or manifest
+/dev-studio manager work-chain prd-to-chain-automation --dry-run           # preferred user-facing preview path
+/dev-studio manager work-chain --resume <run_id> --yes                     # preferred user-facing resume path from summaries/halt records
 scripts/manager-work-chain.sh prd-to-chain-automation --dry-run            # preview the named chain through the manager front door
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements     # unattended start/resume when state is safe and unambiguous
 scripts/studio-chain-runner.sh workflow-measurement-improvements --attended --yes # attended execution with explicit confirmation bypass

--- a/scripts/lint-chain-workflow-docs.sh
+++ b/scripts/lint-chain-workflow-docs.sh
@@ -59,6 +59,10 @@ check_public_docs() {
       E_CHAIN_DOC_DISCOVER 'document bare discovery before chain work starts'
     require_file_contains "$doc" 'scripts/studio-chain-runner.sh --discover prd-to-chain-automation' \
       E_CHAIN_DOC_FILTERED_DISCOVER 'document filtered discovery for a manifest or chain name'
+    require_file_contains "$doc" '/dev-studio manager work-chain prd-to-chain-automation --dry-run' \
+      E_CHAIN_DOC_DEV_STUDIO_PREVIEW 'document preferred dev-studio work-chain preview'
+    require_file_contains "$doc" '/dev-studio manager work-chain --resume <run_id> --yes' \
+      E_CHAIN_DOC_DEV_STUDIO_RESUME 'document preferred dev-studio work-chain resume'
     require_file_contains "$doc" 'scripts/manager-work-chain.sh prd-to-chain-automation --dry-run' \
       E_CHAIN_DOC_MANAGER_PREVIEW 'document manager front-door preview'
     require_file_contains "$doc" 'scripts/studio-chain-runner.sh --auto workflow-measurement-improvements' \
@@ -86,6 +90,10 @@ check_runner_contract() {
     E_CHAIN_RUNNER_DISCOVERY_ONLY 'bare runner invocation must remain non-mutating discovery'
   require_file_contains scripts/studio-chain-runner.sh 'Add a manifest or chain name to filter suggestions' \
     E_CHAIN_RUNNER_FILTER_COPY 'discovery output must explain filtered suggestions'
+  require_file_contains scripts/studio-chain-runner.sh '/dev-studio manager work-chain <chain> --dry-run' \
+    E_CHAIN_RUNNER_DEV_STUDIO_PREVIEW 'discovery output must prefer dev-studio manager preview commands'
+  require_file_contains scripts/studio-chain-runner.sh '## Chain Progress Recap' \
+    E_CHAIN_RUNNER_PROGRESS_RECAP 'chain runner must print compact task progress recaps'
   require_file_contains scripts/studio-chain-runner.sh '--auto is unattended' \
     E_CHAIN_RUNNER_AUTO_MODE 'auto mode must stay unattended unless the contract changes deliberately'
 }
@@ -102,6 +110,8 @@ check_manager_wrapper_contract() {
 check_fixtures() {
   require_file_contains scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh 'scripts/studio-chain-runner.sh" --discover prd-to-chain-automation' \
     E_CHAIN_FIXTURE_FILTERED_DISCOVER 'runner discovery fixture must cover filtered discovery'
+  require_file_contains scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh '/dev-studio manager work-chain field-telemetry-mvp --dry-run' \
+    E_CHAIN_FIXTURE_DEV_STUDIO_DISCOVER 'runner discovery fixture must assert preferred dev-studio commands'
   require_file_contains scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh 'filtered discovery included unrelated runnable chain' \
     E_CHAIN_FIXTURE_FILTER_NEGATIVE 'runner fixture must assert filtered discovery omits unrelated chains'
   require_file_contains scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh '"$RUN" --discover prd-to-chain-automation' \

--- a/scripts/manager-work-chain.sh
+++ b/scripts/manager-work-chain.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # manager-work-chain.sh — repo-side front door for work-chain discovery/start/resume.
 #
-# This stays thin on purpose: the manager shapes intent, then delegates the
-# actual execution and resumable-run machinery to studio-chain-runner.sh.
+# This stays thin on purpose: /dev-studio manager shapes intent, then delegates
+# the actual execution and resumable-run machinery to studio-chain-runner.sh.
 
 set -euo pipefail
 
@@ -31,6 +31,9 @@ can suggest runnable chains and resumable runs. Named chains default to
 unattended supervisor selection through scripts/studio-chain-runner.sh --auto.
 Use --discover [<manifest|chain-name>] for filtered, non-mutating discovery.
 All runner flags are passed through to scripts/studio-chain-runner.sh.
+
+Preferred user-facing entrypoint:
+  /dev-studio manager work-chain [<manifest|chain-name>] [runner-flags...]
 EOF
   exit 2
 }

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -207,9 +207,11 @@ discover_persisted_runs() {
       (.halt_records // []) as $halts
       | if ($halts | length) > 0 and (($halts | last | .next_command // "") != "") then ($halts | last | .next_command)
         elif ($halts | length) > 0 and (($halts | last | .halt_class // "") == "fatal") then "inspect halt record"
-        else "scripts/studio-chain-runner.sh --resume \($run_id) --yes"
+        else "/dev-studio manager work-chain --resume \($run_id) --yes"
         end
-    ' "$state" 2>/dev/null || printf 'scripts/studio-chain-runner.sh --resume %s --yes' "$run_id")
+    ' "$state" 2>/dev/null || printf '/dev-studio manager work-chain --resume %s --yes' "$run_id")
+    next_command=$(printf '%s\n' "$next_command" \
+      | sed "s#${SCRIPT_DIR}/studio-chain-runner.sh#/dev-studio manager work-chain#g; s#scripts/studio-chain-runner.sh#/dev-studio manager work-chain#g")
     printf '| `%s` | `%s` | `%s` | `%s` |\n' "$run_id" "$status" "$manifest" "$next_command" >> "$rows_tmp"
   done <<EOF
 $(find "$chain_root" -mindepth 2 -maxdepth 2 -name state.json -type f 2>/dev/null | sort)
@@ -270,7 +272,7 @@ discover_chain_manifests() {
       name=$(yq -r ".chains[$idx].name" "$manifest")
       [ -n "$ONLY_CHAIN" ] && [ "$name" != "$ONLY_CHAIN" ] && continue
       issues=$(yq -r ".chains[$idx].issues | join(\",\")" "$manifest")
-      command="scripts/manager-work-chain.sh $name --dry-run"
+      command="/dev-studio manager work-chain $name --dry-run"
       printf '| `%s` | `%s` | `%s` | `%s` |\n' "$rel_manifest" "$name" "${issues:-"-"}" "$command" >> "$rows_tmp"
     done
   done < "$manifest_list_tmp"
@@ -289,12 +291,14 @@ discover_chain_manifests() {
 print_discovery() {
   printf '# Studio Chain Discovery\n\n'
   printf -- '- Bare invocation is discovery-only; it never starts or resumes work.\n'
-  printf -- '- Add a manifest or chain name to filter suggestions: `scripts/studio-chain-runner.sh --discover prd-to-chain-automation`.\n\n'
+  printf -- '- Preferred user entrypoint: `/dev-studio manager work-chain`.\n'
+  printf -- '- Add a manifest or chain name to filter suggestions: `/dev-studio manager work-chain --discover prd-to-chain-automation`.\n\n'
   printf '## Next Actions\n\n'
-  printf -- '- Preview a chain: `scripts/manager-work-chain.sh <chain> --dry-run`\n'
-  printf -- '- Attended run: `scripts/studio-chain-runner.sh <manifest|chain-name> --attended --yes`\n'
-  printf -- '- Unattended run or safe resume: `scripts/studio-chain-runner.sh --auto <manifest|chain-name>`\n'
-  printf -- '- Resume a known run: `scripts/studio-chain-runner.sh --resume <run_id> --yes`\n\n'
+  printf -- '- Preview a chain: `/dev-studio manager work-chain <chain> --dry-run`\n'
+  printf -- '- Attended run: `/dev-studio manager work-chain <manifest|chain-name> --attended --yes`\n'
+  printf -- '- Unattended run or safe resume: `/dev-studio manager work-chain <manifest|chain-name>`\n'
+  printf -- '- Resume a known run: `/dev-studio manager work-chain --resume <run_id> --yes`\n\n'
+  printf 'Script equivalents remain available for automation: `scripts/manager-work-chain.sh ...` and `scripts/studio-chain-runner.sh ...`.\n\n'
   discover_persisted_runs
   discover_chain_manifests
   printf '\n'
@@ -3703,9 +3707,58 @@ integrate_issue_result() {
   fi
 }
 
+print_issue_progress_recap() {
+  local chain_name="$1" chain_run_id="$2" issue_run_id="$3" issue="$4" summary_file="${5:-}"
+  [ "$DRY_RUN" -eq 0 ] || return 0
+
+  if [ -z "$summary_file" ] || [ ! -f "$summary_file" ]; then
+    summary_file=$(summary_for_issue_run "$chain_name" "$issue" "$issue_run_id" 2>/dev/null || true)
+  fi
+
+  jq -r \
+    --arg chain_run_id "$chain_run_id" \
+    --arg issue_run_id "$issue_run_id" \
+    --arg run_id "$RUN_ID" \
+    --arg summary_file "$summary_file" \
+    --slurpfile summary "${summary_file:-/dev/null}" '
+      def task_label($task):
+        if $task == null then "None"
+        else "#\($task.number) \($task.title // "(untitled)") (`\($task.status // "unknown")`)"
+        end;
+      def summary_text:
+        ($summary[0] // {}) as $s
+        | ($s.functionality_delivered // $s.summary // null) as $text
+        | if $text == null then "Summary artifact: \($summary_file)"
+          elif ($text | type) == "array" then ($text | map(tostring) | join("; "))
+          else ($text | tostring)
+          end;
+      def signal_count($name):
+        ($summary[0] // {}) as $s
+        | (($s[$name] // []) | length);
+      (.chains[] | select(.chain_run_id == $chain_run_id)) as $chain
+      | ($chain.issues | to_entries) as $items
+      | (($items | map(select(.value.issue_run_id == $issue_run_id)) | .[0].key) // 0) as $idx
+      | ($items[$idx].value // {}) as $current
+      | (if $idx > 0 then $items[$idx - 1].value else null end) as $previous
+      | (($items | map(select(.key > $idx and (.value.status // "pending") != "completed")) | .[0].value) // null) as $next
+      | ([ $chain.issues[] | select((.status // "") == "completed") ] | length) as $completed
+      | ($chain.issues | length) as $total
+      | "## Chain Progress Recap\n\n"
+        + "- Previous task: \(task_label($previous))\n"
+        + "- Just completed: \(task_label($current))\n"
+        + "- What changed: \(summary_text)\n"
+        + "- Verification signals: tests \(signal_count("tests")), lints \(signal_count("lints")), builds \(signal_count("builds"))\n"
+        + "- Next task: \(task_label($next))\n"
+        + "- Overall progress: \($completed)/\($total) issues completed in `\($chain.name)`.\n"
+        + "- Direction: continue toward the chain goal on branch `\($chain.branch)` with phase review gates intact.\n"
+        + "- Preferred command if this session stops: `/dev-studio manager work-chain --resume \($run_id) --yes`\n"
+    ' "$RUN_STATE_JSON"
+  printf '\n'
+}
+
 process_completed_issue_result() {
   local chain_name="$1" branch="$2" chain_worktree="$3" issue="$4" git_metadata_strategy="$5" result_file="$6" chain_run_id="$7" issue_run_id="$8" checkpoint_mode="$9"
-  local result_status result_reason
+  local result_status result_reason summary_file
 
   result_status=$(jq -r '.status // "failed"' "$result_file")
   if [ "$result_status" != "completed" ]; then
@@ -3719,6 +3772,8 @@ process_completed_issue_result() {
     return 1
   fi
   mark_issue_integrated "$issue_run_id"
+  summary_file=$(jq -r '.summary // empty' "$result_file" 2>/dev/null || true)
+  print_issue_progress_recap "$chain_name" "$chain_run_id" "$issue_run_id" "$issue" "$summary_file"
   if [ "$checkpoint_mode" = "auto" ]; then
     if [ "$DRY_RUN" -eq 0 ]; then
       create_auto_checkpoint_after_issue "$checkpoint_mode" "$chain_name" "$branch" "$chain_worktree" "$chain_run_id" "$issue_run_id" "$issue" "$result_file"

--- a/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
+++ b/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
@@ -36,7 +36,7 @@ grep -q 'run-discovery-1' "$TMPROOT/out" || {
   cat "$TMPROOT/out" >&2
   exit 1
 }
-grep -q 'scripts/studio-chain-runner.sh --resume run-discovery-1 --yes' "$TMPROOT/out" || {
+grep -q '/dev-studio manager work-chain --resume run-discovery-1 --yes' "$TMPROOT/out" || {
   printf 'missing resume suggestion\n' >&2
   cat "$TMPROOT/out" >&2
   exit 1
@@ -46,12 +46,12 @@ grep -q 'chains/workflow-measurement-improvements.yaml' "$TMPROOT/out" || {
   cat "$TMPROOT/out" >&2
   exit 1
 }
-grep -q 'scripts/manager-work-chain.sh field-telemetry-mvp --dry-run' "$TMPROOT/out" || {
+grep -q '/dev-studio manager work-chain field-telemetry-mvp --dry-run' "$TMPROOT/out" || {
   printf 'missing runnable chain suggestion\n' >&2
   cat "$TMPROOT/out" >&2
   exit 1
 }
-grep -q 'Attended run: `scripts/studio-chain-runner.sh <manifest|chain-name> --attended --yes`' "$TMPROOT/out" || {
+grep -q 'Attended run: `/dev-studio manager work-chain <manifest|chain-name> --attended --yes`' "$TMPROOT/out" || {
   printf 'missing attended command contract\n' >&2
   cat "$TMPROOT/out" >&2
   exit 1
@@ -63,7 +63,7 @@ grep -q 'prd-to-chain-automation' "$TMPROOT/filtered.out" || {
   cat "$TMPROOT/filtered.out" >&2
   exit 1
 }
-if grep -q 'scripts/manager-work-chain.sh field-telemetry-mvp --dry-run' "$TMPROOT/filtered.out"; then
+if grep -q '/dev-studio manager work-chain field-telemetry-mvp --dry-run' "$TMPROOT/filtered.out"; then
   printf 'filtered discovery included unrelated runnable chain\n' >&2
   cat "$TMPROOT/filtered.out" >&2
   exit 1

--- a/scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
+++ b/scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh
@@ -26,13 +26,15 @@ grep -q '# Studio Chain Discovery' "$TMPROOT/discover.out" \
   || fail "bare manager work-chain should default to discovery"
 grep -q 'prd-to-chain-automation' "$TMPROOT/discover.out" \
   || fail "discovery should surface the PRD automation chain"
-grep -q 'scripts/manager-work-chain.sh <chain> --dry-run' "$TMPROOT/discover.out" \
-  || fail "discovery should surface the preview command contract"
+grep -q '/dev-studio manager work-chain <chain> --dry-run' "$TMPROOT/discover.out" \
+  || fail "discovery should surface the preferred preview command contract"
+grep -q 'scripts/manager-work-chain.sh' "$TMPROOT/discover.out" \
+  || fail "discovery should keep script equivalents for automation"
 
 HOME="$TMPROOT/home" "$RUN" --discover prd-to-chain-automation >"$TMPROOT/discover-filtered.out"
 grep -q 'prd-to-chain-automation' "$TMPROOT/discover-filtered.out" \
   || fail "filtered manager discovery should surface the named chain"
-if grep -q 'scripts/manager-work-chain.sh field-telemetry-mvp --dry-run' "$TMPROOT/discover-filtered.out"; then
+if grep -q '/dev-studio manager work-chain field-telemetry-mvp --dry-run' "$TMPROOT/discover-filtered.out"; then
   fail "filtered manager discovery should not list unrelated chains"
 fi
 

--- a/scripts/test-fixtures/713-chain-progress-recap/test-chain-progress-recap.sh
+++ b/scripts/test-fixtures/713-chain-progress-recap/test-chain-progress-recap.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Verifies chain-runner task completion recaps include progress and next command.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-progress-recap.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+extract="$TMPROOT/progress-recap.sh"
+awk '/^print_issue_progress_recap\(\)/,/^process_completed_issue_result\(\)/ { if ($0 !~ /^process_completed_issue_result\(\)/) print }' \
+  "$ROOT/scripts/studio-chain-runner.sh" > "$extract"
+
+RUN_STATE_JSON="$TMPROOT/state.json"
+SUMMARY="$TMPROOT/summary.json"
+RUN_ID="run-progress-recap"
+DRY_RUN=0
+PLAN_JSON="$RUN_STATE_JSON"
+export RUN_STATE_JSON SUMMARY RUN_ID DRY_RUN PLAN_JSON
+
+cat > "$RUN_STATE_JSON" <<'JSON'
+{
+  "chains": [
+    {
+      "name": "context-hardening",
+      "branch": "feature/context-hardening",
+      "chain_run_id": "chain-1",
+      "issues": [
+        {"number": 711, "title": "Define Studio context contract", "issue_run_id": "issue-711", "status": "completed"},
+        {"number": 712, "title": "Inventory path/auth resolution", "issue_run_id": "issue-712", "status": "completed"},
+        {"number": 713, "title": "Add context resolver", "issue_run_id": "issue-713", "status": "pending"}
+      ]
+    }
+  ]
+}
+JSON
+
+cat > "$SUMMARY" <<'JSON'
+{
+  "functionality_delivered": "Documented the context boundary.",
+  "tests": [{"command": "fixture", "outcome": "passed"}],
+  "lints": [],
+  "builds": []
+}
+JSON
+
+# shellcheck disable=SC1090
+. "$extract"
+
+print_issue_progress_recap "context-hardening" "chain-1" "issue-712" "712" "$SUMMARY" > "$TMPROOT/out"
+
+grep -q '## Chain Progress Recap' "$TMPROOT/out" || fail "missing recap heading"
+grep -q 'Previous task: #711 Define Studio context contract (`completed`)' "$TMPROOT/out" || fail "missing previous task"
+grep -q 'Just completed: #712 Inventory path/auth resolution (`completed`)' "$TMPROOT/out" || fail "missing completed task"
+grep -q 'What changed: Documented the context boundary.' "$TMPROOT/out" || fail "missing change summary"
+grep -q 'Next task: #713 Add context resolver (`pending`)' "$TMPROOT/out" || fail "missing next task"
+grep -q 'Overall progress: 2/3 issues completed' "$TMPROOT/out" || fail "missing progress count"
+grep -q 'Preferred command if this session stops: `/dev-studio manager work-chain --resume run-progress-recap --yes`' "$TMPROOT/out" \
+  || fail "missing preferred dev-studio resume command"
+
+printf 'PASS: chain progress recap\n'


### PR DESCRIPTION
## Problem
Work-chain planning and discovery still presented script commands as the primary next step, and chain task completion did not show the compact progress recap expected in attended sessions.

## Solution
- Prefer `/dev-studio manager work-chain ...` in discovery output, docs, and router guidance.
- Keep script commands as secondary automation/debug equivalents.
- Add a parent-side chain progress recap after each integrated issue: previous task, just-completed task, what changed, verification signal counts, next task, overall progress, direction, and preferred resume command.
- Add lint/fixtures so the preferred command and recap do not drift.

## Verification
- `bash -n` on touched shell scripts and fixtures
- `scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh`
- `scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh`
- `scripts/test-fixtures/713-chain-progress-recap/test-chain-progress-recap.sh`
- `scripts/lint-chain-workflow-docs.sh --full`
- `scripts/lint-skill-prose.sh core/v2/skills/dev-studio/SKILL.md`
- `git diff --check`
- pre-commit hooks

## Notes
`lint-host-agnostic.sh --all` still reports the existing `.codex/capabilities.yaml` Argus secret-scope warning; this PR does not touch that adapter.