### PR TITLE
feature: script TestFlight Slack draft handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ STUDIO_TRACK=<track>             # session-start shortcut for v2 track work
 /dev-studio release-manager tf-push --background     # start TF archive/upload and keep session free for Slack drafting
 /dev-studio release-manager tf-push --version 26.5.0 # TestFlight push with explicit MARKETING_VERSION; live work needs STUDIO_TF_PUSH_LIVE=1
 /fullSendToAppStore              # App Store submit: wrapper approves copy; script owns GitHub/ASC/Slack handoff
+scripts/studio-tf-slack.sh draft --context ctx.json --commits commits.txt # durable, linted TestFlight Slack draft artifact
 scripts/studio-tf-push.sh compose-message --channel testflight < commits.txt # taxonomy-aware release/TestFlight bullet composer
 scripts/studio-tf-push.sh withdraw-tf-tag --version 26.4.17 --build 3162 # rename TF anchor to tf-<version>-<build>-WITHDRAWN
 scripts/release-manager-configure.sh --project turnip-ios --quick --appstore-slack-channel C... # configure opt-in App Store Slack release announcements
@@ -215,6 +216,7 @@ scripts/                # multi-worker fleet (BETA)
   chanakya-task-train.sh # manual single-train runner with sibling plan/outcome reviews and resume state
   analyze-collect.sh    # mechanical stats for usage-analysis passes (see ANALYSIS.md)
   release-manager-configure.sh # project release notification setup (Slack first)
+  studio-tf-slack.sh # script-backed TF Slack draft/send bridge with lint + approval gate
   forge-latency-report.sh  # stage-level task latency + review-gate comparison from event logs
   field-workflow-report.sh # Field loop report: timing, token, gate, review, and improvement mining
   studio-pr-baseline-report.sh # PR-level timing, churn, gate, and generated-file baselines

--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -21,8 +21,8 @@ emission, and durable release handoff state.
 
 | Path | Wrapper owns | Script owns | Watcher/finalizer owns |
 |---|---|---|---|
-| TestFlight push (`/dev-studio release-manager tf-push` or `/pushTFBuild`) | Slack draft, recent-thread reporter `cc:` tagging, human approval, Slack send | build/version bump, TF tag, archive, ASC upload, dSYM upload, pre-Slack events, `emit` primitive for wrapper Slack events | none |
-| TestFlight Slack recovery (`/postSlackTesting`) | Slack draft, reporter `cc:` tagging, human approval, Slack send for an already uploaded build | Slack read/write primitives only | none |
+| TestFlight push (`/dev-studio release-manager tf-push` or `/pushTFBuild`) | Natural-language polish, recent-thread reporter `cc:` tagging, human approval | `studio-tf-push.sh`: build/version bump, TF tag, archive, ASC upload, dSYM upload, pre-Slack events. `studio-tf-slack.sh`: draft artifacts, format lint, approval-gated send, Slack events. | none |
+| TestFlight Slack recovery (`/postSlackTesting`) | Reporter `cc:` tagging and human approval for an already uploaded build | Slack read/write primitives plus `studio-tf-slack.sh` draft/send when release context is available | none |
 | App Store submission (`/fullSendToAppStore`) | GitHub/Slack release-notes body, App Store "What's New", human approval | tag push, GitHub draft release, ASC submission, optional configured Slack parent/thread post, PR handoff, release artifact, pending marker | publish GitHub release, update Slack release link, and promote the PR only after `READY_FOR_SALE` and HEAD-bound release approval |
 
 App Store release notes deliberately omit reporter `cc:` mentions. Reporter
@@ -221,6 +221,10 @@ and TF anchor, submits the replacement build, sets `replaces` /
 `superseded_by`, and updates the existing announcement thread.
 
 Format the parent and thread per `_shared/contracts/build-message-format.md`.
+The deterministic draft/send rail is `scripts/studio-tf-slack.sh`: `draft`
+calls the taxonomy-aware composer, persists parent/thread/combined metadata,
+runs the TestFlight message linter, and emits `slack_drafted`; `send` refuses
+without explicit approval, posts parent then thread, and emits `slack_sent`.
 The default parent is brief: headline, one tester-facing summary, then
 `Details in thread.` The detailed tester checklist goes in the first thread
 reply. Group by product area/module when useful; otherwise use the standard

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-08T18:54:19Z",
+  "generated_at": "2026-05-08T19:54:45Z",
   "agents": [
 
   ]

--- a/commands/dev-studio.md
+++ b/commands/dev-studio.md
@@ -78,9 +78,11 @@ supplies the task context and runtime slug.
      call `$STUDIO_REPO/scripts/release-manager-configure.sh` after shaping
      quick/custom/descriptive Slack options with the user.
    - `release-manager tf-push` -> TestFlight operator path. Use
-     `/pushTFBuild` semantics: the wrapper owns Slack drafting, reporter
-     tagging, approval, and send; `$STUDIO_REPO/scripts/studio-tf-push.sh push`
-     owns build/upload mechanics only.
+     `/pushTFBuild` semantics: `$STUDIO_REPO/scripts/studio-tf-push.sh push`
+     owns build/upload mechanics, and
+     `$STUDIO_REPO/scripts/studio-tf-slack.sh` owns draft artifacts, format
+     lint, approval-gated Slack send, and Slack release events. The wrapper
+     may polish wording and reporter `cc:` attribution before approval.
    - App Store submission remains `/fullSendToAppStore`: the wrapper approves
      release copy, then `$STUDIO_REPO/scripts/studio-tf-push.sh appstore`
      owns tag/GitHub draft/ASC/configured-Slack/PR handoff. The watcher

--- a/commands/pushTFBuild.md
+++ b/commands/pushTFBuild.md
@@ -5,7 +5,12 @@ allowed-tools: [Bash, Read, Edit, Grep]
 
 # Push iOS Build to TestFlight
 
-Hybrid wrapper around `scripts/studio-tf-push.sh` (studio repo at `~/Documents/v-i-s-h-a-l/github/generic-dev-studio`). The studio script owns all mechanical work — bump, archive, export+upload, dSYMs — and emits the four pre-Slack events. This wrapper drives Slack composition + the human-approval gate, then emits `slack_drafted` / `slack_sent` via the same script's `emit` subcommand so all six events share one release-tag.
+Hybrid wrapper around `scripts/studio-tf-push.sh` and
+`scripts/studio-tf-slack.sh` (studio repo at
+`~/Documents/v-i-s-h-a-l/github/generic-dev-studio`). The push script owns all
+mechanical work — bump, archive, export+upload, dSYMs — and emits the four
+pre-Slack events. The Slack bridge owns draft artifacts, format lint,
+approval-gated send, and `slack_drafted` / `slack_sent` event emission.
 
 Operator path: use `/dev-studio release-manager tf-push ...` or this
 `/pushTFBuild` wrapper for a full TestFlight push. The split is intentional:
@@ -22,8 +27,9 @@ channel and notification shape with `/dev-studio release-manager configure`.
 | Surface | Owner |
 |---|---|
 | Build/version bump, archive, ASC upload, dSYM upload, TF anchor tag, pre-Slack events | `scripts/studio-tf-push.sh push` |
-| Slack draft composition, recent-thread reporter `cc:` tagging, human approval, Slack parent/thread send | `/pushTFBuild` wrapper |
-| `slack_drafted`, `slack_sent`, and notification failure events | `/pushTFBuild` via `scripts/studio-tf-push.sh emit` |
+| Slack draft artifact, taxonomy composer, format lint, approval-gated parent/thread send | `scripts/studio-tf-slack.sh` |
+| Natural-language polish and recent-thread reporter `cc:` judgment | `/pushTFBuild` wrapper before approval |
+| `slack_drafted`, `slack_sent`, and notification failure events | `scripts/studio-tf-slack.sh` |
 | Notification-only recovery for an already uploaded build | `/postSlackTesting`, not `push` |
 
 ## Arguments
@@ -102,7 +108,7 @@ PREV_BUILD=$(echo "$CTX" | jq -r .prev_build)
 
 Proceed to Slack drafting while the background run continues. Before sending Slack, require `STATUS_PATH` to show `state=="succeeded"` and load final `CTX` from `CONTEXT_PATH`; if it shows `failed`, surface `LOG_PATH` and stop.
 
-## Step 3: Compose the Slack message
+## Step 3: Draft the Slack message artifact
 
 Compose from the user's commits since the last shared TF build, per `_shared/contracts/build-message-format.md`.
 
@@ -129,10 +135,29 @@ if [ -n "$LAST_SHARED_TF_TAG" ]; then
 else
   LOWER_BOUND=$(git log --oneline --all --grep="Bump build number to $LAST_SHARED_BUILD" | head -1 | cut -d' ' -f1)
 fi
-git log --no-merges --author="vishal" --format="%h | %s%n%b%n---" ${LOWER_BOUND}..HEAD | grep -viE "Bump (build|version)"
+git log --no-merges --author="vishal" --format="%h | %s%n%b%n---" ${LOWER_BOUND}..HEAD \
+  | grep -viE "Bump (build|version)" > /tmp/tf-commits.txt
 ```
 
-Read full commit messages (subject + body). Compose per `build-message-format.md`:
+Then render and lint a durable draft:
+
+```bash
+cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
+DRAFT_JSON=$(./scripts/studio-tf-slack.sh draft \
+  --context "${CONTEXT_PATH:-$PREPARED_CONTEXT_PATH}" \
+  --commits /tmp/tf-commits.txt \
+  --summary "<one tester-facing summary>")
+PARENT_PATH=$(jq -r .parent_path "$DRAFT_JSON")
+THREAD_PATH=$(jq -r .thread_path "$DRAFT_JSON")
+```
+
+The script calls `studio-tf-push.sh compose-message --channel testflight`, runs
+`lint-build-release-message.sh --channel testflight`, persists the parent,
+thread, combined message, and metadata under
+`~/.dev-studio/<project>/state/release-drafts/<release-tag>/`, then emits
+`slack_drafted`.
+
+Before approval, improve the generated parent/thread files when needed:
 
 - Parent: brief tester-facing summary since the last posted TF build, then `Details in thread.`
 - Thread detail: grouped tester checklist. Prefer module/product-area groups when useful; otherwise use `*New*` / `*Fixed*` / `*Crash fixes*`.
@@ -142,7 +167,7 @@ Read full commit messages (subject + body). Compose per `build-message-format.md
 - Headline: `[iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. Prefix `<!here>` only when `STUDIO_TF_SLACK_NOTIFY_HERE=1`.
 - Technical notes go at the end of the thread under `*Technical notes*`, only when they materially affect testing or product expectations.
 
-## Step 4: Scan recent threads for cc-tag attribution
+## Step 4: Scan recent threads for cc-tag attribution and polish
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
@@ -155,50 +180,32 @@ cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
 
 Append `cc: <@USER_ID>` inline on bullets that match a thread reply. Show parenthesised display name to the user only — strip before sending.
 
-## Step 5: Emit `slack_drafted`
+After editing the generated files, re-run:
 
 ```bash
-BULLETS=$(echo "$BODY" | grep -c '^•')
-CCS=$(echo "$BODY" | grep -oE 'cc: <@[A-Z0-9]+>' | wc -l | tr -d ' ')
-cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
-./scripts/studio-tf-push.sh emit slack_drafted --release-tag "$RELEASE_TAG" \
-  --data "$(jq -nc --argjson b "$NEW_BUILD_NUMBER" --argjson bc "$BULLETS" --argjson cc "$CCS" \
-              --arg ch "${STUDIO_TF_SLACK_CHANNEL_NAME:-$TF_CHANNEL}" \
-              '{build:$b, channel:$ch, bullet_count:$bc, cc_count:$cc}')"
+cat "$PARENT_PATH" "$THREAD_PATH" > "$(jq -r .combined_path "$DRAFT_JSON")"
+./scripts/lint-build-release-message.sh --file "$(jq -r .combined_path "$DRAFT_JSON")" --channel testflight
 ```
 
-## Step 6: Human-approval gate
+## Step 5: Human-approval gate
 
 Show the draft to the user verbatim — include parenthesised display names next to each `<@USER_ID>` for review readability. Ask: **"Send this, or edit first?"**
 
-If the user edits, update the draft and re-emit `slack_drafted` with the same `--release-tag` (the ledger keys on it; consumers see one drafted span with the latest content). Wait for explicit approval before Step 7.
+If the user edits, update the parent/thread files and re-show the result. Wait
+for explicit approval before Step 6.
 
-## Step 7: Send to Slack
+## Step 6: Send to Slack
 
-Strip parenthesised display names from the body, then:
+Strip parenthesised display names from the parent/thread files, then:
 
 ```bash
 cd ~/Documents/v-i-s-h-a-l/github/generic-dev-studio
-RESP=$(./scripts/slack-post.sh --channel "$TF_CHANNEL" --text "$FINAL_PARENT_BODY")
-PARENT_TS=$(echo "$RESP" | jq -r .ts)
-[ -n "$PARENT_TS" ] && [ "$PARENT_TS" != "null" ] || { echo "slack-post returned no ts"; exit 1; }
-./scripts/slack-post.sh --channel "$TF_CHANNEL" --thread-ts "$PARENT_TS" --text "$FINAL_THREAD_BODY" >/dev/null
-
-CHARS=$(printf '%s%s' "$FINAL_PARENT_BODY" "$FINAL_THREAD_BODY" | wc -c | tr -d ' ')
-./scripts/studio-tf-push.sh emit slack_sent --release-tag "$RELEASE_TAG" \
-  --data "$(jq -nc --argjson b "$NEW_BUILD_NUMBER" --arg ts "$PARENT_TS" --argjson c "$CHARS" \
-              --arg ch "${STUDIO_TF_SLACK_CHANNEL_NAME:-$TF_CHANNEL}" \
-              '{build:$b, channel:$ch, parent_ts:$ts, message_chars:$c}')"
+./scripts/studio-tf-slack.sh send --draft "$DRAFT_JSON" --approve
 ```
 
-If the post fails:
-
-```bash
-./scripts/studio-tf-push.sh emit release_failed --release-tag "$RELEASE_TAG" \
-  --data "$(jq -nc --arg r "$REASON" '{stage:"slack_send", reason:$r}')"
-```
-
-The build is already on TestFlight; the failure is in notification, not delivery. Do not re-run upload.
+If the post fails, the bridge emits `release_failed` with `stage:"slack_send"`.
+The build is already on TestFlight; the failure is in notification, not
+delivery. Do not re-run upload.
 
 ## Rollback
 

--- a/core/v2/roles/release-manager.yaml
+++ b/core/v2/roles/release-manager.yaml
@@ -64,6 +64,7 @@ verification_floor:
   - Release packet names release scope, anchor issues including #214, notes state, tag state, GitHub release state, TestFlight/App Store state, and blockers.
   - "Release notes inspect `Changelog:` trailers per `_shared/contracts/definition-of-done.md`; if trailers are ignored or rewritten, the release packet records why."
   - Build/release message lint and external-channel states are represented as explicit evidence states.
+  - TestFlight Slack draft/send flows use the script-backed bridge (`scripts/studio-tf-slack.sh`) for draft artifacts, format lint, approval-gated posting, and Slack event emission.
   - Notification setup writes project-scoped config only; Slack is optional, `<!here>` is opt-in, and TestFlight details default to a thread.
   - Any release-blocking item names the missing evidence or required operator decision.
   - Release-manager checkpoints may summarize packet progress, but release-packet remains the release readiness artifact.

--- a/core/v2/skills/dev-studio/docs.html
+++ b/core/v2/skills/dev-studio/docs.html
@@ -544,9 +544,10 @@ scripts/manager-chain-monitor.sh status --project generic-dev-studio --json</cod
           </article>
           <article class="role">
             <h3>Release Handoff</h3>
-            <p>Use the wrapper as the operator path. TestFlight Slack drafting and reporter tagging stay with <code>/pushTFBuild</code>; App Store copy approval stays with <code>/fullSendToAppStore</code>. The script owns GitHub, ASC, configured Slack, artifact, and PR handoff after approval.</p>
+            <p>Use the wrapper as the operator path. TestFlight Slack drafting runs through <code>scripts/studio-tf-slack.sh</code> for durable draft artifacts, format lint, approval-gated posting, and release events; App Store copy approval stays with <code>/fullSendToAppStore</code>.</p>
             <code class="shell">/dev-studio release-manager tf-push --background
 /fullSendToAppStore
+scripts/studio-tf-slack.sh draft --context ctx.json --commits commits.txt
 scripts/studio-tf-push.sh appstore --build N --version X.Y.Z --release-notes-file notes.txt --whatsnew-file whatsnew.txt</code>
           </article>
           <article class="role">
@@ -826,7 +827,7 @@ scripts/v2-multispawn-pilot.sh run</code>
           </article>
           <article class="role">
             <h3>release-manager</h3>
-            <p>Assembles release readiness, blocker state, notes, tag state, TestFlight/App Store state, and approval gates. Live Slack/GitHub/App Store handoff uses the release wrappers and backend scripts after approval.</p>
+            <p>Assembles release readiness, blocker state, notes, tag state, TestFlight/App Store state, and approval gates. TestFlight Slack handoff is script-backed for draft artifacts, lint, approval, posting, and release events.</p>
             <div class="meta"><span class="pill status-contract">approval-gated</span><span class="pill">handoff: release-packet</span></div>
             <code class="shell">/dev-studio release-manager help
 /dev-studio release-manager

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T18:54:19Z",
+  "generated_at": "2026-05-08T19:54:44Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -145,6 +145,8 @@ scripts/push-queue.sh mark-displayed <id>...            # clear after surfacing
 scripts/status-domain.sh rounds                         # one-line round summary (prefers YAML; legacy fallback)
 scripts/status-domain.sh releases                       # one-line release summary + push-tf suggestion
 scripts/release-manager-configure.sh --project <slug> --quick --tf-slack-channel C... # release notification setup
+scripts/studio-tf-slack.sh draft --context ctx.json --commits commits.txt # durable, linted TestFlight Slack draft artifact
+scripts/studio-tf-slack.sh send --draft draft.json --approve              # approval-gated parent/thread Slack post + events
 
 # Reviewer pipeline — mechanical extractions from the v2 reviewer role contract:
 eval "$(scripts/argus-setup.sh T001 S /path/to/worktree)"           # marker + review_requested + trap line

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -3,10 +3,9 @@
 #
 # Implements `_shared/contracts/release-tf-push.md` Steps 1–6 (TF push) and
 # the App Store Connect submission path. Step 7–9 (Slack draft + human
-# approval + send) live in the slash-command wrapper because they need LLM
-# judgment and a user-approval gate; the wrapper emits `slack_drafted` /
-# `slack_sent` via `studio-tf-push.sh emit` so the event taxonomy stays
-# under one roof.
+# approval + send) are handled by `studio-tf-slack.sh` plus the operator
+# wrapper: the script owns deterministic artifacts/events/posting, while the
+# wrapper owns language judgment and explicit approval.
 #
 # Subcommands:
 #   push       (default) — Steps 1–6 of release-tf-push.md. Bumps build /
@@ -14,7 +13,7 @@
 #              Outputs a one-line JSON context blob on stdout for the wrapper
 #              (release_tag, build, version, scheme, branch, archive_path,
 #              prev_build, tf_tag). Slack draft, reporter tagging, approval,
-#              and Slack send stay in /pushTFBuild or /postSlackTesting.
+#              and Slack send go through `studio-tf-slack.sh`.
 #   appstore   — App Store submission: tag + push tag, GH draft release,
 #              find build on ASC, create/update version, set MANUAL release,
 #              update whatsNew per localization. Inputs (release notes, what's

--- a/scripts/studio-tf-slack.sh
+++ b/scripts/studio-tf-slack.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# studio-tf-slack.sh — script-backed TestFlight Slack draft/send bridge.
+#
+# This owns the deterministic Step 7-9 rail from
+# _shared/contracts/release-tf-push.md. Assistants may edit the generated
+# parent/thread files before approval, but they should not freehand the
+# release events, linter gate, or Slack posting sequence.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=lib-release-config.sh
+. "$SCRIPT_DIR/lib-release-config.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/studio-tf-slack.sh draft --context <context.json> --commits <commits.txt> [--summary <text>] [--output-dir <dir>] [--dry-run]
+  scripts/studio-tf-slack.sh send --draft <draft.json> --approve [--dry-run]
+
+Draft renders parent/thread/combined files, validates the TestFlight message
+shape, persists draft metadata, and emits slack_drafted. Send refuses without
+--approve, posts parent then thread, and emits slack_sent. Dry-run events carry
+dry_run:true. On send failure it emits release_failed with stage "slack_send".
+EOF
+  exit 2
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'studio-tf-slack: %s required\n' "$1" >&2
+    exit 2
+  }
+}
+
+json_get() {
+  local file="$1" filter="$2"
+  jq -r "$filter // empty" "$file"
+}
+
+release_emit() {
+  local event="$1" release_tag="$2" data="$3"
+  ACHILLES_PROJECT="$RELEASE_PROJECT" STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/studio-tf-push.sh" emit "$event" \
+    --release-tag "$release_tag" --data "$data"
+}
+
+message_char_count() {
+  wc -c "$@" | awk 'END {print $1}'
+}
+
+cmd_draft() {
+  local context_path="" commits_path="" summary="" output_dir="" dry_run=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --context) context_path="${2:?--context requires a path}"; shift 2 ;;
+      --context=*) context_path="${1#--context=}"; shift ;;
+      --commits) commits_path="${2:?--commits requires a path}"; shift 2 ;;
+      --commits=*) commits_path="${1#--commits=}"; shift ;;
+      --summary) summary="${2:?--summary requires text}"; shift 2 ;;
+      --summary=*) summary="${1#--summary=}"; shift ;;
+      --output-dir) output_dir="${2:?--output-dir requires a path}"; shift 2 ;;
+      --output-dir=*) output_dir="${1#--output-dir=}"; shift ;;
+      --dry-run) dry_run=1; shift ;;
+      -h|--help) usage ;;
+      *) printf 'studio-tf-slack draft: unknown arg %s\n' "$1" >&2; usage ;;
+    esac
+  done
+
+  [ -n "$context_path" ] || usage
+  [ -r "$context_path" ] || { printf 'studio-tf-slack draft: context not readable: %s\n' "$context_path" >&2; exit 2; }
+  [ -n "$commits_path" ] || usage
+  [ -r "$commits_path" ] || { printf 'studio-tf-slack draft: commits not readable: %s\n' "$commits_path" >&2; exit 2; }
+
+  load_release_config || {
+    printf 'studio-tf-slack: could not resolve release config project\n' >&2
+    exit 2
+  }
+  require_cmd jq
+
+  local release_tag build version prev_build channel channel_name headline parent_path thread_path combined_path metadata_path composer_json bullet_count cc_count lint_status
+  release_tag=$(json_get "$context_path" '.release_tag')
+  build=$(json_get "$context_path" '.build')
+  version=$(json_get "$context_path" '.version')
+  prev_build=$(json_get "$context_path" '.prev_build')
+  [ -n "$release_tag" ] || { printf 'studio-tf-slack draft: context missing release_tag\n' >&2; exit 2; }
+  [ -n "$build" ] || { printf 'studio-tf-slack draft: context missing build\n' >&2; exit 2; }
+  [ -n "$version" ] || version="unknown"
+  [ -n "$prev_build" ] || prev_build="null"
+
+  channel="${STUDIO_TF_SLACK_CHANNEL:-}"
+  [ -n "$channel" ] || { printf 'studio-tf-slack draft: STUDIO_TF_SLACK_CHANNEL missing; run /dev-studio release-manager configure\n' >&2; exit 2; }
+  channel_name="${STUDIO_TF_SLACK_CHANNEL_NAME:-$channel}"
+
+  if [ -z "$output_dir" ]; then
+    output_dir="$RELEASE_PROJECT_ROOT/state/release-drafts/$release_tag"
+  fi
+  mkdir -p "$output_dir"
+
+  parent_path="$output_dir/parent.txt"
+  thread_path="$output_dir/thread.txt"
+  combined_path="$output_dir/message.txt"
+  metadata_path="$output_dir/draft.json"
+  composer_json="$output_dir/composer.json"
+
+  "$SCRIPT_DIR/studio-tf-push.sh" compose-message --channel testflight --input "$commits_path" >"$thread_path"
+  "$SCRIPT_DIR/studio-tf-push.sh" compose-message --channel testflight --input "$commits_path" --json >"$composer_json"
+
+  if [ -z "$summary" ]; then
+    summary="Build $build is ready for testing."
+  fi
+
+  headline="[iOS] build $build is available on TestFlight"
+  {
+    printf '%s\n\n' "$headline"
+    printf '%s\n' "$summary"
+    printf 'Details in thread.\n'
+  } >"$parent_path"
+
+  if [ "$prev_build" != "null" ] && [ -n "$prev_build" ] && [ "$prev_build" != "$build" ] && [ "${STUDIO_TF_SLACK_INCLUDE_ROLLOVER:-0}" = "1" ]; then
+    printf '\n- includes changes from %s\n' "$prev_build" >>"$thread_path"
+  fi
+
+  {
+    cat "$parent_path"
+    printf '\n'
+    cat "$thread_path"
+  } >"$combined_path"
+
+  "$SCRIPT_DIR/lint-build-release-message.sh" --file "$combined_path" --channel testflight
+  lint_status="passed"
+
+  bullet_count=$(grep -Ec '^[-] ' "$thread_path" || true)
+  cc_count=$({ grep -Eo 'cc: <@[A-Z0-9]+>' "$thread_path" || true; } | wc -l | tr -d ' ')
+
+  jq -nc \
+    --arg release_tag "$release_tag" \
+    --argjson build "$build" \
+    --arg version "$version" \
+    --arg channel "$channel" \
+    --arg channel_name "$channel_name" \
+    --arg parent_path "$parent_path" \
+    --arg thread_path "$thread_path" \
+    --arg combined_path "$combined_path" \
+    --arg composer_json "$composer_json" \
+    --arg lint_status "$lint_status" \
+    --argjson bullet_count "$bullet_count" \
+    --argjson cc_count "$cc_count" \
+    --argjson dry_run "$dry_run" \
+    '{schema_version:1,kind:"testflight-slack-draft",release_tag:$release_tag,build:$build,version:$version,channel:$channel,channel_name:$channel_name,parent_path:$parent_path,thread_path:$thread_path,combined_path:$combined_path,composer_json:$composer_json,lint_status:$lint_status,bullet_count:$bullet_count,cc_count:$cc_count,dry_run:$dry_run,approved:false}' \
+    >"$metadata_path"
+
+  release_emit slack_drafted "$release_tag" "$(jq -nc \
+    --argjson build "$build" \
+    --arg channel "$channel_name" \
+    --argjson bullet_count "$bullet_count" \
+    --argjson cc_count "$cc_count" \
+    --arg draft_path "$metadata_path" \
+    --argjson dry_run "$dry_run" \
+    '{build:$build,channel:$channel,bullet_count:$bullet_count,cc_count:$cc_count,draft_path:$draft_path,dry_run:$dry_run}')"
+
+  printf '%s\n' "$metadata_path"
+}
+
+cmd_send() {
+  local draft_path="" approve=0 dry_run=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --draft) draft_path="${2:?--draft requires a path}"; shift 2 ;;
+      --draft=*) draft_path="${1#--draft=}"; shift ;;
+      --approve) approve=1; shift ;;
+      --dry-run) dry_run=1; shift ;;
+      -h|--help) usage ;;
+      *) printf 'studio-tf-slack send: unknown arg %s\n' "$1" >&2; usage ;;
+    esac
+  done
+
+  [ -n "$draft_path" ] || usage
+  [ -r "$draft_path" ] || { printf 'studio-tf-slack send: draft not readable: %s\n' "$draft_path" >&2; exit 2; }
+  if [ "$approve" -ne 1 ]; then
+    printf 'studio-tf-slack send: refusing to post without --approve\n' >&2
+    exit 4
+  fi
+
+  load_release_config || {
+    printf 'studio-tf-slack: could not resolve release config project\n' >&2
+    exit 2
+  }
+  require_cmd jq
+
+  local release_tag build channel parent_path thread_path parent_ts resp chars
+  release_tag=$(json_get "$draft_path" '.release_tag')
+  build=$(json_get "$draft_path" '.build')
+  channel=$(json_get "$draft_path" '.channel')
+  parent_path=$(json_get "$draft_path" '.parent_path')
+  thread_path=$(json_get "$draft_path" '.thread_path')
+  [ -n "$release_tag" ] || { printf 'studio-tf-slack send: draft missing release_tag\n' >&2; exit 2; }
+  [ -n "$build" ] || { printf 'studio-tf-slack send: draft missing build\n' >&2; exit 2; }
+  [ -n "$channel" ] || { printf 'studio-tf-slack send: draft missing channel\n' >&2; exit 2; }
+  [ -r "$parent_path" ] || { printf 'studio-tf-slack send: parent not readable: %s\n' "$parent_path" >&2; exit 2; }
+  [ -r "$thread_path" ] || { printf 'studio-tf-slack send: thread not readable: %s\n' "$thread_path" >&2; exit 2; }
+
+  if [ "$dry_run" -eq 1 ]; then
+    "$SCRIPT_DIR/slack-post.sh" --channel "$channel" --text "$(cat "$parent_path")" --dry-run >/dev/null
+    "$SCRIPT_DIR/slack-post.sh" --channel "$channel" --thread-ts "dry-run-parent-ts" --text "$(cat "$thread_path")" --dry-run >/dev/null
+    parent_ts="dry-run-parent-ts"
+  else
+    if ! resp=$(STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" --channel "$channel" --text "$(cat "$parent_path")" 2>&1); then
+      release_emit release_failed "$release_tag" "$(jq -nc --arg reason "$resp" '{stage:"slack_send",reason:$reason}')"
+      printf 'studio-tf-slack send: Slack parent post failed: %s\n' "$resp" >&2
+      exit 1
+    fi
+    parent_ts=$(printf '%s' "$resp" | jq -r '.ts // empty' 2>/dev/null || true)
+    if [ -z "$parent_ts" ]; then
+      release_emit release_failed "$release_tag" "$(jq -nc --arg reason "Slack parent post returned no ts" '{stage:"slack_send",reason:$reason}')"
+      printf 'studio-tf-slack send: Slack parent post returned no ts\n' >&2
+      exit 1
+    fi
+    if ! resp=$(STUDIO_RELEASE_PROJECT="$RELEASE_PROJECT" "$SCRIPT_DIR/slack-post.sh" --channel "$channel" --thread-ts "$parent_ts" --text "$(cat "$thread_path")" 2>&1); then
+      release_emit release_failed "$release_tag" "$(jq -nc --arg reason "$resp" '{stage:"slack_send",reason:$reason}')"
+      printf 'studio-tf-slack send: Slack thread post failed: %s\n' "$resp" >&2
+      exit 1
+    fi
+  fi
+
+  chars=$(message_char_count "$parent_path" "$thread_path")
+  release_emit slack_sent "$release_tag" "$(jq -nc \
+    --argjson build "$build" \
+    --arg channel "$channel" \
+    --arg parent_ts "$parent_ts" \
+    --argjson message_chars "$chars" \
+    --argjson dry_run "$dry_run" \
+    '{build:$build,channel:$channel,parent_ts:$parent_ts,message_chars:$message_chars,dry_run:$dry_run}')"
+
+  jq --arg parent_ts "$parent_ts" --argjson dry_run "$dry_run" \
+    '.approved = true | .sent = {parent_ts:$parent_ts,dry_run:$dry_run}' "$draft_path" >"$draft_path.tmp"
+  mv "$draft_path.tmp" "$draft_path"
+  printf '%s\n' "$draft_path"
+}
+
+case "${1:-}" in
+  draft) shift; cmd_draft "$@" ;;
+  send) shift; cmd_send "$@" ;;
+  -h|--help) usage ;;
+  *) usage ;;
+esac

--- a/scripts/test-fixtures/754-tf-slack-bridge/test-tf-slack-bridge.sh
+++ b/scripts/test-fixtures/754-tf-slack-bridge/test-tf-slack-bridge.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d "${TMPDIR:-/tmp}/tf-slack-bridge-754.XXXXXX")
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+HOME="$TMPROOT/home"
+PROJECT="tf-slack-fixture"
+export HOME STUDIO_RELEASE_PROJECT="$PROJECT"
+mkdir -p "$HOME/.dev-studio/$PROJECT/config"
+cat >"$HOME/.dev-studio/$PROJECT/config/release.env" <<'ENV'
+STUDIO_TF_SLACK_CHANNEL=C_TESTING
+STUDIO_TF_SLACK_CHANNEL_NAME=#testing
+ENV
+
+context="$TMPROOT/context.json"
+commits="$TMPROOT/commits.txt"
+jq -nc '{release_tag:"release-4001-fixture",build:4001,version:"26.5.0",prev_build:4000,branch:"feature/tf-slack",tf_tag:"tf-26.5.0-4001"}' >"$context"
+cat >"$commits" <<'EOF'
+aaa111 | Add gallery import status
+Change-Type: feature
+Problem: Testers could not tell when gallery import finished.
+Solution: The gallery now shows a completion state.
+---
+bbb222 | Fix collage save retry
+Change-Type: bugfix-shipped
+Problem: Collage save retry stopped after a temporary upload failure.
+Solution: Retry state now survives the transient failure.
+EOF
+
+draft_json=$("$ROOT/scripts/studio-tf-slack.sh" draft --context "$context" --commits "$commits" --summary "Gallery import and collage saving are ready for testing.")
+[ -r "$draft_json" ] || fail "draft metadata missing"
+
+parent_path=$(jq -r '.parent_path' "$draft_json")
+thread_path=$(jq -r '.thread_path' "$draft_json")
+combined_path=$(jq -r '.combined_path' "$draft_json")
+
+grep -q '^\[iOS\] build 4001 is available on TestFlight$' "$parent_path" || fail "parent headline missing"
+grep -q '^Details in thread[.]$' "$parent_path" || fail "parent thread pointer missing"
+grep -q '^\*New\*$' "$thread_path" || fail "thread missing New section"
+grep -q 'Testers could not tell when gallery import finished' "$thread_path" || fail "composer output missing feature bullet"
+"$ROOT/scripts/lint-build-release-message.sh" --file "$combined_path" --channel testflight
+
+if "$ROOT/scripts/studio-tf-slack.sh" send --draft "$draft_json" --dry-run >"$TMPROOT/send-unapproved.out" 2>"$TMPROOT/send-unapproved.err"; then
+  fail "send without approval unexpectedly passed"
+fi
+grep -q 'refusing to post without --approve' "$TMPROOT/send-unapproved.err" || fail "missing approval refusal"
+
+"$ROOT/scripts/studio-tf-slack.sh" send --draft "$draft_json" --approve --dry-run >"$TMPROOT/send-approved.out"
+jq -e '.approved == true and .sent.parent_ts == "dry-run-parent-ts"' "$draft_json" >/dev/null \
+  || fail "approved dry-run send did not update draft metadata"
+
+events_file="$HOME/.dev-studio/$PROJECT/events/$(date -u +%Y-%m-%d).jsonl"
+[ -r "$events_file" ] || fail "release events were not emitted"
+jq -e 'select(.event == "slack_drafted" and .task == "release-4001-fixture")' "$events_file" >/dev/null \
+  || fail "missing slack_drafted event"
+jq -e 'select(.event == "slack_sent" and .task == "release-4001-fixture")' "$events_file" >/dev/null \
+  || fail "missing slack_sent event"
+
+printf 'PASS: TestFlight Slack bridge\n'


### PR DESCRIPTION
## Summary

Closes #754.

Adds a script-backed TestFlight Slack draft/send bridge so release-manager `tf-push` no longer relies on prose-only wrapper memory for Slack drafting, format lint, approval, posting, and release events.

- Adds `scripts/studio-tf-slack.sh draft` to render durable parent/thread/combined draft artifacts from release context + commit input, call the existing taxonomy-aware composer, run the TestFlight message linter, and emit `slack_drafted`.
- Adds `scripts/studio-tf-slack.sh send` to refuse posting without `--approve`, post parent then thread, emit `slack_sent`, and emit `release_failed` on Slack send failures.
- Syncs `/pushTFBuild`, `/dev-studio release-manager tf-push`, release contracts, role contract, README surfaces, and v2 HTML docs around the new ownership split: scripts own deterministic rails; the wrapper/LLM only polishes wording and reporter `cc:` attribution before human approval.

## Test plan

- [x] `scripts/test-fixtures/754-tf-slack-bridge/test-tf-slack-bridge.sh`
- [x] `scripts/test-fixtures/692-commit-taxonomy-release-message/test-commit-taxonomy-release-message.sh`
- [x] `scripts/test-fixtures/528-build-release-messaging/test-build-release-messaging-lint.sh`
- [x] `bash -n scripts/studio-tf-slack.sh scripts/studio-tf-push.sh scripts/slack-post.sh scripts/test-fixtures/754-tf-slack-bridge/test-tf-slack-bridge.sh`
- [x] `shellcheck -e SC1091 scripts/studio-tf-slack.sh scripts/test-fixtures/754-tf-slack-bridge/test-tf-slack-bridge.sh`
- [x] `scripts/lint-architecture.sh --staged` — pass with pre-existing `W_ARGUS_SECRET_SCOPE` warning
- [x] `scripts/lint-host-agnostic.sh --staged` — pass with pre-existing `W_ARGUS_SECRET_SCOPE` warning
- [x] `scripts/lint-chain-workflow-docs.sh --staged`
- [x] `scripts/pre-commit-review.sh --review-host claude-reviewer` — approved

## Caveats

- No live Slack, App Store Connect, or TestFlight mutation was run.
- `draft --dry-run` and `send --dry-run` still emit release events with `dry_run:true`, so consumers can distinguish dry-run release telemetry.
