### PR TITLE
bugfix-shipped: keep TF signing check behind live-version guard

### DIFF
--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -33,6 +33,7 @@ Before Step 1:
 - Project release config is readable at `~/.dev-studio/<project>/config/release.env`.
 - ASC private key is readable at `~/.dev-studio/<project>/secrets/appstoreconnect/AuthKey_<key-id>.p8` or the `STUDIO_TF_ASC_KEY_PATH` configured in `release.env`.
 - Slack bot token is readable per `_shared/primitives/slack-post.md` (`~/.dev-studio/<project>/secrets/slack-bot-token`, chmod 600).
+- The repo-local signing keychain is readable at `<project-root>/.dev-studio/signing/zap-dev.keychain-db` or `STUDIO_TF_SIGNING_KEYCHAIN_PATH`, and contains a usable Apple Development / iPhone Developer identity. This check runs after live-version resolution and version-state preflight, but before any pbxproj mutation, so signing setup cannot mask version-resolution failures or strand a build-number commit.
 - `python3` resolves and the `pyjwt` package is importable (used to mint the ASC JWT — see `_shared/primitives/appstore-connect-jwt.md`).
 - Non-interactive GitHub push works for the active branch: `GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=Never git push --dry-run --porcelain -u origin HEAD` succeeds. This preflight runs before any build-number or version mutation; auth failures must not open a credential prompt or create a stranded release commit.
 - Slack notification credentials are verified before mutation unless `STUDIO_TF_SLACK_DEFERRED=1` explicitly marks the run as upload-only/deferred-notification.
@@ -140,7 +141,7 @@ When running in background mode, write `prepared-context.json` after Step 2 and 
 
 Before invoking `xcodebuild archive`, enqueue the archive with `priority: "release"` in `~/.dev-studio/.runtime/build-queue/<node-id>/`, then acquire an `xcodebuild-lock/<node-id>/slot-<n>/` lock before starting the archive. The queue grants up to the node's `parallel_build_slots` and moves release entries ahead of queued task/background work without stopping any in-flight holder.
 
-Authentication is JWT-based via `-authenticationKeyPath` / `-authenticationKeyID` / `-authenticationKeyIssuerID`. `CODE_SIGN_STYLE=Automatic`. Pipe through `xcpretty` for human-readable progress; raw output is preserved on a failure path.
+Authentication is JWT-based via `-authenticationKeyPath` / `-authenticationKeyID` / `-authenticationKeyIssuerID`. `CODE_SIGN_STYLE=Automatic`, with `OTHER_CODE_SIGN_FLAGS="--keychain <repo-local signing keychain>"` so archive signing resolves through the checked keychain. Pipe through `xcpretty` for human-readable progress; raw output is preserved on a failure path.
 
 Verify the `.xcarchive` directory exists at the expected path. If absent, halt — do not export, do not upload, do not draft Slack.
 
@@ -148,7 +149,7 @@ Emit `archive_completed` with `data: { build: NEW_BUILD_NUMBER, version, scheme,
 
 ### Step 5 — Export and upload
 
-Write a transient `ExportOptions.plist` with `method=app-store-connect`, `destination=upload`, `signingStyle=automatic`. Run `xcodebuild -exportArchive` against the archive. The plist's `destination=upload` means xcodebuild posts the build directly to ASC — there is no separate upload step and no local IPA.
+Write a transient `ExportOptions.plist` with `method=app-store-connect`, `destination=upload`, `signingStyle=automatic`. Run `xcodebuild -exportArchive` against the archive with the same repo-local keychain flag used for archive. The plist's `destination=upload` means xcodebuild posts the build directly to ASC — there is no separate upload step and no local IPA.
 
 Do not pipe this command through `xcpretty`. The raw output is short and load-bearing for diagnosis.
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-08T14:40:19Z",
+  "generated_at": "2026-05-08T15:03:33Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T14:40:19Z",
+  "generated_at": "2026-05-08T15:03:33Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -58,6 +58,13 @@
 #   STUDIO_TF_PUSH_PREPARED_CONTEXT_PATH
 #                                 optional path where `push` writes build/version
 #                                 context before the long archive phase.
+#   STUDIO_TF_SIGNING_HOME        override the home directory used for code
+#                                 signing lookups when the host session differs
+#                                 from the login session that owns the signing
+#                                 keychain.
+#   STUDIO_TF_SIGNING_KEYCHAIN_PATH
+#                                 override the repo-local signing keychain path.
+#                                 Defaults to <repo>/.dev-studio/signing/zap-dev.keychain-db.
 
 set -u
 umask 022
@@ -83,11 +90,37 @@ load_release_config || {
   exit 2
 }
 
+resolve_signing_home() {
+  if [ -n "${STUDIO_TF_SIGNING_HOME:-}" ]; then
+    printf '%s\n' "$STUDIO_TF_SIGNING_HOME"
+    return 0
+  fi
+
+  case "$HOME" in
+    */.codex-homes/*)
+      local user_name user_home
+      user_name=$(id -un 2>/dev/null || true)
+      if [ -n "$user_name" ]; then
+        user_home=$(dscl . -read "/Users/$user_name" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || true)
+        if [ -n "$user_home" ]; then
+          printf '%s\n' "$user_home"
+          return 0
+        fi
+      fi
+      ;;
+  esac
+
+  printf '%s\n' "$HOME"
+}
+
+SIGNING_HOME=$(resolve_signing_home)
+
 # Project config is loaded from ~/.dev-studio/<project>/config/release.env.
 # STUDIO_TF_* env overrides keep synthetic fixtures out of the real checkout.
 PROJECT_ROOT="${STUDIO_TF_PROJECT_ROOT:-/Users/vishalsingh/Documents/Turnip.gg/turnip-ios}"
 PBXPROJ="${STUDIO_TF_PBXPROJ:-$PROJECT_ROOT/zaps-app/Turnip.xcodeproj/project.pbxproj}"
 PROJECT_RELPATH="${STUDIO_TF_PROJECT_RELPATH:-zaps-app/Turnip.xcodeproj}"
+SIGNING_KEYCHAIN_PATH="${STUDIO_TF_SIGNING_KEYCHAIN_PATH:-$PROJECT_ROOT/.dev-studio/signing/zap-dev.keychain-db}"
 ASC_KEY_ID="${STUDIO_TF_ASC_KEY_ID:-}"
 ASC_ISSUER_ID="${STUDIO_TF_ASC_ISSUER_ID:-}"
 ASC_KEY_PATH=$(release_asc_key_path "$ASC_KEY_ID" 2>/dev/null || true)
@@ -226,6 +259,23 @@ PY
     [ -r "$SLACK_TOKEN_FILE" ] || halt_failed prereq "Slack token unreadable at $SLACK_TOKEN_FILE; no mutation occurred. Set STUDIO_TF_SLACK_DEFERRED=1 only for an intentionally upload-only run."
     [ -s "$SLACK_TOKEN_FILE" ] || halt_failed prereq "Slack token file is empty at $SLACK_TOKEN_FILE; no mutation occurred. Set STUDIO_TF_SLACK_DEFERRED=1 only for an intentionally upload-only run."
   fi
+}
+
+validate_signing_assets() {
+  [ -r "$SIGNING_KEYCHAIN_PATH" ] || halt_failed prereq "repo-local signing keychain unreadable at $SIGNING_KEYCHAIN_PATH; import the .p12 into that keychain before re-running"
+
+  require_cmd security
+
+  local signing_identities signing_count apple_development_count signing_identity_sha1
+  signing_identities=$(HOME="$SIGNING_HOME" security find-identity -v -p codesigning "$SIGNING_KEYCHAIN_PATH" 2>/dev/null || true)
+  signing_count=$(printf '%s\n' "$signing_identities" | awk '/valid identities found/ {print $1; found=1} END {if (!found) print 0}')
+  apple_development_count=$(printf '%s\n' "$signing_identities" | grep -Ec 'Apple Development|iPhone Developer' || true)
+  if [ "${signing_count:-0}" -eq 0 ] || [ "${apple_development_count:-0}" -eq 0 ]; then
+    halt_failed prereq "No usable Apple Development signing identity is available in the repo-local signing keychain at $SIGNING_KEYCHAIN_PATH; import the matching .p12/private key there before re-running."
+  fi
+  signing_identity_sha1=$(printf '%s\n' "$signing_identities" | awk '/Apple Development|iPhone Developer/ {print $2; exit}')
+  [ -n "$signing_identity_sha1" ] || halt_failed prereq "could not derive signing identity SHA-1 from $SIGNING_KEYCHAIN_PATH"
+  SIGNING_IDENTITY_SHA1="$signing_identity_sha1"
 }
 
 asc_get() {
@@ -803,6 +853,7 @@ cmd_push() {
         halt_failed prereq "explicit version $VERSION already exists in ASC as $existing_live_state; choose a new STUDIO_TF_FORCE_VERSION"
       fi
     fi
+    validate_signing_assets
   fi
 
   # Phase 1.5 — pbxproj bump + commit + push (Step 3).
@@ -914,6 +965,7 @@ EOF
   else
     local archive_log="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-archive.log"
     (
+      HOME="$SIGNING_HOME"
       cd "$PROJECT_ROOT" || exit 1
       xcodebuild archive \
         -project "$PROJECT_RELPATH" \
@@ -924,6 +976,7 @@ EOF
         -authenticationKeyPath "$ASC_KEY_PATH" \
         -authenticationKeyID "$ASC_KEY_ID" \
         -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+        OTHER_CODE_SIGN_FLAGS="--keychain $SIGNING_KEYCHAIN_PATH" \
         CODE_SIGN_STYLE=Automatic \
         2>&1 | tee "$archive_log" | { [ -x "$XCPRETTY" ] && "$XCPRETTY" || cat; }
       exit "${PIPESTATUS[0]}"
@@ -971,7 +1024,7 @@ EOF
 </plist>
 PLIST
     local export_log="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-export.log"
-    if ! xcodebuild -exportArchive \
+    if ! HOME="$SIGNING_HOME" xcodebuild -exportArchive \
         -archivePath "$ARCHIVE_PATH" \
         -exportPath "/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-export" \
         -exportOptionsPlist "$export_plist" \
@@ -979,6 +1032,7 @@ PLIST
         -authenticationKeyPath "$ASC_KEY_PATH" \
         -authenticationKeyID "$ASC_KEY_ID" \
         -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+        OTHER_CODE_SIGN_FLAGS="--keychain $SIGNING_KEYCHAIN_PATH" \
         >"$export_log" 2>&1; then
       halt_failed upload "xcodebuild -exportArchive exit non-zero (log: $export_log)"
     fi

--- a/scripts/test-fixtures/288-tf-push/run.sh
+++ b/scripts/test-fixtures/288-tf-push/run.sh
@@ -257,6 +257,50 @@ fi
 echo "PASS: empty live-version response is not treated as no conflict"
 
 echo
+echo "=== Test 8b: signing prereq runs after live-version resolution ==="
+cat > "$TMPHOME/bin/curl" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"/appStoreVersions?fields[appStoreVersions]=versionString,appStoreState"*)
+    printf '{"data":[{"attributes":{"versionString":"1.0.0","appStoreState":"READY_FOR_SALE"}}]}\n'
+    ;;
+  *)
+    printf '{"data":[]}\n'
+    ;;
+esac
+SH
+chmod +x "$TMPHOME/bin/curl"
+VERSIONS_READY_JSON="$TMPHOME/versions-ready.json"
+printf '{"data":[{"attributes":{"versionString":"1.0.0"}}]}\n' > "$VERSIONS_READY_JSON"
+if PATH="$TMPHOME/bin:$PATH" \
+    STUDIO_TF_PUSH_LIVE=1 \
+    STUDIO_TF_PUSH_SKIP_NODE_PICK=1 \
+    STUDIO_TF_SLACK_DEFERRED=1 \
+    STUDIO_RELEASE_TAG="release-fixture-744" \
+    STUDIO_TF_PROJECT_ROOT="$PROJECT" \
+    STUDIO_TF_PBXPROJ="$PBX" \
+    STUDIO_TF_APP_ID="fixture-app" \
+    STUDIO_TF_ASC_KEY_ID="fixture-key" \
+    STUDIO_TF_ASC_ISSUER_ID="fixture-issuer" \
+    STUDIO_TF_ASC_KEY_PATH="$ASC_KEY" \
+    STUDIO_TF_BUILDS_RESPONSE_FILE="$BUILDS_JSON" \
+    STUDIO_TF_VERSIONS_RESPONSE_FILE="$VERSIONS_READY_JSON" \
+    STUDIO_TF_SIGNING_KEYCHAIN_PATH="$TMPHOME/missing-signing.keychain-db" \
+    "$REPO/scripts/studio-tf-push.sh" push >"$TMPHOME/signing-order.out" 2>&1; then
+  echo "FAIL: missing signing keychain should halt"; exit 1
+fi
+grep -q "repo-local signing keychain unreadable" "$TMPHOME/signing-order.out" \
+  || { echo "FAIL: missing signing-keychain prereq message"; cat "$TMPHOME/signing-order.out"; exit 1; }
+if grep -q "WARNING: Could not determine live App Store version" "$TMPHOME/signing-order.out"; then
+  echo "FAIL: signing-order fixture unexpectedly hit live-version warning"; cat "$TMPHOME/signing-order.out"; exit 1
+fi
+grep -q "CURRENT_PROJECT_VERSION = 1;" "$PBX" || { echo "FAIL: build number mutated before signing prereq"; exit 1; }
+if "$REAL_GIT" -C "$PROJECT" log --oneline --grep="Bump build number" | grep -q .; then
+  echo "FAIL: build-number commit was created before signing prereq"; exit 1
+fi
+echo "PASS: signing prereq waits until after live-version resolution and before mutation"
+
+echo
 echo "=== Test 9: release config resolves under per-project dev-studio root ==="
 CONFIG_ROOT="$TMPHOME/.dev-studio/fixture-ios"
 mkdir -p "$CONFIG_ROOT/config" "$CONFIG_ROOT/secrets/appstoreconnect"


### PR DESCRIPTION
Closes #744.

## Summary
- add repo-local signing keychain validation after live-version and version-state checks, before pbxproj mutation
- pass the checked keychain/HOME context into archive and export
- document the signing prereq in the release TF push contract
- add fixture coverage proving missing signing setup no longer masks live-version failures

## Verification
- `bash scripts/test-fixtures/288-tf-push/run.sh`
- `bash -n scripts/studio-tf-push.sh && bash -n scripts/test-fixtures/288-tf-push/run.sh && git diff --check`
- `scripts/pre-commit-review.sh` -> `PRECOMMIT_REVIEW_VERDICT=approved`

Note: pre-commit regenerated `docs-surface.json` and `_shared/schemas/capability-manifest.json` timestamps only.