### PR TITLE
chore: add iOS v2 execution chain

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T18:40:28Z",
+  "generated_at": "2026-05-07T18:48:43Z",
   "agents": [
 
   ]

--- a/chains/ios-v2-execution.yaml
+++ b/chains/ios-v2-execution.yaml
@@ -1,0 +1,51 @@
+# iOS v2 execution chain from the 2026-05-08 manager intake.
+#
+# Discover:
+#   scripts/studio-chain-runner.sh --discover ios-v2-execution
+#
+# Dry-run:
+#   scripts/studio-chain-runner.sh ios-v2-execution --dry-run
+#
+# Reviewed dry-run:
+#   scripts/studio-chain-reviewed.sh ios-v2-execution --dry-run
+#
+# Manager front door:
+#   /dev-studio manager work-chain ios-v2-execution
+#
+# Scope:
+# - #662 is the umbrella and is intentionally excluded from execution.
+# - `host: auto` matches existing chain manifests; the runner resolves the
+#   concrete host at execution time.
+# - #663 defines the contract and must land before implementation leaves start.
+# - #664 and #665 can proceed independently after #663.
+# - #666 and #667 can proceed independently after #665.
+# - #668 depends on routing plus retention/failover surfaces.
+# - #669 layers release/TestFlight priority after generic routing/failover.
+# - #670 records telemetry after the behavior surfaces exist.
+# - #671 validates the full contract after all implementation issues land.
+
+schema_version: 1
+chains:
+  - name: ios-v2-execution
+    base: main
+    branch: feature/ios-v2-execution
+    host: auto
+    phase_review: required
+    issues:
+      - number: 663
+      - number: 664
+        dependencies: [663]
+      - number: 665
+        dependencies: [663]
+      - number: 666
+        dependencies: [665]
+      - number: 667
+        dependencies: [663, 665]
+      - number: 668
+        dependencies: [666, 667]
+      - number: 669
+        dependencies: [667, 668]
+      - number: 670
+        dependencies: [664, 666, 668, 669]
+      - number: 671
+        dependencies: [663, 664, 665, 666, 667, 668, 669, 670]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T18:40:28Z",
+  "generated_at": "2026-05-07T18:48:43Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary

Adds `chains/ios-v2-execution.yaml` as the runnable manager work-chain entry point for the #662 iOS execution arc.

Related issues:

- #662 umbrella, intentionally excluded from execution
- #663 contract gate
- #664 source-branch targets
- #665 scoped build/test artifacts
- #666 retention and janitor policy
- #667 local-first worker routing
- #668 worker-routed failover
- #669 release/TestFlight priority routing
- #670 telemetry
- #671 end-to-end fixtures

## Verification

- `scripts/phase-review.sh --review-host claude-reviewer --kind plan ...` -> `PHASE_REVIEW_VERDICT=clean`, `PHASE_REVIEW_CROSS_HOST_SATISFIED=true`
- `scripts/studio-chain-runner.sh --discover ios-v2-execution`
- `scripts/studio-chain-runner.sh ios-v2-execution --dry-run`
- `git diff --check`
- pre-commit hooks during commit

## Caveat

Discovery currently renders object-form issue entries with blank cells in the compact issue-list column, but dry-run resolves all issues and dependency edges correctly.
