### PR TITLE
feature: summarize work-chain finishes

### DIFF
--- a/_shared/contracts/chain-task-envelope.md
+++ b/_shared/contracts/chain-task-envelope.md
@@ -72,7 +72,7 @@ Required normalized fields:
 | `tokens` | Token telemetry object, number, or `null`. |
 | `telemetry_gaps` | String array of missing telemetry fields. |
 
-Optional normalized fields include `commit_or_pr_references`, `decisions_made`, `assumptions_escrowed`, `next_recommended_action`, `functionality_delivered`, `refactoring_needed_now`, `refactoring_follow_ups`, `carryover`, `lessons`, and `blocked_reason`.
+Optional normalized fields include `commit_or_pr_references`, `decisions_made`, `assumptions_escrowed`, `next_recommended_action`, `functionality_delivered`, `user_visible_change`, `refactoring_needed_now`, `refactoring_follow_ups`, `carryover`, `lessons`, and `blocked_reason`.
 
 `refactoring_needed_now[]` lists cleanup that was required to complete the current bounded issue safely. `refactoring_follow_ups[]` lists deferred design debt with reason, affected area, risk, and suggested timing so parent summaries can distinguish "fixed as part of this task" from "proposed as follow-up work."
 

--- a/_shared/contracts/chain-task-envelope.schema.json
+++ b/_shared/contracts/chain-task-envelope.schema.json
@@ -327,6 +327,9 @@
         "functionality_delivered": {
           "$ref": "#/$defs/narrative"
         },
+        "user_visible_change": {
+          "$ref": "#/$defs/narrative"
+        },
         "refactoring_needed_now": {
           "type": "array",
           "items": {

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-08T22:14:37Z",
+  "generated_at": "2026-05-08T22:56:27Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T22:14:37Z",
+  "generated_at": "2026-05-08T22:56:27Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lint-chain-workflow-docs.sh
+++ b/scripts/lint-chain-workflow-docs.sh
@@ -58,7 +58,7 @@ check_public_docs() {
     require_file_contains "$doc" 'scripts/studio-chain-runner.sh --discover' \
       E_CHAIN_DOC_DISCOVER 'document bare discovery before chain work starts'
     require_file_contains "$doc" 'scripts/studio-chain-runner.sh --discover ios-v2-execution' \
-      E_CHAIN_DOC_FILTERED_DISCOVER 'document filtered discovery for a manifest or chain name'
+      E_CHAIN_DOC_FILTERED_DISCOVER 'document filtered discovery for a manifest, chain name, or chain id'
     require_file_contains "$doc" '/dev-studio manager work-chain ios-v2-execution --dry-run' \
       E_CHAIN_DOC_DEV_STUDIO_PREVIEW 'document preferred dev-studio work-chain preview'
     require_file_contains "$doc" '/dev-studio manager work-chain --resume <run_id> --yes' \
@@ -77,7 +77,7 @@ check_public_docs() {
 check_router_docs() {
   require_file_contains core/v2/skills/dev-studio/SKILL.md 'manager work-chain' \
     E_CHAIN_ROUTER_WORK_CHAIN 'dev-studio skill must route the manager work-chain front door'
-  require_file_contains core/v2/skills/dev-studio/SKILL.md '`--discover <manifest|chain-name>`' \
+  require_file_contains core/v2/skills/dev-studio/SKILL.md '`--discover <manifest|chain-name|chain-id>`' \
     E_CHAIN_ROUTER_FILTERED_DISCOVER 'dev-studio skill must name the filtered discovery contract'
   require_file_contains core/v2/skills/dev-studio/SKILL.md '`--attended` and `--unattended`' \
     E_CHAIN_ROUTER_EXECUTION_MODE 'dev-studio skill must name execution modes'
@@ -88,7 +88,7 @@ check_runner_contract() {
     E_CHAIN_RUNNER_USAGE_DISCOVER 'runner usage must expose filtered discovery and --only'
   require_file_contains scripts/studio-chain-runner.sh 'Bare invocation is discovery-only; it never starts or resumes work.' \
     E_CHAIN_RUNNER_DISCOVERY_ONLY 'bare runner invocation must remain non-mutating discovery'
-  require_file_contains scripts/studio-chain-runner.sh 'Add a manifest or chain name to filter suggestions' \
+  require_file_contains scripts/studio-chain-runner.sh 'Add a manifest, chain name, or chain id to filter suggestions' \
     E_CHAIN_RUNNER_FILTER_COPY 'discovery output must explain filtered suggestions'
   require_file_contains scripts/studio-chain-runner.sh '/dev-studio manager work-chain <chain> --dry-run' \
     E_CHAIN_RUNNER_DEV_STUDIO_PREVIEW 'discovery output must prefer dev-studio manager preview commands'
@@ -103,7 +103,7 @@ check_manager_wrapper_contract() {
     E_CHAIN_MANAGER_BARE_DISCOVER 'bare manager work-chain must land in discovery'
   require_file_contains scripts/manager-work-chain.sh 'exec "$RUNNER" --auto "$@"' \
     E_CHAIN_MANAGER_NAMED_AUTO 'named manager work-chain must default to supervisor auto mode'
-  require_file_contains scripts/manager-work-chain.sh 'Use --discover [<manifest|chain-name>] for filtered, non-mutating discovery.' \
+  require_file_contains scripts/manager-work-chain.sh 'Use --discover [<manifest|chain-name|chain-id>] for filtered, non-mutating discovery.' \
     E_CHAIN_MANAGER_FILTERED_USAGE 'manager wrapper help must document filtered non-mutating discovery'
   require_file_contains scripts/manager-work-chain.sh 'exec "$PLAN_CHAIN" --from-plan "${1:?--from-plan requires a planner artifact}" --execute --unattended' \
     E_CHAIN_MANAGER_FROM_PLAN_EXECUTE 'manager --from-plan must default to unattended end-to-end execution'

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -588,11 +588,11 @@ print_discovery() {
   printf '# Studio Chain Discovery\n\n'
   printf -- '- Bare invocation is discovery-only; it never starts or resumes work.\n'
   printf -- '- Preferred user entrypoint: `/dev-studio manager work-chain`.\n'
-  printf -- '- Add a manifest or chain name to filter suggestions: `/dev-studio manager work-chain --discover ios-v2-execution`; chain IDs are also exact selectors.\n\n'
+  printf -- '- Add a manifest, chain name, or chain id to filter suggestions: `/dev-studio manager work-chain --discover ios-v2-execution`.\n\n'
   printf '## Next Actions\n\n'
   printf -- '- Preview a chain: `/dev-studio manager work-chain <chain> --dry-run`\n'
-  printf -- '- Attended run: `/dev-studio manager work-chain <manifest|chain-name> --attended --yes`\n'
-  printf -- '- Unattended run or safe resume: `/dev-studio manager work-chain <manifest|chain-name>`\n'
+  printf -- '- Attended run: `/dev-studio manager work-chain <manifest|chain-name|chain-id> --attended --yes`\n'
+  printf -- '- Unattended run or safe resume: `/dev-studio manager work-chain <manifest|chain-name|chain-id>`\n'
   printf -- '- Resume a known run: `/dev-studio manager work-chain --resume <run_id> --yes`\n\n'
   printf 'Script equivalents remain available for automation: `scripts/manager-work-chain.sh ...` and `scripts/studio-chain-runner.sh ...`.\n\n'
   discover_persisted_runs
@@ -2258,6 +2258,7 @@ ingest_worker_summary() {
         telemetry_sources: (((.telemetry_sources // []) + (if (($session_telemetry.source // "") == "") then [] else [$session_telemetry.source] end)) | unique),
         execution_telemetry: normalized_execution_telemetry,
         functionality_delivered: (.functionality_delivered // null),
+        user_visible_change: (.user_visible_change // .user_facing_change // .change_for_user // .user_change // null),
         carryover: (.carryover // null),
         lessons: (.lessons // null),
         telemetry_gaps: (((.telemetry_gaps // [])
@@ -2342,6 +2343,7 @@ ingest_worker_summary() {
         telemetry_sources: (if (($session_telemetry.source // "") == "") then [] else [$session_telemetry.source] end),
         execution_telemetry: null,
         functionality_delivered: null,
+        user_visible_change: null,
         carryover: null,
         lessons: null,
         telemetry_gaps: (([$summary_gap, "tests_lints_builds"] + ios_execution_gaps)
@@ -2411,6 +2413,8 @@ generate_run_report() {
     printf -- '- Ended: `%s`\n' "$ended_ts"
     printf -- '- Duration: `%ss`\n' "$duration_s"
     [ -n "$failure_reason" ] && printf -- '- Failure reason: `%s`\n' "$failure_reason"
+    printf '\n'
+    render_run_finish_summary "$status" "$failure_reason"
     printf '\n## Functionality Delivered\n\n'
     if [ "$summary_count" -gt 0 ]; then
       jq -r -s '
@@ -2766,6 +2770,98 @@ generate_run_report() {
   } > "$RUN_REPORT"
 }
 
+render_run_finish_summary() {
+  local status="$1" failure_reason="${2:-}" summary_count run_state_json
+  summary_count=0
+  [ -n "${SUMMARY_ROOT:-}" ] && summary_count=$(find "$SUMMARY_ROOT" -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+  run_state_json="${RUN_STATE_JSON:-}"
+
+  printf '## Work-Chain Finish Summary\n\n'
+  printf -- '- Status: `%s`\n' "$status"
+  printf -- '- Run UUID: `%s`\n' "${RUN_ID:-unknown}"
+  [ -n "${FINAL_PR_URL:-}" ] && printf -- '- PR URL: %s\n' "$FINAL_PR_URL"
+  [ -n "${RUN_REPORT:-}" ] && printf -- '- Private report: `%s`\n' "$RUN_REPORT"
+  [ -n "$failure_reason" ] && printf -- '- Failure reason: `%s`\n' "$failure_reason"
+  if [ -n "$run_state_json" ] && [ -f "$run_state_json" ]; then
+    jq -r '
+      def issue_total: [ .chains[]?.issues[]? ] | length;
+      def issue_completed: [ .chains[]?.issues[]? | select((.status // "") == "completed") ] | length;
+      def issue_closed: [ .chains[]?.issues[]? | select((.lifecycle_state // "") == "closed") ] | length;
+      "- Chains completed: \([ .chains[]? | select((.status // "") == "completed") ] | length)/\((.chains // []) | length)",
+      "- Issues completed: \(issue_completed)/\(issue_total)",
+      "- Issues closed: \(issue_closed)/\(issue_total)"
+    ' "$run_state_json" 2>/dev/null || true
+  fi
+
+  printf '\n### What Was Accomplished\n\n'
+  if [ "$summary_count" -gt 0 ]; then
+    jq -r -s '
+      def lines($v):
+        if $v == null then []
+        elif ($v | type) == "array" then [$v[] | tostring]
+        elif ($v | type) == "object" then [$v | tojson]
+        else [$v | tostring]
+        end;
+      [ .[] | {issue:(.issue_number // "unknown"), title:(.issue_title // ""), lines: lines(.functionality_delivered // .summary)} | select(.lines | length > 0) ] as $items |
+      if ($items | length) == 0 then "- No accomplishment narrative was supplied by worker summaries."
+      else $items[] | . as $item | $item.lines[] | "- #\($item.issue): \(.)"
+      end
+    ' "$SUMMARY_ROOT"/*.json
+  elif [ -n "$run_state_json" ] && [ -f "$run_state_json" ]; then
+    jq -r '
+      [ .chains[]?.issues[]? | select((.status // "") == "completed") ] as $issues |
+      if ($issues | length) == 0 then "- No completed issues were recorded."
+      else $issues[] | "- #\(.number): \(.title // "completed")"
+      end
+    ' "$run_state_json" 2>/dev/null || printf -- '- No worker summaries were ingested.\n'
+  else
+    printf -- '- No worker summaries were ingested.\n'
+  fi
+
+  printf '\n### User-Facing Change\n\n'
+  if [ "$summary_count" -gt 0 ]; then
+    jq -r -s '
+      def lines($v):
+        if $v == null then []
+        elif ($v | type) == "array" then [$v[] | tostring]
+        elif ($v | type) == "object" then [$v | tojson]
+        else [$v | tostring]
+        end;
+      def user_change:
+        .user_visible_change
+        // .user_facing_change
+        // .change_for_user
+        // .user_change
+        // .functionality_delivered
+        // null;
+      [ .[] | {issue:(.issue_number // "unknown"), lines: lines(user_change)} | select(.lines | length > 0) ] as $items |
+      if ($items | length) == 0 then "- No user-facing change narrative was supplied by worker summaries."
+      else $items[] | . as $item | $item.lines[] | "- #\($item.issue): \(.)"
+      end
+    ' "$SUMMARY_ROOT"/*.json
+  else
+    printf -- '- No user-facing change narrative was supplied by worker summaries.\n'
+  fi
+
+  printf '\n### Follow-Up\n\n'
+  if [ "$summary_count" -gt 0 ]; then
+    jq -r -s '
+      def lines($v):
+        if $v == null then []
+        elif ($v | type) == "array" then [$v[] | tostring]
+        elif ($v | type) == "object" then [$v | tojson]
+        else [$v | tostring]
+        end;
+      [ .[] | {issue:(.issue_number // "unknown"), lines: lines(.carryover // .next_recommended_action)} | select(.lines | length > 0) ] as $items |
+      if ($items | length) == 0 then "- No carryover was supplied by worker summaries."
+      else $items[] | . as $item | $item.lines[] | "- #\($item.issue): \(.)"
+      end
+    ' "$SUMMARY_ROOT"/*.json
+  else
+    printf -- '- No carryover was supplied by worker summaries.\n'
+  fi
+}
+
 finish_run() {
   local status="${1:-$RUN_STATUS}" reason="${2:-$RUN_FAILURE_REASON}" duration_s
   RUN_FINISHED=1
@@ -2791,6 +2887,7 @@ finish_run() {
     rm -rf "$RUN_WORK_ROOT" 2>/dev/null || true
   fi
   log "report written to $RUN_REPORT"
+  render_run_finish_summary "$status" "$reason"
 }
 
 abort_run() {
@@ -4465,6 +4562,7 @@ Summary JSON fields:
 - execution_telemetry optional object for iOS work: implementation/build/test/review/release executors when applicable, routing reason class, economics/cost summary, private artifact roots, public artifact classes, cleanup outcome, retained TTL class, and control-plane timing
 - tokens object when available, otherwise null
 - functionality_delivered optional string or array describing what users/agents can now do
+- user_visible_change optional string or array describing what changes for the human user or operator
 - refactoring_needed_now optional array for cleanup required by this task
 - refactoring_follow_ups optional array for deferred design debt with reason, affected area, risk, and suggested timing
 - carryover optional string or array for follow-up issues, parking-lot adds, or uncaptured asks

--- a/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
+++ b/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh
@@ -95,7 +95,7 @@ if grep -q '/dev-studio manager work-chain archived-chain-id --dry-run' "$TMPROO
   cat "$TMPROOT/out" >&2
   exit 1
 fi
-grep -q 'Attended run: `/dev-studio manager work-chain <manifest|chain-name> --attended --yes`' "$TMPROOT/out" || {
+grep -q 'Attended run: `/dev-studio manager work-chain <manifest|chain-name|chain-id> --attended --yes`' "$TMPROOT/out" || {
   printf 'missing attended command contract\n' >&2
   cat "$TMPROOT/out" >&2
   exit 1

--- a/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-report-sections.sh
+++ b/scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-report-sections.sh
@@ -32,6 +32,7 @@ cat > "$SUMMARY_ROOT/issue-446.json" <<'JSON'
   "review_pass_count": 1,
   "review_findings_tier": "warn",
   "functionality_delivered": ["Operators can list persisted chain runs."],
+  "user_visible_change": ["The manager finish output now explains the operator-facing result."],
   "carryover": ["Full D1 amendment flow remains deferred."],
   "lessons": ["List mode should short-circuit before run allocation."],
   "telemetry_gaps": []
@@ -79,6 +80,7 @@ duration_since() { printf '%s\n' "$(( ${2:-120} - $1 ))"; }
 generate_run_report completed ""
 
 for heading in \
+  '## Work-Chain Finish Summary' \
   '## Functionality Delivered' \
   '## Telemetry Roll-up' \
   '## Quality Signals' \
@@ -99,6 +101,11 @@ done
 
 grep -q 'Operators can list persisted chain runs.' "$RUN_REPORT" || {
   printf 'missing functionality narrative\n' >&2
+  cat "$RUN_REPORT" >&2
+  exit 1
+}
+grep -q 'The manager finish output now explains the operator-facing result.' "$RUN_REPORT" || {
+  printf 'missing user-facing change narrative\n' >&2
   cat "$RUN_REPORT" >&2
   exit 1
 }


### PR DESCRIPTION
## Summary
- Add a Work-Chain Finish Summary to chain-run reports and final runner stdout.
- Add additive `user_visible_change` support to worker summaries so operators can distinguish implementation accomplishment from user-facing change.
- Align chain workflow docs lint and discovery fixture wording with existing chain-id selector support.

## Verification
- `bash -n scripts/studio-chain-runner.sh scripts/lint-chain-workflow-docs.sh scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh`
- `jq empty _shared/contracts/chain-task-envelope.schema.json`
- `bash scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-report-sections.sh`
- `bash scripts/test-fixtures/656-chain-runner-followups/test-chain-runner-followups.sh`
- `bash scripts/test-fixtures/478-chain-task-envelope/test-chain-task-envelope.sh`
- `bash scripts/test-fixtures/480-chain-run-telemetry/test-chain-run-telemetry.sh`
- `bash scripts/test-fixtures/446-chain-mode-enhancements/test-chain-runner-discover.sh`
- `bash scripts/test-fixtures/655-manager-work-chain/test-manager-work-chain.sh`
- `scripts/lint-host-agnostic.sh --staged` (0 errors, pre-existing W_ARGUS_SECRET_SCOPE warning)
- `scripts/lint-skill-prose.sh --staged`
- `git diff --cached --check`