### PR TITLE
bugfix-shipped: tolerate non-repo chain manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ scripts/studio-chain-runner.sh --auto workflow-measurement-improvements # unatte
 scripts/studio-chain-runner.sh workflow-measurement-improvements --attended --yes # attended run with explicit confirmation bypass
 scripts/studio-chain-runner.sh workflow-measurement-improvements --unattended --yes # no routine continue prompts; typed blockers halt
 scripts/studio-chain-runner.sh --resume <run_id> --yes # resume state; reconcile completed worker summaries before dependents
+STUDIO_CHAIN_TARGET_REPO_ROOT=/repo scripts/studio-chain-runner.sh /tmp/chain.yaml --dry-run # run a non-repo manifest against an explicit checkout
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview checkpoint-aware safe-boundary hooks
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show next supervisor action without state mutation
 scripts/studio-chain-rule-gates.sh --plan plan.json --dry-run # deterministic rule-pack workflow gates with JSON audit output

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-07T22:26:00Z",
+  "generated_at": "2026-05-08T14:40:19Z",
   "agents": [
 
   ]

--- a/_shared/schemas/chain-plan.md
+++ b/_shared/schemas/chain-plan.md
@@ -16,6 +16,7 @@ private `plan.json` and `state.json` artifacts.
 
 ```yaml
 schema_version: 1
+target_repo_root: /path/to/repo
 rule_packs:
   required: [source-branch-integration]
 chains:
@@ -40,6 +41,7 @@ chains:
 | Field | Required | Default | Notes |
 |---|---:|---|---|
 | `schema_version` | yes | - | Must be `1`. |
+| `target_repo_root` | no | manifest checkout or runner repo | Git checkout used for chain worktrees, branch checks, fetches, and cleanup. Relative paths resolve from the manifest directory first, then the runner repo. `STUDIO_CHAIN_TARGET_REPO_ROOT` and `STUDIO_CONTEXT_REPO_ROOT` are env overrides when the manifest is outside a git checkout. |
 | `rule_packs` | no | `[]` | Global selective rule-pack request. Accepts a string, list, or `{required, optional, advisory, disabled}` object. |
 | `chains[].name` | yes | - | Stable chain name; also drives default branch and worktree slugs. |
 | `chains[].base` | no | `main` | Explicit PR base. Mechanical gates reject missing or invalid bases in the generated plan. |

--- a/core/v2/schemas/chain-manifest.schema.json
+++ b/core/v2/schemas/chain-manifest.schema.json
@@ -8,6 +8,15 @@
   "required": ["schema_version", "chains"],
   "properties": {
     "schema_version": { "const": 1 },
+    "target_repo_root": { "type": "string", "minLength": 1 },
+    "repo_root": { "type": "string", "minLength": 1 },
+    "repo": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "root": { "type": "string", "minLength": 1 }
+      }
+    },
     "rule_packs": { "$ref": "#/$defs/rule_packs" },
     "chains": {
       "type": "array",

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T22:26:00Z",
+  "generated_at": "2026-05-08T14:40:19Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,6 +70,7 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements            # de
 scripts/studio-chain-runner.sh workflow-measurement-improvements --dry-run  # same resolved graph, then non-mutating command trace
 scripts/studio-chain-runner.sh workflow-measurement-improvements --host codex --yes # execute after plan with node/RAM-sized session pool + private report
 scripts/studio-chain-runner.sh my-chain --dry-run                          # object-form issues may declare dependencies/depends_on; ready independent issues fill worker_pool
+STUDIO_CHAIN_TARGET_REPO_ROOT=/repo scripts/studio-chain-runner.sh /tmp/chain.yaml --dry-run # run a non-repo manifest against an explicit checkout
 scripts/studio-chain-runner.sh workflow-measurement-improvements --checkpoint auto --dry-run # preview role/branch-scoped checkpoint hooks
 scripts/studio-chain-runner.sh --discover                                  # bare invocation lists runnable chains, resumable runs, and next actions
 scripts/studio-chain-runner.sh --discover prd-to-chain-automation          # filtered discovery for one chain or manifest

--- a/scripts/lib-studio-context.sh
+++ b/scripts/lib-studio-context.sh
@@ -175,14 +175,30 @@ _studio_context_auth_home_for_profile() {
       fi
       ;;
     codex-reviewer)
-      printf '%s\n' "${CODEX_REVIEWER_HOME:-}"
+      if [ -n "${CODEX_REVIEWER_HOME:-}" ]; then
+        printf '%s\n' "$CODEX_REVIEWER_HOME"
+      elif [ -n "${CODEX_HOME:-}" ]; then
+        printf '%s\n' "$CODEX_HOME"
+      else
+        login_home=$(_studio_context_login_home) || return 1
+        if [ -d "$login_home/.codex-reviewer" ]; then
+          printf '%s\n' "$login_home/.codex-reviewer"
+        else
+          printf '%s\n' "$login_home/.codex"
+        fi
+      fi
       ;;
     claude-code)
       login_home=$(_studio_context_login_home) || return 1
       printf '%s\n' "${CLAUDE_HOME:-$login_home}"
       ;;
     claude-reviewer)
-      printf '%s\n' "${CLAUDE_REVIEWER_HOME:-}"
+      if [ -n "${CLAUDE_REVIEWER_HOME:-}" ]; then
+        printf '%s\n' "$CLAUDE_REVIEWER_HOME"
+      else
+        login_home=$(_studio_context_login_home) || return 1
+        printf '%s\n' "$login_home"
+      fi
       ;;
     gemini|gemini-cli)
       login_home=$(_studio_context_login_home) || return 1

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -254,6 +254,7 @@ fi
 mkdir -p "$(dirname "$output")"
 [ -n "$err_output" ] || err_output="$output.err"
 mkdir -p "$(dirname "$err_output")"
+input_dir=$(cd "$(dirname "$input")" && pwd -P) || fail "input directory not readable: $input"
 
 eligibility_cache_dir="${STUDIO_PHASE_REVIEW_ELIGIBILITY_CACHE_DIR:-}"
 eligibility_cache_file=""
@@ -382,7 +383,7 @@ case "$review_host" in
       CLAUDE_REVIEWER_HOME="$reviewer_claude_home" \
       STUDIO_HOST="$review_host" \
       REVIEW_PAYLOAD="$input" \
-      "${spawn_argv[@]}" "$prompt")
+      "${spawn_argv[@]}" "--add-dir=$input_dir" "$prompt")
     ;;
 esac
 

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -541,7 +541,7 @@ run_review_candidate() {
         REVIEW_PAYLOAD="$payload" \
         PR_URL="$pr_url" \
         PR_HEAD_SHA="$head_sha" \
-        "${spawn_argv[@]}" "$review_prompt" </dev/null > "$summary" 2>"$summary.err" ); then
+        "${spawn_argv[@]}" "--add-dir=$tmpdir" "$review_prompt" </dev/null > "$summary" 2>"$summary.err" ); then
         review_rc=0
       else
         review_rc=$?

--- a/scripts/pre-commit-review.sh
+++ b/scripts/pre-commit-review.sh
@@ -276,7 +276,7 @@ case "$REVIEW_HOST" in
       STUDIO_HOST="$REVIEW_HOST" \
       REVIEW_PAYLOAD="$payload" \
       STAGED_PATCH_ID="$patch_id" \
-      "${spawn_argv[@]}" "$review_prompt")
+      "${spawn_argv[@]}" "--add-dir=$tmpdir" "$review_prompt")
     ;;
 esac
 

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -29,6 +29,7 @@ umask 022
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 CALLER_HOME="${HOME:-}"
+TARGET_REPO_ROOT=""
 
 # shellcheck source=lib-ledger.sh
 . "$SCRIPT_DIR/lib-ledger.sh"
@@ -2254,6 +2255,61 @@ canonical_path() {
   printf '%s\n' "$path"
 }
 
+resolve_existing_path() {
+  local path="$1" base="$2" candidate dir base_name
+  if [ -z "$path" ] || [ "$path" = "null" ]; then
+    return 1
+  fi
+
+  case "$path" in
+    /*) candidate="$path" ;;
+    *)
+      if [ -n "$base" ] && [ -e "$base/$path" ]; then
+        candidate="$base/$path"
+      elif [ -e "$REPO_ROOT/$path" ]; then
+        candidate="$REPO_ROOT/$path"
+      else
+        candidate="$path"
+      fi
+      ;;
+  esac
+
+  [ -e "$candidate" ] || return 1
+  dir=$(cd "$(dirname "$candidate")" && pwd -P) || return 1
+  base_name=$(basename "$candidate")
+  printf '%s/%s\n' "$dir" "$base_name"
+}
+
+resolve_target_repo_root() {
+  local manifest="${1:?usage: resolve_target_repo_root <manifest>}" manifest_dir hint env_hint root
+  manifest_dir=$(cd "$(dirname "$manifest")" && pwd -P) || return 1
+
+  hint=$(yq -r '.target_repo_root // .repo_root // .repo.root // ""' "$manifest" 2>/dev/null || true)
+  root=$(resolve_existing_path "$hint" "$manifest_dir" 2>/dev/null || true)
+  if [ -n "$hint" ] && [ "$hint" != "null" ] && [ -z "$root" ]; then
+    printf 'studio-chain-runner: target repo root does not exist: %s\n' "$hint" >&2
+    exit 2
+  fi
+  if [ -z "$root" ]; then
+    env_hint="${STUDIO_CHAIN_TARGET_REPO_ROOT:-${STUDIO_CONTEXT_REPO_ROOT:-}}"
+    root=$(resolve_existing_path "$env_hint" "$manifest_dir" 2>/dev/null || true)
+    if [ -n "$env_hint" ] && [ -z "$root" ]; then
+      printf 'studio-chain-runner: target repo root does not exist: %s\n' "$env_hint" >&2
+      exit 2
+    fi
+  fi
+  if [ -z "$root" ]; then
+    root=$(git -C "$manifest_dir" rev-parse --show-toplevel 2>/dev/null || true)
+  fi
+  [ -n "$root" ] || root="$REPO_ROOT"
+
+  if ! git -C "$root" rev-parse --show-toplevel >/dev/null 2>&1; then
+    printf 'studio-chain-runner: target repo root is not a git checkout: %s\n' "$root" >&2
+    exit 2
+  fi
+  git -C "$root" rev-parse --show-toplevel
+}
+
 state_manifest_matches() {
   local state="$1" manifest="$2" state_manifest
   state_manifest=$(jq -r '.manifest // empty' "$state" 2>/dev/null || true)
@@ -2906,6 +2962,7 @@ build_plan_json() {
   jq -n \
     --arg run_id "$RUN_ID" \
     --arg manifest "$MANIFEST" \
+    --arg target_repo_root "$TARGET_REPO_ROOT" \
     --arg only_chain "$ONLY_CHAIN" \
     --arg host_override "$HOST_OVERRIDE" \
     --arg parallel_chains "$PARALLEL_CHAINS" \
@@ -2918,6 +2975,7 @@ build_plan_json() {
       schema_version:1,
       run_id:$run_id,
       manifest:$manifest,
+      target_repo_root:$target_repo_root,
       only_chain:(if $only_chain == "" then null else $only_chain end),
       host_override:(if $host_override == "" then null else $host_override end),
       parallel_chains:$parallel_chains,
@@ -3049,7 +3107,7 @@ apply_mechanical_rule_gates() {
   gate_args=(
     --plan "$plan"
     --manifest "$MANIFEST"
-    --repo "$REPO_ROOT"
+    --repo "$TARGET_REPO_ROOT"
     --audit-log "$audit_log"
     --expected-run-work-root "$RUN_WORK_ROOT"
   )
@@ -3167,7 +3225,7 @@ live_preflight() {
   while IFS=$'\t' read -r branch base; do
     run_retryable_or_abort network_partition "cannot verify origin/$base" \
       with_login_home_for_github git ls-remote --exit-code --heads origin "$base"
-    if [ -z "$RESUME_ID" ] && git show-ref --verify --quiet "refs/heads/$branch"; then
+    if [ -z "$RESUME_ID" ] && git -C "$TARGET_REPO_ROOT" show-ref --verify --quiet "refs/heads/$branch"; then
       printf 'studio-chain-runner: local chain branch already exists: %s\n' "$branch" >&2
       exit 2
     fi
@@ -3180,7 +3238,7 @@ $(jq -r '.chains[] | [.branch, .base] | @tsv' "$plan")
 EOF
   while IFS= read -r issue_branch; do
     [ -n "$issue_branch" ] || continue
-    if [ -z "$RESUME_ID" ] && git show-ref --verify --quiet "refs/heads/$issue_branch"; then
+    if [ -z "$RESUME_ID" ] && git -C "$TARGET_REPO_ROOT" show-ref --verify --quiet "refs/heads/$issue_branch"; then
       printf 'studio-chain-runner: local issue branch already exists: %s\n' "$issue_branch" >&2
       exit 2
     fi
@@ -3204,6 +3262,7 @@ explain_plan() {
   printf '# Studio Chain Plan\n\n'
   printf -- '- Run UUID: `%s`\n' "$RUN_ID"
   printf -- '- Manifest: `%s`\n' "$MANIFEST"
+  printf -- '- Target repo root: `%s`\n' "$TARGET_REPO_ROOT"
   printf -- '- State: `%s`\n' "$RUN_STATE_JSON"
   printf -- '- Parallel chains: `%s` effective `%s`\n' "$PARALLEL_CHAINS" "$effective_parallel"
   printf -- '- Execution mode: `%s`\n' "$execution_mode"
@@ -3271,10 +3330,21 @@ explain_plan() {
 prepare_plan() {
   if [ -n "$RESUME_ID" ]; then
     resolve_resume_state
+    TARGET_REPO_ROOT=$(jq -r '.target_repo_root // empty' "$RUN_STATE_JSON" 2>/dev/null || true)
+    if [ -z "$TARGET_REPO_ROOT" ]; then
+      TARGET_REPO_ROOT=$(resolve_target_repo_root "$MANIFEST")
+    fi
+    if ! git -C "$TARGET_REPO_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
+      printf 'studio-chain-runner: target repo root is not a git checkout: %s\n' "$TARGET_REPO_ROOT" >&2
+      exit 2
+    fi
     cp "$RUN_STATE_JSON" "$PLAN_JSON"
+    jq --arg target_repo_root "$TARGET_REPO_ROOT" '.target_repo_root = $target_repo_root' "$PLAN_JSON" > "$PLAN_JSON.tmp.$$"
+    mv "$PLAN_JSON.tmp.$$" "$PLAN_JSON"
   else
     MANIFEST=$(resolve_manifest "$MANIFEST")
     MANIFEST=$(canonical_path "$MANIFEST")
+    TARGET_REPO_ROOT=$(resolve_target_repo_root "$MANIFEST")
     build_plan_json "$PLAN_JSON"
   fi
   attach_rule_pack_resolutions "$PLAN_JSON"
@@ -3541,7 +3611,7 @@ detach_chain_worktree_for_merge_cleanup() {
 
 chain_worktree_registered() {
   local chain_worktree="$1"
-  git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null | awk -v target="$chain_worktree" '
+  git -C "$TARGET_REPO_ROOT" worktree list --porcelain 2>/dev/null | awk -v target="$chain_worktree" '
     /^worktree / && substr($0, 10) == target { found=1 }
     END { exit found ? 0 : 1 }
   '
@@ -3650,7 +3720,7 @@ run_issue_job() {
 
   log "issue #$issue -> $issue_branch"
   if [ "$DRY_RUN" -eq 0 ]; then
-    chain_git_prepare_issue_workspace "$REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
+    chain_git_prepare_issue_workspace "$TARGET_REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
     before=$(git -C "$issue_worktree" rev-parse HEAD)
   else
     printf 'DRY-RUN git metadata strategy for host %q: %s\n' "$host" "$git_metadata_strategy"
@@ -3726,7 +3796,7 @@ run_issue_job() {
     auto_retry_performed=true
     log "issue #$issue exited $worker_rc with no summary and no public diff; retrying once in a fresh issue worktree"
     mark_issue_retry_attempt "$issue_run_id" "worker_summary_missing_no_changes"
-    chain_git_prepare_issue_workspace "$REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
+    chain_git_prepare_issue_workspace "$TARGET_REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
     before=$(git -C "$issue_worktree" rev-parse HEAD)
     mark_issue_state "$issue_run_id" running "$before"
     issue_started_at=$(now_epoch)
@@ -3927,7 +3997,7 @@ integrate_issue_result() {
     if [ "$(jq -r '.resumed // false' "$result_file")" = "true" ]; then
       case "$git_metadata_strategy" in
         linked-worktree)
-          if ! git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$issue_branch"; then
+          if ! git -C "$TARGET_REPO_ROOT" show-ref --verify --quiet "refs/heads/$issue_branch"; then
             log "resume assumes completed issue #$issue already integrated; issue branch missing"
             return 0
           fi
@@ -3950,7 +4020,7 @@ integrate_issue_result() {
       return 1
     fi
     git -C "$chain_worktree" checkout "$branch" || return 1
-    chain_git_integrate_issue_workspace "$REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy" "$sync_strategy" || return 1
+    chain_git_integrate_issue_workspace "$TARGET_REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy" "$sync_strategy" || return 1
     emit_chain_event chain_issue_merged "$issue" "$RUN_ID" "$chain_run_id" "$issue_run_id" completed 0 \
       "$(jq -cn --arg chain "$chain_name" --arg branch "$branch" --arg issue_branch "$issue_branch" --arg commit_after "$result_commit_after" --arg sync_strategy "$sync_strategy" '{chain:$chain, branch:$branch, issue_branch:$issue_branch, sync_strategy:$sync_strategy, commit_after:(if $commit_after == "" then null else $commit_after end)}')"
   else
@@ -3968,8 +4038,8 @@ integrate_issue_result() {
             printf 'DRY-RUN git -C %q commit -m %q\n' "$chain_worktree" "Squash $issue_branch into $branch"
             ;;
         esac
-        printf 'DRY-RUN git -C %q worktree remove %q\n' "$REPO_ROOT" "$issue_worktree"
-        printf 'DRY-RUN git -C %q branch -D %q\n' "$REPO_ROOT" "$issue_branch"
+        printf 'DRY-RUN git -C %q worktree remove %q\n' "$TARGET_REPO_ROOT" "$issue_worktree"
+        printf 'DRY-RUN git -C %q branch -D %q\n' "$TARGET_REPO_ROOT" "$issue_branch"
         ;;
       local-clone)
         case "$sync_strategy" in
@@ -4452,15 +4522,15 @@ for ((idx = 0; idx < chain_count; idx++)); do
   mark_chain_state "$chain_run_id" running
   emit_chain_event chain_started "" "$RUN_ID" "$chain_run_id" "" running 0 \
     "$(jq -cn --arg name "$name" --arg branch "$branch" --arg base "$base" --arg host "$host" --arg git_metadata_strategy "$git_metadata_strategy" --arg sync_strategy "$sync_strategy" --arg approved_release_id "$approved_release_id" --argjson issue_count "$issue_count" --argjson worker_pool "$CHAIN_WORKER_POOL" '{chain:$name, branch:$branch, base:$base, host:$host, git_metadata_strategy:$git_metadata_strategy, sync_strategy:$sync_strategy, approved_release_id:(if $approved_release_id == "" then null else $approved_release_id end), issue_count:$issue_count, worker_pool:$worker_pool}')"
-  host_preflight "$host" "$REPO_ROOT" || abort_run "host preflight failed for $host"
+  host_preflight "$host" "$TARGET_REPO_ROOT" || abort_run "host preflight failed for $host"
   run_retryable_or_abort network_partition "fetch origin failed before chain $name" \
-    with_login_home_for_github git -C "$REPO_ROOT" fetch origin --prune
+    with_login_home_for_github git -C "$TARGET_REPO_ROOT" fetch origin --prune
   if [ "$DRY_RUN" -eq 0 ]; then
     mkdir -p "$chain_results_dir"
     if [ -n "$RESUME_ID" ] && git_checkout_exists "$chain_worktree"; then
       git -C "$chain_worktree" checkout "$branch"
     elif ! git_checkout_exists "$chain_worktree"; then
-      git -C "$REPO_ROOT" worktree add -B "$branch" "$chain_worktree" "origin/$base"
+      git -C "$TARGET_REPO_ROOT" worktree add -B "$branch" "$chain_worktree" "origin/$base"
       git -C "$chain_worktree" checkout "$branch"
       git -C "$chain_worktree" reset --hard "origin/$base"
     else
@@ -4507,17 +4577,17 @@ PR: $FINAL_PR_URL"
 
   if [ "$DRY_RUN" -eq 0 ]; then
     run_retryable_or_abort network_partition "fetch origin failed during chain cleanup" \
-      with_login_home_for_github git -C "$REPO_ROOT" fetch origin --prune
+      with_login_home_for_github git -C "$TARGET_REPO_ROOT" fetch origin --prune
     if chain_worktree_registered "$chain_worktree"; then
-      git -C "$REPO_ROOT" worktree remove "$chain_worktree" || true
+      git -C "$TARGET_REPO_ROOT" worktree remove "$chain_worktree" || true
     else
       log "chain worktree already removed: $chain_worktree"
     fi
-    git -C "$REPO_ROOT" branch -D "$branch" 2>/dev/null || true
+    git -C "$TARGET_REPO_ROOT" branch -D "$branch" 2>/dev/null || true
   else
-    printf 'DRY-RUN git -C %q fetch origin --prune\n' "$REPO_ROOT"
-    printf 'DRY-RUN git -C %q worktree remove %q\n' "$REPO_ROOT" "$chain_worktree"
-    printf 'DRY-RUN git -C %q branch -D %q\n' "$REPO_ROOT" "$branch"
+    printf 'DRY-RUN git -C %q fetch origin --prune\n' "$TARGET_REPO_ROOT"
+    printf 'DRY-RUN git -C %q worktree remove %q\n' "$TARGET_REPO_ROOT" "$chain_worktree"
+    printf 'DRY-RUN git -C %q branch -D %q\n' "$TARGET_REPO_ROOT" "$branch"
   fi
 done
 

--- a/scripts/test-fixtures/732-studio-context/test-studio-context.sh
+++ b/scripts/test-fixtures/732-studio-context/test-studio-context.sh
@@ -12,8 +12,10 @@ BIN="$TMPROOT/bin"
 LOGIN_HOME="$TMPROOT/login-home"
 SYNTH_HOME="$TMPROOT/.codex-homes/personal"
 CODEX_AUTH="$LOGIN_HOME/.codex"
+CODEX_REVIEWER_AUTH="$LOGIN_HOME/.codex-reviewer"
+CLAUDE_REVIEWER_AUTH="$LOGIN_HOME/.claude-reviewer"
 FAKE_AUTH="$TMPROOT/fake-profile-auth"
-mkdir -p "$BIN" "$LOGIN_HOME" "$SYNTH_HOME" "$CODEX_AUTH" "$FAKE_AUTH"
+mkdir -p "$BIN" "$LOGIN_HOME" "$SYNTH_HOME" "$CODEX_AUTH" "$CODEX_REVIEWER_AUTH" "$CLAUDE_REVIEWER_AUTH" "$FAKE_AUTH"
 
 cat > "$BIN/dscl" <<SH
 #!/usr/bin/env bash
@@ -59,6 +61,30 @@ assert_eq "codex auth_home" "$CODEX_AUTH" "$(json_field "$codex_json" auth_home)
 assert_eq "codex github_home normalized to login home" "$LOGIN_HOME" "$(json_field "$codex_json" github_home)"
 assert_eq "codex runtime owner remains project" "project" "$(json_field "$codex_json" runtime_owner)"
 assert_eq "codex data visibility remains private runtime" "private-runtime" "$(json_field "$codex_json" data_visibility)"
+
+codex_reviewer_json="$TMPROOT/codex-reviewer-context.json"
+PATH="$BIN:$PATH" HOME="$SYNTH_HOME" STUDIO_CONTEXT_PROJECT_SLUG=generic-dev-studio STUDIO_CONTEXT_HOST_PROFILE=codex-reviewer \
+  bash -c ". '$ROOT/scripts/lib-studio-context.sh'; studio_context_emit_json delegated-host-spawn" \
+  >"$codex_reviewer_json"
+
+assert_eq "codex reviewer auth_home defaults to login reviewer profile" "$CODEX_REVIEWER_AUTH" "$(json_field "$codex_reviewer_json" auth_home)"
+assert_eq "codex reviewer runtime owner" "reviewer" "$(json_field "$codex_reviewer_json" runtime_owner)"
+
+claude_reviewer_json="$TMPROOT/claude-reviewer-context.json"
+PATH="$BIN:$PATH" HOME="$SYNTH_HOME" STUDIO_CONTEXT_PROJECT_SLUG=generic-dev-studio STUDIO_CONTEXT_HOST_PROFILE=claude-reviewer \
+  bash -c ". '$ROOT/scripts/lib-studio-context.sh'; studio_context_emit_json delegated-host-spawn" \
+  >"$claude_reviewer_json"
+
+assert_eq "claude reviewer auth_home defaults to login home" "$LOGIN_HOME" "$(json_field "$claude_reviewer_json" auth_home)"
+assert_eq "claude reviewer runtime owner" "reviewer" "$(json_field "$claude_reviewer_json" runtime_owner)"
+
+rm -rf "$CODEX_REVIEWER_AUTH"
+codex_reviewer_fallback_json="$TMPROOT/codex-reviewer-fallback-context.json"
+PATH="$BIN:$PATH" HOME="$SYNTH_HOME" STUDIO_CONTEXT_PROJECT_SLUG=generic-dev-studio STUDIO_CONTEXT_HOST_PROFILE=codex-reviewer \
+  bash -c ". '$ROOT/scripts/lib-studio-context.sh'; studio_context_emit_json delegated-host-spawn" \
+  >"$codex_reviewer_fallback_json"
+
+assert_eq "codex reviewer falls back to logged-in codex profile" "$CODEX_AUTH" "$(json_field "$codex_reviewer_fallback_json" auth_home)"
 
 if [ "$(json_field "$codex_json" studio_home)" = "$(json_field "$codex_json" auth_home)" ]; then
   fail "durable Studio state and Codex auth home collapsed to the same root"

--- a/scripts/test-fixtures/745-chain-nonrepo-manifest/test-chain-nonrepo-manifest.sh
+++ b/scripts/test-fixtures/745-chain-nonrepo-manifest/test-chain-nonrepo-manifest.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Verifies chain-runner accepts manifests stored outside any git checkout.
+
+set -eu
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t chain-nonrepo-manifest.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+BIN="$TMPROOT/bin"
+HOME_DIR="$TMPROOT/home"
+mkdir -p "$BIN" "$HOME_DIR" "$TMPROOT/nonrepo"
+
+cat > "$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+  cat <<'JSON'
+{
+  "number": 745,
+  "title": "Non-repo manifest fixture",
+  "body": "Keep temp chain manifests working.",
+  "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/745",
+  "state": "OPEN"
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 1
+SH
+chmod +x "$BIN/gh"
+
+manifest="$TMPROOT/nonrepo/chain.yaml"
+cat > "$manifest" <<YAML
+schema_version: 1
+target_repo_root: $ROOT
+chains:
+  - name: nonrepo-manifest-fixture
+    base: main
+    branch: feature/nonrepo-manifest-fixture
+    host: codex
+    issues: [745]
+YAML
+
+if git -C "$(dirname "$manifest")" rev-parse --show-toplevel >/dev/null 2>&1; then
+  fail "fixture manifest directory unexpectedly lives inside a git checkout"
+fi
+
+PATH="$BIN:$PATH" HOME="$HOME_DIR" "$ROOT/scripts/studio-chain-runner.sh" "$manifest" --dry-run > "$TMPROOT/out" 2>&1
+
+grep -q "Target repo root: \`$ROOT\`" "$TMPROOT/out" || {
+  cat "$TMPROOT/out" >&2
+  fail "plan did not report the manifest-selected target repo root"
+}
+
+grep -q "DRY-RUN HOME=.* scripts/host-preflight.sh codex $ROOT" "$TMPROOT/out" || {
+  cat "$TMPROOT/out" >&2
+  fail "host preflight did not use the target repo root"
+}
+
+grep -q "DRY-RUN retry\\[network_partition\\].* git -C $ROOT fetch origin --prune" "$TMPROOT/out" || {
+  cat "$TMPROOT/out" >&2
+  fail "fetch did not use the target repo root"
+}
+
+fallback_manifest="$TMPROOT/nonrepo/fallback-chain.yaml"
+cat > "$fallback_manifest" <<'YAML'
+schema_version: 1
+chains:
+  - name: fallback-root-fixture
+    base: main
+    branch: feature/fallback-root-fixture
+    host: codex
+    issues: [745]
+YAML
+
+PATH="$BIN:$PATH" HOME="$HOME_DIR" "$ROOT/scripts/studio-chain-runner.sh" "$fallback_manifest" --dry-run > "$TMPROOT/fallback.out" 2>&1
+grep -q "Target repo root: \`$ROOT\`" "$TMPROOT/fallback.out" || {
+  cat "$TMPROOT/fallback.out" >&2
+  fail "non-repo manifest without a target did not fall back to the studio repo root"
+}
+
+if grep -q 'not a git repository' "$TMPROOT/out"; then
+  cat "$TMPROOT/out" >&2
+  fail "non-repo manifest directory leaked into git root resolution"
+fi
+
+bad_manifest="$TMPROOT/nonrepo/bad-chain.yaml"
+cat > "$bad_manifest" <<YAML
+schema_version: 1
+target_repo_root: $TMPROOT/missing-repo
+chains:
+  - name: bad-root-fixture
+    base: main
+    branch: feature/bad-root-fixture
+    host: codex
+    issues: [745]
+YAML
+
+if PATH="$BIN:$PATH" HOME="$HOME_DIR" "$ROOT/scripts/studio-chain-runner.sh" "$bad_manifest" --dry-run > "$TMPROOT/bad.out" 2>&1; then
+  cat "$TMPROOT/bad.out" >&2
+  fail "missing explicit target repo root unexpectedly passed"
+fi
+
+grep -q 'target repo root does not exist' "$TMPROOT/bad.out" || {
+  cat "$TMPROOT/bad.out" >&2
+  fail "missing explicit target repo root did not produce an actionable error"
+}
+
+printf 'PASS: chain-runner non-repo manifest\n'


### PR DESCRIPTION
## Summary
- Fixes chain-runner target repo resolution for manifests stored outside any git checkout.
- Persists `target_repo_root` into chain plan/resume state and uses it for worktree, fetch, branch, and cleanup git operations.
- Makes reviewer auth discovery use the logged-in user profile automatically when dedicated reviewer env vars are missing.
- Allows Claude reviewer wrappers to read generated temp payloads via `--add-dir=<payload-dir>`.

## Verification
- `scripts/test-fixtures/732-studio-context/test-studio-context.sh`
- `scripts/test-fixtures/745-chain-nonrepo-manifest/test-chain-nonrepo-manifest.sh`
- `scripts/test-fixtures/396-chain-telemetry/test-chain-runner-dry-run-telemetry.sh`
- `scripts/test-fixtures/395-chain-control-plane/test-plan-state-and-validation.sh`
- `scripts/lint-chain-workflow-docs.sh`
- `bash -n scripts/lib-studio-context.sh scripts/studio-chain-runner.sh scripts/pre-commit-review.sh scripts/pr-headless-review.sh scripts/phase-review.sh`
- `git diff --check`
- `scripts/pre-commit-review.sh --review-host claude-reviewer` -> approved

Closes #745
