### PR TITLE
bugfix-shipped: preserve Codex worker auth home

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -62,12 +62,13 @@ codex --sandbox workspace-write --add-dir ~/.dev-studio --ask-for-approval never
 Studio-launched Codex workers use `scripts/codex-worker-exec.sh` instead of
 plain `codex exec`. The wrapper resolves the login `HOME`, adds
 `$HOME/.dev-studio` as the runtime writable root, forces
-`--sandbox workspace-write`, disables transcript/session persistence with
-`--ephemeral`, and runs with `approval_policy=never`.
+`--sandbox workspace-write`, exports an explicit `CODEX_HOME` for Codex auth,
+disables transcript/session persistence with `--ephemeral`, and runs with
+`approval_policy=never`.
 
 ## GitHub Auth Parity
 
-Codex worker sessions must launch with the same login `HOME`, keychain, ssh-agent, and GitHub credential-helper surface that Claude-backed sessions use. The studio chain runner sets `HOME` to the login home before spawning Codex so `gh` and `git` see the user's normal credentials instead of a scratch home. Parent-side studio scripts that run under a synthetic Codex home also normalize GitHub operations to the login `HOME` per command; set `STUDIO_BYPASS_PARENT_HOME_FLIP=1` only when intentionally testing synthetic-home isolation.
+Codex worker sessions split data/auth roots deliberately: `HOME` is set to the login home so `gh` and `git` see the user's normal credentials, while `CODEX_HOME` points at the Codex auth profile. This matters when the parent Codex session runs under a synthetic home such as `~/.codex-homes/...`; reusing login `HOME` alone would give the worker GitHub auth but drop Codex API auth. Parent-side studio scripts that run under a synthetic Codex home also normalize GitHub operations to the login `HOME` per command; set `STUDIO_BYPASS_PARENT_HOME_FLIP=1` only when intentionally testing synthetic-home isolation.
 
 Before task work starts, `scripts/host-preflight.sh <host> <repo-root>` runs:
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T19:19:43Z",
+  "generated_at": "2026-05-07T19:45:43Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T19:19:43Z",
+  "generated_at": "2026-05-07T19:45:43Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/hosts/ADAPTER-SPEC.md
+++ b/hosts/ADAPTER-SPEC.md
@@ -99,6 +99,12 @@ For fleet nodes, set `CLAUDE_REVIEWER_HOME` to a locked-down reviewer account
 home that contains no GitHub tokens or project secrets. Codex-based reviewers
 keep using scratch `HOME` plus `CODEX_HOME`.
 
+Codex worker profiles use the same split-root pattern for a different reason:
+the worker needs normal GitHub credentials through login `HOME`, but Codex API
+auth must come from an explicit `CODEX_HOME`/`CODEX_WORKER_HOME`. Do not treat
+ambient `HOME` as the Codex auth source when the parent host may be running
+under a synthetic Codex home.
+
 Do not make a normal worker profile eligible by relaxing the gate. Add a
 dedicated `<host>-reviewer` adapter with its own manifest and enforcement.
 

--- a/scripts/codex-worker-exec.sh
+++ b/scripts/codex-worker-exec.sh
@@ -4,9 +4,36 @@
 set -euo pipefail
 umask 022
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+
+resolve_codex_worker_home() {
+  local login_home
+  if [ -n "${CODEX_WORKER_HOME:-}" ]; then
+    printf '%s\n' "$CODEX_WORKER_HOME"
+  elif [ -n "${CODEX_HOME:-}" ]; then
+    printf '%s\n' "$CODEX_HOME"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/.codex" ]; then
+    printf '%s\n' "$HOME/.codex"
+  else
+    login_home=$(resolve_user_login_home 2>/dev/null || true)
+    if [ -n "$login_home" ] && [ -d "$login_home/.codex" ]; then
+      printf '%s\n' "$login_home/.codex"
+    fi
+  fi
+}
+
+codex_home=$(resolve_codex_worker_home)
+[ -n "$codex_home" ] && [ -d "$codex_home" ] || {
+  printf 'codex-worker-exec: Codex auth home not found; set CODEX_WORKER_HOME or CODEX_HOME to a directory containing Codex credentials\n' >&2
+  exit 70
+}
+
 dev_studio_root="${STUDIO_CODEX_WRITABLE_ROOT:-${HOME:?HOME required}/.dev-studio}"
 
-exec codex exec \
+exec env CODEX_HOME="$codex_home" codex exec \
   --ephemeral \
   --sandbox workspace-write \
   --add-dir "$dev_studio_root" \

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -28,6 +28,7 @@ umask 022
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+CALLER_HOME="${HOME:-}"
 
 # shellcheck source=lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh"
@@ -1503,6 +1504,8 @@ codex_home_for_worker() {
     printf '%s\n' "$CODEX_WORKER_HOME"
   elif [ -n "${CODEX_HOME:-}" ]; then
     printf '%s\n' "$CODEX_HOME"
+  elif [ -n "${CALLER_HOME:-}" ] && [ -d "$CALLER_HOME/.codex" ]; then
+    printf '%s\n' "$CALLER_HOME/.codex"
   elif [ -n "$launch_home" ] && [ -d "$launch_home/.codex" ]; then
     printf '%s\n' "$launch_home/.codex"
   elif [ -n "${HOME:-}" ] && [ -d "$HOME/.codex" ]; then
@@ -2605,6 +2608,21 @@ host_launch_home() {
   resolve_user_login_home 2>/dev/null || true
 }
 
+codex_auth_home_for_worker_launch() {
+  local launch_home="${1:-}"
+  if [ -n "${CODEX_WORKER_HOME:-}" ]; then
+    printf '%s\n' "$CODEX_WORKER_HOME"
+  elif [ -n "${CODEX_HOME:-}" ]; then
+    printf '%s\n' "$CODEX_HOME"
+  elif [ -n "$CALLER_HOME" ] && [ -d "$CALLER_HOME/.codex" ]; then
+    printf '%s\n' "$CALLER_HOME/.codex"
+  elif [ -n "$launch_home" ] && [ -d "$launch_home/.codex" ]; then
+    printf '%s\n' "$launch_home/.codex"
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/.codex" ]; then
+    printf '%s\n' "$HOME/.codex"
+  fi
+}
+
 host_preflight() {
   local host="$1" repo="$2" launch_home
   launch_home=$(host_launch_home)
@@ -3284,7 +3302,7 @@ execute_issue_session() {
   local chain_name="$1" chain_branch="$2" issue="$3" host="$4" git_metadata_strategy="$5" worktree="$6" issue_branch="$7" chain_run_id="$8" issue_run_id="$9" before="${10}" phase_review_context="${11:-[]}" rule_pack_resolution="${12:-null}"
   local issue_json issue_title issue_body spawn prompt summary_path start_path
   local -a spawn_argv
-  local launch_home=""
+  local launch_home="" codex_auth_home=""
 
   issue_json=$(with_login_home_for_github gh issue view "$issue" --repo "$REPO_SLUG" --json number,title,body,url,state)
   issue_title=$(printf '%s' "$issue_json" | jq -r '.title')
@@ -3299,6 +3317,9 @@ execute_issue_session() {
   # shellcheck disable=SC2206
   spawn_argv=( $spawn )
   launch_home=$(host_launch_home)
+  case "$host" in
+    codex*|*codex*) codex_auth_home=$(codex_auth_home_for_worker_launch "$launch_home") ;;
+  esac
 
   prompt=$(cat <<EOF
 Implement this studio issue in a fresh chain-runner session.
@@ -3369,15 +3390,24 @@ EOF
 
   if [ "$DRY_RUN" -eq 1 ]; then
     printf 'DRY-RUN cd %q && ' "$worktree"
+    [ -z "$codex_auth_home" ] || printf 'CODEX_HOME=%q ' "$codex_auth_home"
     printf '%q ' "${spawn_argv[@]}"
     printf '%q\n' "$prompt"
     return 0
   fi
 
   if [ -n "$launch_home" ] && [ -d "$launch_home" ]; then
-    (cd "$worktree" && env HOME="$launch_home" "${spawn_argv[@]}" "$prompt")
+    if [ -n "$codex_auth_home" ]; then
+      (cd "$worktree" && env HOME="$launch_home" CODEX_HOME="$codex_auth_home" "${spawn_argv[@]}" "$prompt")
+    else
+      (cd "$worktree" && env HOME="$launch_home" "${spawn_argv[@]}" "$prompt")
+    fi
   else
-    (cd "$worktree" && "${spawn_argv[@]}" "$prompt")
+    if [ -n "$codex_auth_home" ]; then
+      (cd "$worktree" && env CODEX_HOME="$codex_auth_home" "${spawn_argv[@]}" "$prompt")
+    else
+      (cd "$worktree" && "${spawn_argv[@]}" "$prompt")
+    fi
   fi
 }
 

--- a/scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh
+++ b/scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh
@@ -26,6 +26,8 @@ grep -q -- 'approval_policy=never' "$WORKER_WRAPPER" \
   || fail "Codex worker wrapper does not force noninteractive approval"
 grep -q -- '--add-dir "$dev_studio_root"' "$WORKER_WRAPPER" \
   || fail "Codex worker wrapper does not add the resolved runtime writable root"
+grep -q -- 'CODEX_HOME="$codex_home"' "$WORKER_WRAPPER" \
+  || fail "Codex worker wrapper does not export an explicit Codex auth home"
 if grep -Eq -- 'dangerously-bypass-approvals-and-sandbox|dangerously-skip-permissions' "$WORKER_WRAPPER"; then
   fail "Codex worker wrapper uses a dangerous sandbox bypass"
 fi
@@ -41,7 +43,7 @@ grep -q '^secret_scope: none$' "$REVIEWER_CAPS" \
 
 BIN="$TMPROOT/bin"
 HOME_DIR="$TMPROOT/home"
-mkdir -p "$BIN" "$HOME_DIR"
+mkdir -p "$BIN" "$HOME_DIR/.codex"
 
 cat > "$BIN/gh" <<'SH'
 #!/usr/bin/env bash
@@ -83,9 +85,44 @@ grep -q 'Git metadata strategy: `local-clone`' "$TMPROOT/out" \
   || fail "dry-run plan did not keep Codex on local-clone git metadata"
 grep -q 'scripts/codex-worker-exec.sh' "$TMPROOT/out" \
   || fail "dry-run did not use the effective Codex worker wrapper"
+grep -q "CODEX_HOME=$HOME_DIR/.codex" "$TMPROOT/out" \
+  || fail "dry-run did not pass the caller Codex auth home to the worker"
 if grep -q 'codex exec .*Implement this studio issue' "$TMPROOT/out"; then
   fail "dry-run still used plain codex exec for Codex worker"
 fi
+
+FAKE_CODEX_LOG="$TMPROOT/fake-codex.log"
+cat > "$BIN/codex" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf 'CODEX_HOME=%s\n' "${CODEX_HOME:-}" > "$FAKE_CODEX_LOG"
+printf 'ARGS=%s\n' "$*" >> "$FAKE_CODEX_LOG"
+SH
+chmod +x "$BIN/codex"
+
+AUTH_HOME="$TMPROOT/synthetic-codex-home"
+mkdir -p "$AUTH_HOME"
+PATH="$BIN:$PATH" \
+  HOME="$TMPROOT/login-home" \
+  CODEX_WORKER_HOME="$AUTH_HOME" \
+  FAKE_CODEX_LOG="$FAKE_CODEX_LOG" \
+  "$WORKER_WRAPPER" "fixture prompt"
+
+grep -qx "CODEX_HOME=$AUTH_HOME" "$FAKE_CODEX_LOG" \
+  || fail "worker wrapper did not preserve explicit Codex auth home"
+grep -q -- '--sandbox workspace-write' "$FAKE_CODEX_LOG" \
+  || fail "worker wrapper did not invoke codex exec with workspace-write"
+
+SYNTH_HOME="$TMPROOT/synthetic-home"
+mkdir -p "$SYNTH_HOME/.codex"
+PATH="$BIN:$PATH" \
+  HOME="$SYNTH_HOME" \
+  FAKE_CODEX_LOG="$FAKE_CODEX_LOG" \
+  env -u CODEX_WORKER_HOME -u CODEX_HOME \
+  "$WORKER_WRAPPER" "fixture prompt"
+
+grep -qx "CODEX_HOME=$SYNTH_HOME/.codex" "$FAKE_CODEX_LOG" \
+  || fail "worker wrapper did not infer Codex auth from synthetic HOME"
 
 bash "$ROOT/scripts/lint-host-agnostic.sh" >/tmp/codex-worker-spawn-lint.out 2>/tmp/codex-worker-spawn-lint.err \
   || {


### PR DESCRIPTION
## Summary
- split Codex worker auth from login HOME by passing explicit CODEX_HOME
- make codex-worker-exec fail loudly when no Codex auth home resolves
- cover caller-home, CODEX_WORKER_HOME, and synthetic HOME paths in the Codex worker fixture

## Verification
- bash -n scripts/codex-worker-exec.sh scripts/studio-chain-runner.sh scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh
- bash scripts/test-fixtures/576-codex-worker-spawn/test-codex-worker-spawn.sh
- scripts/codex-worker-exec.sh real AUTH_OK smoke
- bash scripts/lint-host-agnostic.sh (0 errors, existing W_ARGUS_SECRET_SCOPE warning)
- git diff --check
- phase-review claude-reviewer outcome clean

## Review
- sibling phase review: clean, cross-host satisfied