### PR TITLE
docs: add chain monitor reconciliation manifest

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T20:32:32Z",
+  "generated_at": "2026-05-07T20:44:37Z",
   "agents": [
 
   ]

--- a/chains/chain-monitor-reconciliation.yaml
+++ b/chains/chain-monitor-reconciliation.yaml
@@ -1,0 +1,26 @@
+# Slack chain monitor reconciliation hardening for #705.
+#
+# Discover:
+#   /dev-studio manager work-chain --discover chain-monitor-reconciliation
+#
+# Dry-run:
+#   /dev-studio manager work-chain chain-monitor-reconciliation --dry-run
+#
+# Execute:
+#   /dev-studio manager work-chain chain-monitor-reconciliation --attended --yes
+#
+# The chain is ordered so the row model lands before Slack reconciliation, sync
+# integration, and front-door commands.
+
+schema_version: 1
+chains:
+  - name: chain-monitor-reconciliation
+    base: main
+    branch: feature/chain-monitor-reconciliation
+    host: auto
+    phase_review: required
+    issues:
+      - 727
+      - 728
+      - 729
+      - 730

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T20:32:32Z",
+  "generated_at": "2026-05-07T20:44:37Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary\n\n- Adds a runner-compatible chain manifest for #705 execution.\n- References worker task issues #727, #728, #729, and #730.\n- Keeps phase review required for the implementation chain.\n\n## Verification\n\n- scripts/manager-work-chain.sh chain-monitor-reconciliation --dry-run\n- pre-commit hooks during commit\n\n## Notes\n\nThe manifest can be executed from this branch/worktree immediately with an absolute path, or by name after the PR lands on main.