### PR TITLE
Harden Project reader fallback errors

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T20:28:30Z",
+  "generated_at": "2026-05-07T20:32:32Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T20:28:30Z",
+  "generated_at": "2026-05-07T20:32:32Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-project-state.sh
+++ b/scripts/studio-project-state.sh
@@ -72,7 +72,8 @@ resolve_repo_slug() {
       remote=${remote%.git}
       ;;
     *)
-      remote="v-i-s-h-a-l/generic-dev-studio"
+      printf 'studio-project-state: could not resolve GitHub repo slug from origin; set STUDIO_PROJECT_REPO=owner/repo\n' >&2
+      return 2
       ;;
   esac
   printf '%s\n' "$remote"
@@ -176,6 +177,7 @@ fallback_items_for_search() {
   repo_slug=$(resolve_repo_slug)
   tmp_numbers=$(mktemp -t studio-project-state-numbers.XXXXXX)
   tmp_items=$(mktemp -t studio-project-state-items.XXXXXX)
+  trap 'rm -f "$tmp_numbers" "$tmp_items"' RETURN
   : > "$tmp_numbers"
   : > "$tmp_items"
 
@@ -192,13 +194,12 @@ fallback_items_for_search() {
     fi
   done < <(search_terms)
 
-  sort -nu "$tmp_numbers" | while IFS= read -r issue_number; do
+  while IFS= read -r issue_number; do
     [ -n "$issue_number" ] || continue
     graphql_project_item_for_issue "$repo_slug" "$issue_number" >> "$tmp_items" || return $?
-  done
+  done < <(sort -nu "$tmp_numbers")
 
   jq -s '.' "$tmp_items"
-  rm -f "$tmp_numbers" "$tmp_items"
 }
 
 raw_json=$(


### PR DESCRIPTION
## Summary
- address cross-host review findings from PR #725
- make GraphQL candidate verification fail from the parent fallback function
- fail loudly when the repo slug cannot be resolved and clean up temp files on return

## Verification
- `bash scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `bash -n scripts/studio-project-state.sh scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `shellcheck -e SC1091,SC2016 scripts/studio-project-state.sh scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `scripts/studio-project-state.sh --search "694"`

Follow-up to #725 / #694.