### PR TITLE
bugfix-shipped: validate chain run-state projection output

### DIFF
--- a/_shared/contracts/chain-halt-record.md
+++ b/_shared/contracts/chain-halt-record.md
@@ -99,7 +99,7 @@ Writers choose only `reason_id`; the schema enforces the class.
 | Halt class | Reason IDs |
 |---|---|
 | `retryable` | `github_auth_unavailable`, `github_home_mismatch`, `github_rate_limited`, `network_partition`, `child_timeout`, `disk_runtime_pressure` |
-| `recoverable` | `parent_host_unknown`, `branch_worktree_conflict`, `base_branch_advanced`, `missing_child_summary`, `child_crash`, `issue_body_changed`, `partial_github_operation`, `test_build_infra_unavailable`, `telemetry_artifact_malformed`, `telemetry_artifact_missing`, `manifest_schema_version_mismatch`, `implementation_scope_blocked`, `checkpoint_drift_detected` |
+| `recoverable` | `parent_host_unknown`, `branch_worktree_conflict`, `base_branch_advanced`, `missing_child_summary`, `child_crash`, `issue_body_changed`, `partial_github_operation`, `test_build_infra_unavailable`, `telemetry_artifact_malformed`, `telemetry_artifact_missing`, `manifest_schema_version_mismatch`, `chain_state_projection_invalid`, `chain_state_projection_repair_failed`, `implementation_scope_blocked`, `checkpoint_drift_detected` |
 | `review-needed` | `reviewer_blocked`, `reviewer_ambiguous` |
 | `human-needed` | `reviewer_host_ineligible`, `model_tool_permission_prompt`, `context_output_overflow` |
 | `fatal` | `required_review_failed`, `secret_detected`, `destructive_change_required`, `permission_expansion_required`, `unsafe_external_state` |

--- a/_shared/contracts/chain-halt-record.schema.json
+++ b/_shared/contracts/chain-halt-record.schema.json
@@ -339,6 +339,8 @@
         "telemetry_artifact_malformed",
         "telemetry_artifact_missing",
         "manifest_schema_version_mismatch",
+        "chain_state_projection_invalid",
+        "chain_state_projection_repair_failed",
         "secret_detected",
         "destructive_change_required",
         "permission_expansion_required",
@@ -390,6 +392,8 @@
                 "telemetry_artifact_malformed",
                 "telemetry_artifact_missing",
                 "manifest_schema_version_mismatch",
+                "chain_state_projection_invalid",
+                "chain_state_projection_repair_failed",
                 "implementation_scope_blocked",
                 "checkpoint_drift_detected"
               ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-08T23:58:28Z",
+  "generated_at": "2026-05-09T10:25:29Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-08T23:58:27Z",
+  "generated_at": "2026-05-09T10:25:28Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-run-state.sh
+++ b/scripts/lib-chain-run-state.sh
@@ -210,6 +210,11 @@ chain_run_state_reconcile_file() {
     jq -cn --arg status "projection_failed" --arg state "$state_path" --arg events "$events_path" '{status:$status,state:$state,events:$events}'
     return 1
   fi
+  if [ ! -s "$projection" ] || ! jq empty "$projection" >/dev/null 2>&1; then
+    rm -f "$projection" "$tmp"
+    jq -cn --arg status "projection_invalid" --arg state "$state_path" --arg events "$events_path" '{status:$status,state:$state,events:$events}'
+    return 1
+  fi
 
   mismatch=$(chain_run_state_projection_mismatch_json "$state_path" "$projection")
   if [ "$(printf '%s\n' "$mismatch" | jq -r '.status')" = "ok" ]; then
@@ -242,6 +247,11 @@ chain_run_state_reconcile_file() {
   then
     rm -f "$projection" "$tmp"
     jq -cn --arg status "repair_projection_metadata_failed" --arg state "$state_path" --arg events "$events_path" --arg backup "$backup" '{status:$status,state:$state,events:$events,backup:$backup}'
+    return 1
+  fi
+  if [ ! -s "$tmp" ] || ! jq empty "$tmp" >/dev/null 2>&1; then
+    rm -f "$projection" "$tmp"
+    jq -cn --arg status "repair_output_invalid" --arg state "$state_path" --arg events "$events_path" --arg backup "$backup" '{status:$status,state:$state,events:$events,backup:$backup}'
     return 1
   fi
   if ! mv "$tmp" "$state_path"; then

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -2335,7 +2335,15 @@ reconcile_resume_state_projection_or_halt() {
   reconcile_rc=$?
   set -e
   if [ "$reconcile_rc" -ne 0 ]; then
-    write_halt_record "chain_state_projection_invalid" "resume startup could not derive chain run projection from events: $RUN_STATE_JSON" >/dev/null || true
+    status=$(jq -r '.status // "unknown"' "$summary_file" 2>/dev/null || printf 'unknown')
+    case "$status" in
+      backup_failed|repair_projection_metadata_failed|repair_output_invalid|repair_write_failed)
+        write_halt_record "chain_state_projection_repair_failed" "resume startup could not repair chain run state projection ($status): $RUN_STATE_JSON" >/dev/null || true
+        ;;
+      *)
+        write_halt_record "chain_state_projection_invalid" "resume startup could not derive chain run projection from events ($status): $RUN_STATE_JSON" >/dev/null || true
+        ;;
+    esac
     rm -f "$summary_file"
     exit 2
   fi

--- a/scripts/test-fixtures/708-chain-run-state/test-chain-run-state.sh
+++ b/scripts/test-fixtures/708-chain-run-state/test-chain-run-state.sh
@@ -119,6 +119,22 @@ jq -e '.status == "repaired" and .repaired == true and (.backup | length > 0)' "
 jq -e '.projection.source == "events.jsonl" and .chains[0].issues[0].status == "completed"' "$state" >/dev/null \
   || fail "state.json was not repaired from projection"
 
+invalid_summary="$TMPROOT/invalid-summary.json"
+(
+  chain_run_state_projection_file() { : > "$3"; return 0; }
+  chain_run_state_reconcile_file "$state" "$events" resume-startup > "$invalid_summary"
+) && fail "reconcile did not flag empty projection output"
+jq -e '.status == "projection_invalid"' "$invalid_summary" >/dev/null \
+  || fail "reconcile did not report projection_invalid for empty projection output"
+
+malformed_summary="$TMPROOT/malformed-summary.json"
+(
+  chain_run_state_projection_file() { printf 'not json\n' > "$3"; return 0; }
+  chain_run_state_reconcile_file "$state" "$events" resume-startup > "$malformed_summary"
+) && fail "reconcile did not flag malformed projection JSON"
+jq -e '.status == "projection_invalid"' "$malformed_summary" >/dev/null \
+  || fail "reconcile did not report projection_invalid for malformed projection output"
+
 rows="$TMPROOT/monitor-rows.json"
 fixture_now=$(jq -nr '"2026-05-07T00:10:00Z" | fromdateiso8601')
 chain_monitor_claims_from_persisted_run_json "$run_id" "$state" "$fixture_now" 3600 300 > "$rows"


### PR DESCRIPTION
## Summary
- Add `chain_state_projection_invalid` and `chain_state_projection_repair_failed` to the recoverable enum in `chain-halt-record.md` and `chain-halt-record.schema.json` so halt records emitted with these reasons (`studio-chain-runner.sh:2338` and the new repair-failure path) round-trip through schema validation.
- Add non-empty + `jq empty` gates to `chain_run_state_reconcile_file` after the projection step and after the metadata-merge jq, returning `projection_invalid` / `repair_output_invalid` instead of silently writing malformed state.
- Map repair-side reconcile statuses (`backup_failed`, `repair_projection_metadata_failed`, `repair_output_invalid`, `repair_write_failed`) to `chain_state_projection_repair_failed` in `reconcile_resume_state_projection_or_halt`; other failures still surface as `chain_state_projection_invalid`.

## Why
The runner can write halt records with reasons the contract didn't list — schema validation would reject them silently in tooling. Separately, two `jq` invocations in the reconcile path trusted exit code only; an empty or malformed output paired with rc=0 would corrupt `state.json` on the subsequent `mv`. Both are loud-failure improvements per REVIEW R14.

## Test plan
- [x] `bash scripts/test-fixtures/708-chain-run-state/test-chain-run-state.sh` — existing assertions pass + two new assertions exercise the empty-projection and malformed-projection guards via function override.
- [x] `bash -n` clean on both touched scripts; `jq empty` clean on the schema; `shellcheck -S warning` produces only pre-existing warnings.
- [ ] Reviewer to sanity-check that no other call site relies on the old behavior of `chain_run_state_reconcile_file` exiting 0 with bad output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)