### PR TITLE
Fix Project reader lag for new items

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T19:45:43Z",
+  "generated_at": "2026-05-07T20:28:30Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T19:45:43Z",
+  "generated_at": "2026-05-07T20:28:30Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-project-state.sh
+++ b/scripts/studio-project-state.sh
@@ -12,6 +12,7 @@
 #   scripts/studio-project-state.sh --status "Todo"
 
 set -u
+set -o pipefail
 umask 022
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
@@ -21,6 +22,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 OWNER="${STUDIO_PROJECT_OWNER:-v-i-s-h-a-l}"
 PROJECT_NUMBER="${STUDIO_PROJECT_NUMBER:-1}"
 LIMIT="${STUDIO_PROJECT_LIMIT:-200}"
+FALLBACK_LIMIT="${STUDIO_PROJECT_SEARCH_FALLBACK_LIMIT:-20}"
+REPO_SLUG="${STUDIO_PROJECT_REPO:-}"
 MODE=human
 QUERY=""
 PROJECT_STATUS=""
@@ -49,6 +52,153 @@ command -v gh >/dev/null 2>&1 || {
 command -v jq >/dev/null 2>&1 || {
   printf 'studio-project-state: jq is required on PATH\n' >&2
   exit 127
+}
+
+resolve_repo_slug() {
+  if [ -n "$REPO_SLUG" ]; then
+    printf '%s\n' "$REPO_SLUG"
+    return 0
+  fi
+
+  local remote
+  remote=$(git remote get-url origin 2>/dev/null || true)
+  case "$remote" in
+    git@github.com:*)
+      remote=${remote#git@github.com:}
+      remote=${remote%.git}
+      ;;
+    https://github.com/*)
+      remote=${remote#https://github.com/}
+      remote=${remote%.git}
+      ;;
+    *)
+      remote="v-i-s-h-a-l/generic-dev-studio"
+      ;;
+  esac
+  printf '%s\n' "$remote"
+}
+
+search_terms() {
+  printf '%s\n' "$QUERY" | tr '|' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | awk 'length > 0'
+}
+
+graphql_project_item_for_issue() {
+  local repo_slug="$1"
+  local issue_number="$2"
+  local repo_owner repo_name
+  repo_owner=${repo_slug%%/*}
+  repo_name=${repo_slug#*/}
+
+  with_login_home_for_github gh api graphql \
+    -f query='
+      query($owner:String!,$repo:String!,$number:Int!){
+        repository(owner:$owner,name:$repo){
+          issue(number:$number){
+            number
+            title
+            url
+            repository { nameWithOwner url }
+            labels(first:50){ nodes { name } }
+            milestone { title }
+            projectItems(first:50){
+              nodes {
+                type
+                project {
+                  number
+                  owner {
+                    ... on User { login }
+                    ... on Organization { login }
+                  }
+                }
+                fieldValues(first:50){
+                  nodes {
+                    ... on ProjectV2ItemFieldTextValue {
+                      text
+                      field { ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                      field { ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      number
+                      field { ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldDateValue {
+                      date
+                      field { ... on ProjectV2FieldCommon { name } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }' \
+    -f owner="$repo_owner" \
+    -f repo="$repo_name" \
+    -F number="$issue_number" |
+    jq -c --arg owner "$OWNER" --argjson project_number "$PROJECT_NUMBER" '
+      def field_value($name):
+        [
+          .fieldValues.nodes[]
+          | select(.field.name == $name)
+          | (.name // .text // (.number | tostring) // .date // empty)
+        ][0] // "";
+      .data.repository.issue as $issue
+      | ($issue.projectItems.nodes // [])
+      | map(select((.project.number == $project_number) and (.project.owner.login == $owner)))
+      | .[0] as $project_item
+      | if $issue == null or $project_item == null then empty else
+          $project_item
+          | {
+              issue_number: $issue.number,
+              title: ($issue.title // ""),
+              url: ($issue.url // ""),
+              repository: ($issue.repository.nameWithOwner // $issue.repository.url // ""),
+              type: (.type // ""),
+              status: field_value("Status"),
+              track: field_value("Track"),
+              phase: field_value("Phase"),
+              size: field_value("Size"),
+              sibling_host_reviewed: field_value("Sibling host reviewed"),
+              labels: (($issue.labels.nodes // []) | map(.name)),
+              milestone: ($issue.milestone.title // null)
+            }
+        end
+    '
+}
+
+fallback_items_for_search() {
+  [ -n "$QUERY" ] || { printf '[]\n'; return 0; }
+
+  local repo_slug tmp_numbers tmp_items term
+  repo_slug=$(resolve_repo_slug)
+  tmp_numbers=$(mktemp -t studio-project-state-numbers.XXXXXX)
+  tmp_items=$(mktemp -t studio-project-state-items.XXXXXX)
+  : > "$tmp_numbers"
+  : > "$tmp_items"
+
+  while IFS= read -r term; do
+    if [[ "$term" =~ ^[0-9]+$ ]]; then
+      printf '%s\n' "$term" >> "$tmp_numbers"
+    else
+      with_login_home_for_github gh issue list \
+        --repo "$repo_slug" \
+        --search "$term" \
+        --limit "$FALLBACK_LIMIT" \
+        --json number |
+        jq -r '.[].number' >> "$tmp_numbers" || return $?
+    fi
+  done < <(search_terms)
+
+  sort -nu "$tmp_numbers" | while IFS= read -r issue_number; do
+    [ -n "$issue_number" ] || continue
+    graphql_project_item_for_issue "$repo_slug" "$issue_number" >> "$tmp_items" || return $?
+  done
+
+  jq -s '.' "$tmp_items"
+  rm -f "$tmp_numbers" "$tmp_items"
 }
 
 raw_json=$(
@@ -96,6 +246,32 @@ items_json=$(
       | select($q == "" or (. as $item | any(($q | ascii_downcase | split("|") | map(select(length > 0)))[]; . as $term | ($item | haystack | contains($term)))))
     ]
   '
+) || exit $?
+
+fallback_json=$(fallback_items_for_search) || exit $?
+items_json=$(
+  jq -c --arg q "$QUERY" --arg project_status "$PROJECT_STATUS" -s '
+    def haystack:
+      [
+        (.issue_number // "" | tostring),
+        .title,
+        .repository,
+        .status,
+        .track,
+        .phase,
+        .size,
+        .sibling_host_reviewed,
+        (.labels // [] | join(" ")),
+        (.milestone // "")
+      ] | join(" ") | ascii_downcase;
+    (.[0] + .[1])
+    | unique_by((.issue_number // .url // .title) | tostring)
+    | [
+        .[]
+        | select($project_status == "" or (.status | ascii_downcase) == ($project_status | ascii_downcase))
+        | select($q == "" or (. as $item | any(($q | ascii_downcase | split("|") | map(select(length > 0)))[]; . as $term | ($item | haystack | contains($term)))))
+      ]
+  ' <(printf '%s\n' "$items_json") <(printf '%s\n' "$fallback_json")
 ) || exit $?
 
 if [ "$MODE" = json ]; then

--- a/scripts/test-fixtures/503-project-state/test-studio-project-state.sh
+++ b/scripts/test-fixtures/503-project-state/test-studio-project-state.sh
@@ -56,6 +56,93 @@ case "$1 $2" in
       "totalCount": 2
     }'
     ;;
+  "issue list")
+    case "$*" in
+      *"--search PM surface"*)
+        printf '%s\n' '[{"number":443}]'
+        ;;
+      *"--search reader lag"*)
+        printf '%s\n' '[{"number":694}]'
+        ;;
+      *)
+        printf '%s\n' '[]'
+        ;;
+    esac
+    ;;
+  "api graphql")
+    case "$*" in
+      *"number=443"*)
+        printf '%s\n' '{
+          "data": {
+            "repository": {
+              "issue": {
+                "number": 443,
+                "title": "Adopt GitHub as primary PM surface",
+                "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/443",
+                "repository": {"nameWithOwner": "v-i-s-h-a-l/generic-dev-studio"},
+                "labels": {"nodes": [{"name": "enhancement"}, {"name": "track:pm-surface"}]},
+                "milestone": null,
+                "projectItems": {
+                  "nodes": [
+                    {
+                      "type": "ISSUE",
+                      "project": {"number": 1, "owner": {"login": "v-i-s-h-a-l"}},
+                      "fieldValues": {
+                        "nodes": [
+                          {"name": "Todo", "field": {"name": "Status"}},
+                          {"name": "B PM surface", "field": {"name": "Track"}},
+                          {"name": "B1", "field": {"name": "Phase"}},
+                          {"name": "M", "field": {"name": "Size"}},
+                          {"name": "Needs review", "field": {"name": "Sibling host reviewed"}}
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }'
+        ;;
+      *"number=694"*)
+        printf '%s\n' '{
+          "data": {
+            "repository": {
+              "issue": {
+                "number": 694,
+                "title": "Fix Project reader lag for newly added items",
+                "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/694",
+                "repository": {"nameWithOwner": "v-i-s-h-a-l/generic-dev-studio"},
+                "labels": {"nodes": [{"name": "bug"}, {"name": "track:pm-surface"}]},
+                "milestone": null,
+                "projectItems": {
+                  "nodes": [
+                    {
+                      "type": "ISSUE",
+                      "project": {"number": 1, "owner": {"login": "v-i-s-h-a-l"}},
+                      "fieldValues": {
+                        "nodes": [
+                          {"name": "Todo", "field": {"name": "Status"}},
+                          {"name": "B PM surface", "field": {"name": "Track"}},
+                          {"name": "B1", "field": {"name": "Phase"}},
+                          {"name": "S", "field": {"name": "Size"}},
+                          {"name": "Needs review", "field": {"name": "Sibling host reviewed"}}
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }'
+        ;;
+      *)
+        printf 'unexpected graphql call: %s\n' "$*" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   *)
     printf 'unexpected gh call: %s\n' "$*" >&2
     exit 2
@@ -86,6 +173,13 @@ assert "search exits zero" "[ '$search_rc' -eq 0 ]"
 assert "search prints project fields" "grep -q '#443 \\[Todo\\].* -- track=B PM surface phase=B1 size=M review=Needs review' '$TMPROOT/search.out'"
 assert "search filters non-matches" "! grep -q '#446' '$TMPROOT/search.out'"
 assert "uses project item-list" "grep -q '^project item-list 1 --owner v-i-s-h-a-l' '$GH_STUB_LOG'"
+
+bash "$ROOT/scripts/studio-project-state.sh" --search "reader lag" >"$TMPROOT/fallback.out" 2>"$TMPROOT/fallback.err"
+fallback_rc=$?
+assert "fallback search exits zero" "[ '$fallback_rc' -eq 0 ]"
+assert "fallback finds item-list miss" "grep -q '#694 \\[Todo\\] Fix Project reader lag for newly added items -- track=B PM surface phase=B1 size=S review=Needs review' '$TMPROOT/fallback.out'"
+assert "fallback uses issue search" "grep -q '^issue list --repo v-i-s-h-a-l/generic-dev-studio --search reader lag' '$GH_STUB_LOG'"
+assert "fallback verifies project fields through graphql" "grep -q '^api graphql' '$GH_STUB_LOG' && grep -q 'number=694' '$GH_STUB_LOG'"
 
 bash "$ROOT/scripts/studio-project-state.sh" --json --status Done >"$TMPROOT/status.json" 2>"$TMPROOT/status.err"
 status_rc=$?


### PR DESCRIPTION
## Summary
- add a search-scoped GraphQL fallback to `studio-project-state.sh` for Project item-list misses
- merge fallback ProjectV2 field values with normal item-list results
- extend the project-state fixture for a newly added item with Status/Track/Phase/Size/review fields

## Verification
- `bash scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `bash -n scripts/studio-project-state.sh scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `shellcheck -e SC1091,SC2016 scripts/studio-project-state.sh scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `scripts/studio-project-state.sh --search "694"`

Closes #694