### PR TITLE
B3: Migrate review wrappers to Studio context profiles

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T21:22:17Z",
+  "generated_at": "2026-05-07T22:26:00Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T21:22:16Z",
+  "generated_at": "2026-05-07T22:26:00Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -30,11 +30,12 @@ umask 022
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
-CALLER_HOME="${HOME:-}"
 
-# shellcheck source=lib-paths.sh
+# shellcheck source=scripts/lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
-# shellcheck source=lib-review-budget.sh
+# shellcheck source=scripts/lib-studio-context.sh
+. "$SCRIPT_DIR/lib-studio-context.sh"
+# shellcheck source=scripts/lib-review-budget.sh
 . "$SCRIPT_DIR/lib-review-budget.sh"
 
 usage() {
@@ -288,28 +289,23 @@ trap 'rm -rf "$tmpdir"' EXIT
 reviewer_home="$tmpdir/reviewer-home"
 mkdir -p "$reviewer_home"
 
-LOGIN_HOME=$(resolve_user_login_home 2>/dev/null || true)
 reviewer_codex_home=""
 reviewer_claude_home=""
 reviewer_claude_config_dir=""
 
+export STUDIO_CONTEXT_HOST_PROFILE="$review_host"
+studio_context_resolve delegated-host-spawn || fail "reviewer auth home unavailable via Studio context for $review_host"
+
 case "$review_host" in
   codex*|*codex*)
-    reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-}}"
-    if [ -z "$reviewer_codex_home" ]; then
-      if [ -n "$CALLER_HOME" ] && [ -d "$CALLER_HOME/.codex" ]; then
-        reviewer_codex_home="$CALLER_HOME/.codex"
-      elif [ -n "$LOGIN_HOME" ] && [ -d "$LOGIN_HOME/.codex" ]; then
-        reviewer_codex_home="$LOGIN_HOME/.codex"
-      fi
-    fi
+    reviewer_codex_home="$STUDIO_CONTEXT_AUTH_HOME"
     [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] \
-      || fail "codex reviewer auth home not found; set CODEX_REVIEWER_HOME or CODEX_HOME"
+      || fail "codex reviewer auth home not found via Studio context"
     ;;
   claude*|*claude*)
-    reviewer_claude_home="${CLAUDE_REVIEWER_HOME:-$LOGIN_HOME}"
+    reviewer_claude_home="$STUDIO_CONTEXT_AUTH_HOME"
     [ -n "$reviewer_claude_home" ] && [ -d "$reviewer_claude_home" ] \
-      || fail "claude reviewer auth home not found; set CLAUDE_REVIEWER_HOME"
+      || fail "claude reviewer auth home not found via Studio context"
     reviewer_claude_config_dir="${CLAUDE_REVIEWER_CONFIG_DIR:-$reviewer_claude_home/.claude-reviewer}"
     mkdir -p "$reviewer_claude_config_dir" \
       || fail "failed to create claude reviewer config dir: $reviewer_claude_config_dir"

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -22,7 +22,6 @@ usage() {
 [ $# -ge 1 ] || usage
 PR="$1"
 shift
-CALLER_HOME="${HOME:-}"
 PR_REVIEW_STARTED_AT=$(date +%s)
 PR_URL_FOR_EVENT=""
 PR_HEAD_SHA_FOR_EVENT=""
@@ -84,14 +83,15 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 AUTOPILOT="${PR_HEADLESS_REVIEW_AUTOPILOT:-$SCRIPT_DIR/pr-autopilot.sh}"
 
-# shellcheck source=lib-paths.sh
+# shellcheck source=scripts/lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
-# shellcheck source=lib-review-budget.sh
+# shellcheck source=scripts/lib-studio-context.sh
+. "$SCRIPT_DIR/lib-studio-context.sh"
+# shellcheck source=scripts/lib-review-budget.sh
 . "$SCRIPT_DIR/lib-review-budget.sh"
-# shellcheck source=lib-ledger.sh
+# shellcheck source=scripts/lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh" 2>/dev/null || true
 
-LOGIN_HOME=$(resolve_user_login_home 2>/dev/null || true)
 PARENT_HOST=$(resolve_current_studio_host unknown)
 
 emit_pr_review_duration() {
@@ -288,7 +288,7 @@ eligible_hosts() {
   rm -f "$hosts_file"
 }
 
-pr_json=$(with_login_home_for_github gh pr view "$PR" --json number,title,url,baseRefName,headRefName,headRefOid,author,commits) \
+pr_json=$("$SCRIPT_DIR/studio-gh.sh" pr view "$PR" --json number,title,url,baseRefName,headRefName,headRefOid,author,commits) \
   || { printf 'pr-headless-review: failed to read PR %s\n' "$PR" >&2; exit 1; }
 pr_num=$(printf '%s' "$pr_json" | jq -r '.number')
 pr_url=$(printf '%s' "$pr_json" | jq -r '.url')
@@ -372,7 +372,7 @@ reviewer_codex_home=""
 reviewer_claude_home=""
 reviewer_claude_config_dir=""
 
-with_login_home_for_github gh pr diff "$PR" --patch > "$diff_payload"
+"$SCRIPT_DIR/studio-gh.sh" pr diff "$PR" --patch > "$diff_payload"
 
 write_pr_payload() {
   local mode="$1" policy_json="$2"
@@ -443,6 +443,12 @@ run_review_candidate() {
     append_failure "$REVIEW_HOST" "$summary" "$summary.err"
     return 1
   }
+  export STUDIO_CONTEXT_HOST_PROFILE="$REVIEW_HOST"
+  studio_context_resolve delegated-host-spawn || {
+    printf 'pr-headless-review: failed to resolve reviewer auth home for %s\n' "$REVIEW_HOST" > "$summary.err"
+    append_failure "$REVIEW_HOST" "$summary" "$summary.err"
+    return 1
+  }
   resolver_args=(--review-host "$REVIEW_HOST" --implementation-host "$PARENT_HOST" --role reviewer.heavyweight)
   [ "$ALLOW_SAME_HOST_REVIEW" -eq 0 ] || resolver_args+=(--allow-same-family)
   model_resolution=$("$SCRIPT_DIR/resolve-reviewer-model.sh" "${resolver_args[@]}" 2>&1) || {
@@ -458,24 +464,17 @@ run_review_candidate() {
   reviewer_claude_config_dir=""
   case "$REVIEW_HOST" in
     codex*|*codex*)
-      reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-}}"
-      if [ -z "$reviewer_codex_home" ]; then
-        if [ -n "$CALLER_HOME" ] && [ -d "$CALLER_HOME/.codex" ]; then
-          reviewer_codex_home="$CALLER_HOME/.codex"
-        elif [ -n "$LOGIN_HOME" ] && [ -d "$LOGIN_HOME/.codex" ]; then
-          reviewer_codex_home="$LOGIN_HOME/.codex"
-        fi
-      fi
+      reviewer_codex_home="$STUDIO_CONTEXT_AUTH_HOME"
       [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] || {
-        printf 'pr-headless-review: codex reviewer auth home not found; set CODEX_REVIEWER_HOME or CODEX_HOME\n' > "$summary.err"
+        printf 'pr-headless-review: codex reviewer auth home not found via Studio context\n' > "$summary.err"
         append_failure "$REVIEW_HOST" "$summary" "$summary.err"
         return 1
       }
       ;;
     claude*|*claude*)
-      reviewer_claude_home="${CLAUDE_REVIEWER_HOME:-$LOGIN_HOME}"
+      reviewer_claude_home="$STUDIO_CONTEXT_AUTH_HOME"
       [ -n "$reviewer_claude_home" ] && [ -d "$reviewer_claude_home" ] || {
-        printf 'pr-headless-review: claude reviewer auth home not found; set CLAUDE_REVIEWER_HOME\n' > "$summary.err"
+        printf 'pr-headless-review: claude reviewer auth home not found via Studio context\n' > "$summary.err"
         append_failure "$REVIEW_HOST" "$summary" "$summary.err"
         return 1
       }

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -16,12 +16,11 @@ HOST="${1:-${STUDIO_REVIEW_HOST:-codex-reviewer}}"
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 SMOKE_TIMEOUT_SEC="${STUDIO_REVIEWER_SMOKE_TIMEOUT_SEC:-45}"
-CALLER_HOME="${HOME:-}"
 
-# shellcheck source=lib-paths.sh
+# shellcheck source=scripts/lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
-
-LOGIN_HOME=$(resolve_user_login_home 2>/dev/null || true)
+# shellcheck source=scripts/lib-studio-context.sh
+. "$SCRIPT_DIR/lib-studio-context.sh"
 
 fail() {
   printf 'PR_REVIEWER_ELIGIBLE=0\n'
@@ -56,24 +55,27 @@ run_smoke_gate() {
   reviewer_claude_config_dir=""
   case "$HOST" in
     codex*|*codex*)
-      reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-}}"
-      if [ -z "$reviewer_codex_home" ]; then
-        if [ -n "$CALLER_HOME" ] && [ -d "$CALLER_HOME/.codex" ]; then
-          reviewer_codex_home="$CALLER_HOME/.codex"
-        elif [ -n "$LOGIN_HOME" ] && [ -d "$LOGIN_HOME/.codex" ]; then
-          reviewer_codex_home="$LOGIN_HOME/.codex"
-        fi
-      fi
+      export STUDIO_CONTEXT_HOST_PROFILE="$HOST"
+      studio_context_resolve delegated-host-spawn || {
+        rm -rf "$tmpdir"
+        fail smoke_auth_unavailable "codex reviewer auth home unavailable via Studio context"
+      }
+      reviewer_codex_home="$STUDIO_CONTEXT_AUTH_HOME"
       [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] || {
         rm -rf "$tmpdir"
-        fail smoke_auth_unavailable "codex reviewer auth home not found; set CODEX_REVIEWER_HOME or CODEX_HOME"
+        fail smoke_auth_unavailable "codex reviewer auth home not found via Studio context"
       }
       ;;
     claude*|*claude*)
-      reviewer_claude_home="${CLAUDE_REVIEWER_HOME:-$LOGIN_HOME}"
+      export STUDIO_CONTEXT_HOST_PROFILE="$HOST"
+      studio_context_resolve delegated-host-spawn || {
+        rm -rf "$tmpdir"
+        fail smoke_auth_unavailable "claude reviewer auth home unavailable via Studio context"
+      }
+      reviewer_claude_home="$STUDIO_CONTEXT_AUTH_HOME"
       [ -n "$reviewer_claude_home" ] && [ -d "$reviewer_claude_home" ] || {
         rm -rf "$tmpdir"
-        fail smoke_auth_unavailable "claude reviewer auth home not found; set CLAUDE_REVIEWER_HOME"
+        fail smoke_auth_unavailable "claude reviewer auth home not found via Studio context"
       }
       reviewer_claude_config_dir="${CLAUDE_REVIEWER_CONFIG_DIR:-$reviewer_claude_home/.claude-reviewer}"
       [ -n "$reviewer_claude_config_dir" ] || {

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -17,7 +17,6 @@ usage() {
 
 REVIEW_HOST="${STUDIO_REVIEW_HOST:-}"
 BYPASS_REVIEW=0
-CALLER_HOME="${HOME:-}"
 REVIEW_STARTED_AT=$(date +%s)
 REVIEW_CONTEXT_JSON="null"
 
@@ -32,14 +31,14 @@ done
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
-# shellcheck source=lib-paths.sh
+# shellcheck source=scripts/lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
-# shellcheck source=lib-review-budget.sh
+# shellcheck source=scripts/lib-studio-context.sh
+. "$SCRIPT_DIR/lib-studio-context.sh"
+# shellcheck source=scripts/lib-review-budget.sh
 . "$SCRIPT_DIR/lib-review-budget.sh"
-# shellcheck source=lib-ledger.sh
+# shellcheck source=scripts/lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh" 2>/dev/null || true
-
-LOGIN_HOME=$(resolve_user_login_home 2>/dev/null || true)
 
 yaml_field() {
   local file="$1" key="$2"
@@ -161,23 +160,26 @@ reviewer_claude_home=""
 reviewer_claude_config_dir=""
 case "$REVIEW_HOST" in
   codex*|*codex*)
-    reviewer_codex_home="${CODEX_REVIEWER_HOME:-${CODEX_HOME:-}}"
-    if [ -z "$reviewer_codex_home" ]; then
-      if [ -n "$CALLER_HOME" ] && [ -d "$CALLER_HOME/.codex" ]; then
-        reviewer_codex_home="$CALLER_HOME/.codex"
-      elif [ -n "$LOGIN_HOME" ] && [ -d "$LOGIN_HOME/.codex" ]; then
-        reviewer_codex_home="$LOGIN_HOME/.codex"
-      fi
-    fi
+    export STUDIO_CONTEXT_HOST_PROFILE="$REVIEW_HOST"
+    studio_context_resolve delegated-host-spawn || {
+      printf 'pre-commit-review: codex reviewer auth home unavailable via Studio context\n' >&2
+      exit 1
+    }
+    reviewer_codex_home="$STUDIO_CONTEXT_AUTH_HOME"
     [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] || {
-      printf 'pre-commit-review: codex reviewer auth home not found; set CODEX_REVIEWER_HOME or CODEX_HOME\n' >&2
+      printf 'pre-commit-review: codex reviewer auth home not found via Studio context\n' >&2
       exit 1
     }
     ;;
   claude*|*claude*)
-    reviewer_claude_home="${CLAUDE_REVIEWER_HOME:-$LOGIN_HOME}"
+    export STUDIO_CONTEXT_HOST_PROFILE="$REVIEW_HOST"
+    studio_context_resolve delegated-host-spawn || {
+      printf 'pre-commit-review: claude reviewer auth home unavailable via Studio context\n' >&2
+      exit 1
+    }
+    reviewer_claude_home="$STUDIO_CONTEXT_AUTH_HOME"
     [ -n "$reviewer_claude_home" ] && [ -d "$reviewer_claude_home" ] || {
-      printf 'pre-commit-review: claude reviewer auth home not found; set CLAUDE_REVIEWER_HOME\n' >&2
+      printf 'pre-commit-review: claude reviewer auth home not found via Studio context\n' >&2
       exit 1
     }
     reviewer_claude_config_dir="${CLAUDE_REVIEWER_CONFIG_DIR:-$reviewer_claude_home/.claude-reviewer}"

--- a/scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
+++ b/scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
@@ -38,6 +38,11 @@ cat > "$BIN/gh" <<'SH'
 #!/usr/bin/env bash
 set -u
 
+[ -n "${EXPECTED_GITHUB_HOME:-}" ] && [ "$HOME" = "$EXPECTED_GITHUB_HOME" ] || {
+  printf 'gh did not receive normalized github HOME\n' >&2
+  exit 11
+}
+
 case "$1 $2" in
   "pr view")
     case " $* " in
@@ -77,11 +82,19 @@ export GITHUB_TOKEN="must-not-leak"
 export OPENAI_API_KEY="must-not-leak"
 export ANTHROPIC_API_KEY="must-not-leak"
 export HOME="$TMPROOT/caller-home"
-export CODEX_HOME="$HOME/.codex"
+export STUDIO_CONTEXT_GITHUB_HOME="$TMPROOT/github-home"
+export CODEX_REVIEWER_HOME="$TMPROOT/reviewer-home"
+export EXPECTED_GITHUB_HOME="$STUDIO_CONTEXT_GITHUB_HOME"
 export STUDIO_PARENT_HOST="claude-code"
 mkdir -p "$HOME/.config/gh"
 printf 'github.com: token\n' > "$HOME/.config/gh/hosts.yml"
-mkdir -p "$CODEX_HOME"
+mkdir -p "$STUDIO_CONTEXT_GITHUB_HOME" "$CODEX_REVIEWER_HOME"
+
+resolved_codex_home=$(STUDIO_CONTEXT_HOST_PROFILE=codex-reviewer bash -c ". '$ROOT/scripts/lib-studio-context.sh'; studio_context_get auth_home delegated-host-spawn")
+[ "$resolved_codex_home" = "$CODEX_REVIEWER_HOME" ] || {
+  printf 'fixture resolved codex auth home incorrectly: %s\n' "$resolved_codex_home" >&2
+  exit 1
+}
 
 failures=0
 assert() {

--- a/scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
+++ b/scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
@@ -48,9 +48,15 @@ export GITHUB_TOKEN="must-not-leak"
 export OPENAI_API_KEY="must-not-leak"
 export ANTHROPIC_API_KEY="must-not-leak"
 export HOME="$TMPROOT/caller-home"
-export CODEX_HOME="$HOME/.codex"
-mkdir -p "$HOME/.config/gh" "$CODEX_HOME"
+export CODEX_REVIEWER_HOME="$TMPROOT/reviewer-home"
+mkdir -p "$HOME/.config/gh" "$CODEX_REVIEWER_HOME"
 printf 'github.com: token\n' > "$HOME/.config/gh/hosts.yml"
+
+resolved_codex_home=$(STUDIO_CONTEXT_HOST_PROFILE=codex-reviewer bash -c ". '$ROOT/scripts/lib-studio-context.sh'; studio_context_get auth_home delegated-host-spawn")
+[ "$resolved_codex_home" = "$CODEX_REVIEWER_HOME" ] || {
+  printf 'fixture resolved codex auth home incorrectly: %s\n' "$resolved_codex_home" >&2
+  exit 1
+}
 
 git -C "$REPO" init -q
 git -C "$REPO" config user.email test@example.com

--- a/scripts/test-fixtures/454-phase-review/test-phase-review.sh
+++ b/scripts/test-fixtures/454-phase-review/test-phase-review.sh
@@ -102,7 +102,7 @@ chmod +x "$BIN/codex"
 
 export PATH="$BIN:$PATH"
 export HOME="$TMPROOT/caller-home"
-export CODEX_HOME="$HOME/.codex"
+export CODEX_REVIEWER_HOME="$TMPROOT/codex-reviewer-home"
 export CLAUDE_REVIEWER_HOME="$TMPROOT/reviewer-home"
 export CLAUDE_REVIEWER_CONFIG_DIR="$CLAUDE_REVIEWER_HOME/.claude-reviewer"
 export GH_TOKEN="must-not-leak"
@@ -110,8 +110,14 @@ export GITHUB_TOKEN="must-not-leak"
 export OPENAI_API_KEY="must-not-leak"
 export ANTHROPIC_API_KEY="must-not-leak"
 
-mkdir -p "$HOME/.config/gh" "$CODEX_HOME" "$CLAUDE_REVIEWER_CONFIG_DIR"
+mkdir -p "$HOME/.config/gh" "$CODEX_REVIEWER_HOME" "$CLAUDE_REVIEWER_CONFIG_DIR"
 printf 'github.com: token\n' > "$HOME/.config/gh/hosts.yml"
+
+resolved_codex_home=$(STUDIO_CONTEXT_HOST_PROFILE=codex-reviewer bash -c ". '$ROOT/scripts/lib-studio-context.sh'; studio_context_get auth_home delegated-host-spawn")
+[ "$resolved_codex_home" = "$CODEX_REVIEWER_HOME" ] || {
+  printf 'fixture resolved codex auth home incorrectly: %s\n' "$resolved_codex_home" >&2
+  exit 1
+}
 
 input="$TMPROOT/plan.md"
 output="$TMPROOT/review.md"


### PR DESCRIPTION
Implements #734.

Summary:
- move reviewer auth-home selection onto Studio context
- route PR metadata/diff reads through the Studio GitHub wrapper
- keep smoke-gated reviewer eligibility and degraded phase-review semantics
- refresh fixtures for normalized home assertions

Verification:
- scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review.sh
- scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
- scripts/test-fixtures/342-precommit-review/test-precommit-review.sh
- scripts/test-fixtures/454-phase-review/test-phase-review.sh
- bash -n ...
- shellcheck -x -e SC1091,SC2016 ...
- git diff --check