### PR TITLE
Add control-plane context resolver chain

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T20:44:37Z",
+  "generated_at": "2026-05-07T21:04:26Z",
   "agents": [
 
   ]

--- a/chains/control-plane-context-substrate.yaml
+++ b/chains/control-plane-context-substrate.yaml
@@ -10,10 +10,14 @@
 # Execute/resume the spec chain:
 #   scripts/studio-chain-runner.sh chains/control-plane-context-substrate.yaml --only control-plane-context-spec --attended
 #
+# Execute/resume the resolver chain:
+#   scripts/studio-chain-runner.sh chains/control-plane-context-substrate.yaml --only control-plane-context-resolver --attended
+#
 # Scope note:
-#   This manifest intentionally starts with the spec/inventory chain only. Add
-#   resolver, enforcement, and migration chains after #711/#712 produce reviewed
-#   contract and inventory outputs.
+#   The resolver chain intentionally covers only the resolver foundation and
+#   first GitHub/auth migration surface. Add review-wrapper, chain-runner,
+#   manager/profile, enforcement, and broad migration chains after #732/#733
+#   produce reviewed outputs.
 
 schema_version: 1
 chains:
@@ -23,3 +27,9 @@ chains:
     host: auto
     phase_review: required
     issues: [711, 712]
+  - name: control-plane-context-resolver
+    base: main
+    branch: feature/control-plane-context-resolver
+    host: auto
+    phase_review: required
+    issues: [732, 733]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T20:44:37Z",
+  "generated_at": "2026-05-07T21:04:26Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
Ingests parent #710 after the reviewed A1/A2 outputs by adding the next runnable resolver chain.

Changes:
- Adds `control-plane-context-resolver` to `chains/control-plane-context-substrate.yaml`.
- Routes the first implementation slice through #732 then #733.
- Leaves #734 as the review-wrapper follow-up outside this first chain.

Verification:
- `scripts/phase-review.sh --review-host claude-reviewer --kind plan --input /Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-08-control-plane-context-next-ingest-plan.md --output /Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-08-control-plane-context-next-ingest-plan-review.md`
- `scripts/studio-chain-runner.sh chains/control-plane-context-substrate.yaml --only control-plane-context-resolver --dry-run`
- `scripts/manager-work-chain.sh --discover control-plane-context-substrate`
- `git diff --check`

Note: full-manifest dry-run still sees closed #711/#712 unless scoped with `--only`; the new resolver chain validates cleanly.
