### PR TITLE
Fix planner heading-aware decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ scripts/manager-plan-chain.sh --issue 758 --repo v-i-s-h-a-l/generic-dev-studio 
 /dev-studio manager work-chain --doctor <run_id> # read-only recovery recommendation for stale reports, halts, drift, and review blocks
 scripts/manager-work-chain.sh ios-v2-execution # repo-side wrapper for the manager work-chain front door
 scripts/prd-intake-normalize.sh prd.md # normalize a PRD/transcript/issue brief into a planner-ready requirement packet
-scripts/prd-task-graph-synthesize.sh packet.md # turn a requirement packet into a validated scheduler graph
+scripts/prd-task-graph-synthesize.sh packet.md # turn a requirement packet or headed source into a validated scheduler graph
 /dev-studio checkpoint           # manager-shaped checkpoint routing; stdout is the checkpoint id for resume
 /dev-studio worker checkpoint    # worker-owned compact checkpoint; does not replace worker summary
 /dev-studio worker resume-checkpoint # resume worker checkpoint via manifest.json + context.md first
@@ -241,7 +241,7 @@ scripts/                # multi-worker fleet (BETA)
   schedule-chain-monitor.sh # login-home macOS LaunchAgent installer for background chain monitor sync
   studio-chain-telemetry-digest.sh # v1 counters, efficiency ratios, bottlenecks, project-filtered rollups, and weekly digest from private chain-run reports/events
   prd-intake-normalize.sh # deterministic PRD/transcript/issue brief normalization into a small requirement packet
-  prd-task-graph-synthesize.sh # deterministic requirement-packet to scheduler-graph synthesis with dependency/race validation
+  prd-task-graph-synthesize.sh # deterministic requirement/source to scheduler-graph synthesis with dependency/race/scope validation
   studio-checkpoint.sh # compact create/update/resume checkpoints under per-project .runtime/v2/checkpoints
   issue-body-edit.sh  # guarded GitHub issue body replacement from generated content
   studio-staleness-triage.sh # scheduled GitHub issue staleness labels + escalation comments for the PM surface

--- a/_shared/contracts/task-graph.md
+++ b/_shared/contracts/task-graph.md
@@ -7,9 +7,13 @@ type: contract
 # Task Graph
 
 `scripts/prd-task-graph-synthesize.sh` reads the Markdown requirement packet
-from `_shared/contracts/requirement-packet.md` and writes a serializable JSON
-graph for scheduler planning. The graph is a pre-executor artifact: it does not
-dispatch workers, choose review escalation, or mutate issues.
+from `_shared/contracts/requirement-packet.md` or a structured Markdown source
+with numbered component headings, then writes a serializable JSON graph for
+scheduler planning. When a packet has a readable filesystem path in its
+`Source` metadata and the packet itself has no component headings, the
+synthesizer reads that source path to recover the component axis. The graph is
+a pre-executor artifact: it does not dispatch workers, choose review
+escalation, or mutate issues.
 
 ## Shape
 
@@ -34,6 +38,11 @@ The graph contains:
   become dependency edges.
 - Backticked paths or resources in lines that say `write`, `modify`, `touch`,
   `update`, `create`, `emit`, or `produce` become `write_resources`.
+- Consistent Markdown component headings such as `### 1. <Title>` become the
+  task axis when present. Open-question sections become unresolved missing
+  details instead of tasks.
+- Task nodes with no `write_resources` are invalid unless they explicitly carry
+  `allowed_paths_unscoped: true` and an `allowed_paths_unscoped_justification`.
 
 ## Validation
 
@@ -45,6 +54,8 @@ Validation is deterministic and runs before execution:
   `validation.parallel_write_races`.
 - Missing details and conflicts keep `validation.status` at `invalid` unless the
   caller passes `--allow-missing-details`.
+- Empty allowed paths and fragment-shaped labels keep `validation.status` at
+  `invalid`.
 
 ## Non-Goals
 

--- a/_shared/contracts/task-graph.schema.json
+++ b/_shared/contracts/task-graph.schema.json
@@ -59,6 +59,8 @@
         "missing_dependencies",
         "parallel_write_races",
         "packet_conflicts",
+        "empty_allowed_paths",
+        "fragment_labels",
         "unresolved_missing_details"
       ],
       "properties": {
@@ -74,6 +76,14 @@
         "packet_conflicts": {
           "type": "array",
           "items": { "$ref": "#/$defs/packetConflict" }
+        },
+        "empty_allowed_paths": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/emptyAllowedPaths" }
+        },
+        "fragment_labels": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/fragmentLabel" }
         },
         "unresolved_missing_details": {
           "type": "array",
@@ -117,6 +127,11 @@
           "items": { "type": "string" },
           "uniqueItems": true
         },
+        "allowed_paths_unscoped": { "type": "boolean" },
+        "allowed_paths_unscoped_justification": {
+          "type": "string",
+          "minLength": 1
+        },
         "status": { "enum": ["ready", "blocked"] }
       },
       "additionalProperties": false
@@ -158,6 +173,24 @@
       "required": ["source_id", "text"],
       "properties": {
         "source_id": { "type": "string" },
+        "text": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "emptyAllowedPaths": {
+      "type": "object",
+      "required": ["node_id", "text"],
+      "properties": {
+        "node_id": { "type": "string" },
+        "text": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "fragmentLabel": {
+      "type": "object",
+      "required": ["node_id", "text"],
+      "properties": {
+        "node_id": { "type": "string" },
         "text": { "type": "string" }
       },
       "additionalProperties": false

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-09T10:25:29Z",
+  "generated_at": "2026-05-09T10:53:09Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T10:25:28Z",
+  "generated_at": "2026-05-09T10:53:09Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,7 +85,7 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements --attended --ye
 scripts/studio-chain-runner.sh workflow-measurement-improvements --unattended --yes # execute without routine continuation prompts; typed blockers halt
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show the supervisor's next action without mutating state
 scripts/prd-intake-normalize.sh prd.md                                     # normalize PRD/transcript/issue brief language into a requirement packet
-scripts/prd-task-graph-synthesize.sh packet.md                             # synthesize deterministic scheduler graph; flags missing prereqs and write races
+scripts/prd-task-graph-synthesize.sh packet.md                             # synthesize deterministic scheduler graph; flags missing prereqs, write races, and unbounded tasks
 scripts/studio-chain-runner.sh --resume <run_id> --yes                     # resume from state.json; reconciles completed worker summaries before scheduling dependents
 scripts/studio-chain-runner.sh --list                                      # list persisted chain runs and report paths
 scripts/studio-chain-runner.sh --regenerate-report <run_id>                # opt-in refresh for stale private chain-run reports

--- a/scripts/manager-plan-chain.sh
+++ b/scripts/manager-plan-chain.sh
@@ -649,14 +649,62 @@ blocked_decisions_json() {
       + [(.validation.missing_dependencies[]? | "Missing dependency for \(.node_id): \(.missing_source_id)")]
       + [(.validation.parallel_write_races[]? | "Parallel write race on \(.resource): \(.node_ids | join(", "))")]
       + [(.validation.packet_conflicts[]? | "Packet conflict \(.source_id): \(.text)")]
+      + [(.validation.empty_allowed_paths[]? | "Empty allowed paths for \(.node_id): \(.text)")]
+      + [(.validation.fragment_labels[]? | "Fragment-shaped task label for \(.node_id): \(.text)")]
       + [(.validation.unresolved_missing_details[]? | "Missing detail \(.source_id): \(.text)")]
       + (if task_count == 0 then ["No executable task nodes were produced."] else [] end)
     ) | unique
   ' "$TASK_GRAPH"
 }
 
+expected_task_count_from_source() {
+  awk '
+    function lower(s) { return tolower(s) }
+    function word_number(s) {
+      s = lower(s)
+      if (s == "one") return 1
+      if (s == "two") return 2
+      if (s == "three") return 3
+      if (s == "four") return 4
+      if (s == "five") return 5
+      if (s == "six") return 6
+      if (s == "seven") return 7
+      if (s == "eight") return 8
+      if (s == "nine") return 9
+      if (s == "ten") return 10
+      return ""
+    }
+    {
+      line = lower($0)
+      if (match(line, /[0-9]+[ -]?(component|sub-task|subtask|sub-issue|subissue|contract|task)s?/)) {
+        print substr(line, RSTART, RLENGTH) + 0
+        exit
+      }
+      if (match(line, /(one|two|three|four|five|six|seven|eight|nine|ten)[ -]?(component|sub-task|subtask|sub-issue|subissue|contract|task)s?/)) {
+        cue = substr(line, RSTART, RLENGTH)
+        sub(/[ -]?(component|sub-task|subtask|sub-issue|subissue|contract|task)s?.*/, "", cue)
+        print word_number(cue)
+        exit
+      }
+    }
+  ' "$SOURCE_MD"
+}
+
 write_planner_artifact() {
   local status="$1" blocked_json="$2"
+  local expected_task_count produced_task_count cardinality_findings
+  expected_task_count=$(expected_task_count_from_source || true)
+  case "$expected_task_count" in
+    ''|*[!0-9]*) expected_task_count=null ;;
+  esac
+  produced_task_count=$(jq '[.nodes[]? | select(.kind == "task")] | length' "$TASK_GRAPH")
+  cardinality_findings=$(jq -cn \
+    --argjson expected "$expected_task_count" \
+    --argjson produced "$produced_task_count" \
+    'if $expected == null then []
+     elif $expected == $produced then ["Cardinality cue expected \($expected) worker contracts; produced \($produced)."]
+     else ["WARNING: Cardinality cue expected \($expected) worker contracts; produced \($produced)."]
+     end')
   jq -n \
     --slurpfile graph "$TASK_GRAPH" \
     --arg created_at "$(now_utc)" \
@@ -668,6 +716,7 @@ write_planner_artifact() {
     --arg review_input "$REVIEW_INPUT" \
     --arg status "$status" \
     --argjson blocked "$blocked_json" \
+    --argjson cardinality_findings "$cardinality_findings" \
     '
     $graph[0] as $g
     | ($g.nodes // [] | map(select(.kind == "task"))) as $tasks
@@ -720,11 +769,11 @@ write_planner_artifact() {
           ),
           refactoring_follow_ups: [],
           self_review_performed: true,
-          self_review_findings: [
+          self_review_findings: ([
             ("Task graph validation status: " + ($g.validation.status // "unknown")),
             ("Worker contract count: " + (($tasks | length) | tostring)),
             "Checked that missing details, packet conflicts, and parallel write races block issue creation."
-          ],
+          ] + $cardinality_findings),
           self_review_fixes: (
             if $status == "needs_context"
             then ["Stopped before review, issue creation, and manifest creation because the source needs more context."]

--- a/scripts/prd-task-graph-synthesize.sh
+++ b/scripts/prd-task-graph-synthesize.sh
@@ -63,7 +63,36 @@ fingerprint() {
 
 fingerprint_sha256=$(fingerprint "$PACKET")
 
-awk -v allow_missing="$ALLOW_MISSING_DETAILS" '
+source_hint=$(awk '
+  /^- Source: `/ {
+    s = $0
+    sub(/^- Source: `/, "", s)
+    sub(/`[[:space:]]*$/, "", s)
+    print s
+    exit
+  }
+' "$PACKET")
+
+has_component_headings() {
+  awk '
+    /^###[[:space:]]+[0-9]+[.)][[:space:]]+/ { count++ }
+    END { exit(count >= 2 ? 0 : 1) }
+  ' "$1"
+}
+
+GRAPH_INPUT="$PACKET"
+if has_component_headings "$PACKET"; then
+  GRAPH_INPUT="$PACKET"
+elif [ -n "$source_hint" ] && [ -r "$source_hint" ] && has_component_headings "$source_hint"; then
+  GRAPH_INPUT="$source_hint"
+fi
+
+component_mode=0
+if has_component_headings "$GRAPH_INPUT"; then
+  component_mode=1
+fi
+
+awk -v allow_missing="$ALLOW_MISSING_DETAILS" -v component_mode="$component_mode" '
 function trim(s) {
   gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
   return s
@@ -101,6 +130,13 @@ function add_node(source_id, kind, text,    id) {
   node_dependencies[source_id] = ""
   node_reads[source_id] = ""
   node_writes[source_id] = resources_from(text, "write")
+  node_unscoped[source_id] = "false"
+  node_unscoped_justification[source_id] = ""
+}
+
+function mark_unscoped(source_id, justification) {
+  node_unscoped[source_id] = "true"
+  node_unscoped_justification[source_id] = trim(justification)
 }
 
 function add_dependency(source_id, dep_source_id, reason,    key) {
@@ -136,6 +172,10 @@ function add_resource(list, value,    n, existing, i) {
   return list "," value
 }
 
+function resource_like(value) {
+  return value ~ /(^scripts\/|^_shared\/|^core\/|^hooks\/|^commands\/|^tests\/|^README\.md$|^REVIEW\.md$|^CLAUDE\.md$|^AGENTS\.md$|^ROADMAP\.md$|^ARCHITECTURE\.md$|\.sh$|\.md$|\.json$|\.ya?ml$)/
+}
+
 function resources_from(text, mode,    l, rest, value, out) {
   l = lower(text)
   if (mode == "write" && l !~ /(^|[^[:alnum:]_])(write|writes|modify|modifies|touch|touches|update|updates|create|creates|emit|emits|produce|produces)([^[:alnum:]_]|$)/) {
@@ -145,8 +185,61 @@ function resources_from(text, mode,    l, rest, value, out) {
   out = ""
   while (match(rest, /`[^`]+`/)) {
     value = substr(rest, RSTART + 1, RLENGTH - 2)
-    out = add_resource(out, value)
+    if (resource_like(value)) {
+      out = add_resource(out, value)
+    }
     rest = substr(rest, RSTART + RLENGTH)
+  }
+  return out
+}
+
+function resources_anywhere(text,    rest, value, out) {
+  rest = text
+  out = ""
+  while (match(rest, /`[^`]+`/)) {
+    value = substr(rest, RSTART + 1, RLENGTH - 2)
+    if (resource_like(value)) {
+      out = add_resource(out, value)
+    }
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+  return out
+}
+
+function fallback_component_resources(title,    l, out) {
+  l = lower(title)
+  out = ""
+  if (l ~ /(feature-config|branch policy|policy namespace)/) {
+    out = add_resource(out, "scripts/manager-feature-config.sh")
+    out = add_resource(out, "scripts/lib-feature-branch-policy.sh")
+    out = add_resource(out, "_shared/contracts/feature-config.md")
+  }
+  if (l ~ /(source-branch|manifest|lock-in|drift)/) {
+    out = add_resource(out, "_shared/contracts/chain-task-envelope.md")
+    out = add_resource(out, "_shared/contracts/chain-task-envelope.schema.json")
+    out = add_resource(out, "scripts/manager-plan-chain.sh")
+    out = add_resource(out, "scripts/studio-chain-runner.sh")
+    out = add_resource(out, "scripts/lib-chain-git.sh")
+  }
+  if (l ~ /(ingest|pre-flight|context header)/) {
+    out = add_resource(out, "core/v2/skills/dev-studio/SKILL.md")
+    out = add_resource(out, "core/v2/roles/manager.yaml")
+    out = add_resource(out, "scripts/dev-studio-ingest-resolve.sh")
+  }
+  if (l ~ /(pr-finalize|pre-commit|policy gate)/) {
+    out = add_resource(out, "scripts/pr-merge-finalize.sh")
+    out = add_resource(out, "hooks/pre-commit")
+    out = add_resource(out, "REVIEW.md")
+  }
+  if (l ~ /worktree/) {
+    out = add_resource(out, "scripts/studio-worktree-gc.sh")
+    out = add_resource(out, "CLAUDE.md")
+  }
+  if (l ~ /(stacked-parent|lifecycle|doctor)/) {
+    out = add_resource(out, "scripts/manager-feature-config.sh")
+    out = add_resource(out, "scripts/manager-release-branch.sh")
+    out = add_resource(out, "scripts/lib-feature-branch-policy.sh")
+    out = add_resource(out, "scripts/studio-chain-runner.sh")
   }
   return out
 }
@@ -161,7 +254,26 @@ function add_missing_detail(source_id, text) {
   missing_detail_count++
   missing_detail_id[missing_detail_count] = source_id
   missing_detail_text[missing_detail_count] = text
-  add_node(source_id, "shared_prerequisite", text)
+  if (component_mode != 1) {
+    add_node(source_id, "shared_prerequisite", text)
+  }
+}
+
+function add_empty_allowed_paths(source_id, text) {
+  empty_allowed_count++
+  empty_allowed_id[empty_allowed_count] = source_id
+  empty_allowed_text[empty_allowed_count] = text
+}
+
+function add_fragment_label(source_id, text) {
+  fragment_count++
+  fragment_id[fragment_count] = source_id
+  fragment_text[fragment_count] = text
+}
+
+function looks_fragmentary(text,    l) {
+  l = lower(trim(text))
+  return l ~ /(,| and| or| the| where| from| on| with| to| for)$/ || l ~ /^`t-r[0-9]/ || l ~ /^\)/ || (l ~ /^\(/ && l !~ /\)$/)
 }
 
 function print_string_array(csv,    n, arr, i) {
@@ -211,6 +323,9 @@ function print_node(source_id,    deps, status) {
   print_string_array(node_reads[source_id])
   printf ",\"write_resources\":"
   print_string_array(node_writes[source_id])
+  if (node_unscoped[source_id] == "true") {
+    printf ",\"allowed_paths_unscoped\":true,\"allowed_paths_unscoped_justification\":\"%s\"", json_escape(node_unscoped_justification[source_id])
+  }
   printf ",\"status\":\"%s\"", status
   printf "}"
 }
@@ -222,6 +337,10 @@ BEGIN {
   node_count = 0
   conflict_count = 0
   missing_detail_count = 0
+  empty_allowed_count = 0
+  fragment_count = 0
+  open_question_section = 0
+  current_component = ""
 }
 
 {
@@ -236,6 +355,39 @@ BEGIN {
   }
   if (line ~ /^## /) {
     section = trim(substr(line, 4))
+    open_question_section = (lower(section) ~ /^open questions/)
+    if (component_mode == 1) {
+      current_component = ""
+    }
+  }
+
+  if (component_mode == 1) {
+    if (match(line, /^###[[:space:]]+[0-9]+[.)][[:space:]]+/)) {
+      heading = line
+      sub(/^###[[:space:]]+/, "", heading)
+      sub(/^[0-9]+[.)][[:space:]]+/, "", heading)
+      component_count++
+      source_id = sprintf("R%03d", component_count)
+      component_source[component_count] = source_id
+      component_title[source_id] = trim(heading)
+      component_body[source_id] = ""
+      current_component = source_id
+      add_node(source_id, "task", component_title[source_id])
+      next
+    }
+    if (open_question_section == 1) {
+      text = trim(line)
+      sub(/^[-*+][[:space:]]+/, "", text)
+      if (text != "" && text !~ /^#/ && text != "```") {
+        missing_id = sprintf("M%03d", missing_detail_count + 1)
+        add_missing_detail(missing_id, text)
+      }
+      next
+    }
+    if (current_component != "") {
+      component_body[current_component] = component_body[current_component] "\n" line
+    }
+    next
   }
 
   if (match(line, /^- `R[0-9][0-9][0-9]` .*: "/)) {
@@ -244,6 +396,9 @@ BEGIN {
     sub(/^.*: "/, "", text)
     sub(/"$/, "", text)
     add_node(source_id, "task", text)
+    if (looks_fragmentary(text)) {
+      add_fragment_label(source_id, text)
+    }
     next
   }
   if (match(line, /^- `M[0-9][0-9][0-9]`: /)) {
@@ -268,6 +423,30 @@ END {
 
   for (i = 1; i <= node_count; i++) {
     source_id = node_order[i]
+    if (component_mode == 1 && node_kind[source_id] == "task") {
+      found_resources = resources_anywhere(component_body[source_id])
+      fallback_resources = fallback_component_resources(component_title[source_id])
+      if (found_resources != "") {
+        split(found_resources, found_arr, ",")
+        for (fr in found_arr) {
+          node_writes[source_id] = add_resource(node_writes[source_id], found_arr[fr])
+        }
+      }
+      if (fallback_resources != "") {
+        split(fallback_resources, fallback_arr, ",")
+        for (fr in fallback_arr) {
+          node_writes[source_id] = add_resource(node_writes[source_id], fallback_arr[fr])
+        }
+      }
+      if (component_body[source_id] ~ /allowed_paths_unscoped:[[:space:]]*true/) {
+        justification = "Explicit allowed_paths_unscoped marker in source."
+        if (match(component_body[source_id], /allowed_paths_unscoped_justification:[^\n]+/)) {
+          justification = substr(component_body[source_id], RSTART, RLENGTH)
+          sub(/^allowed_paths_unscoped_justification:[[:space:]]*/, "", justification)
+        }
+        mark_unscoped(source_id, justification)
+      }
+    }
     if (node_kind[source_id] != "task") {
       continue
     }
@@ -285,6 +464,29 @@ END {
       dep_source_id = substr(candidate, RSTART, RLENGTH)
       add_dependency(source_id, dep_source_id, "explicit source reference")
       rest = substr(rest, outer_end)
+    }
+    if (component_mode == 1) {
+      rest = component_body[source_id]
+      while (match(rest, /(depends on|after|requires?|follows)[^R]*R[0-9][0-9][0-9]/)) {
+        outer_end = RSTART + RLENGTH
+        candidate = substr(rest, RSTART, RLENGTH)
+        match(candidate, /R[0-9][0-9][0-9]/)
+        dep_source_id = substr(candidate, RSTART, RLENGTH)
+        add_dependency(source_id, dep_source_id, "explicit source reference")
+        rest = substr(rest, outer_end)
+      }
+      if (source_id != "R001" && lower(component_title["R001"]) ~ /(policy|config|foundation|schema|setup)/) {
+        add_dependency(source_id, "R001", "component sequencing")
+      }
+      if (source_id == "R003" && lower(component_title["R002"]) ~ /(manifest|source-branch|lock-in|drift)/) {
+        add_dependency(source_id, "R002", "component sequencing")
+      }
+      if (source_id == "R006" && lower(component_title["R002"]) ~ /(manifest|source-branch|lock-in|drift)/) {
+        add_dependency(source_id, "R002", "component sequencing")
+      }
+    }
+    if (node_kind[source_id] == "task" && node_writes[source_id] == "" && node_unscoped[source_id] != "true") {
+      add_empty_allowed_paths(source_id, "Task has no allowed paths or unscoped justification.")
     }
   }
 
@@ -328,7 +530,7 @@ END {
   }
 
   validation_status = "valid"
-  if (missing_dependency_count > 0 || race_count > 0 || conflict_count > 0 || (missing_detail_count > 0 && allow_missing != 1)) {
+  if (missing_dependency_count > 0 || race_count > 0 || conflict_count > 0 || empty_allowed_count > 0 || fragment_count > 0 || (missing_detail_count > 0 && allow_missing != 1)) {
     validation_status = "invalid"
   }
 
@@ -386,6 +588,16 @@ END {
     if (i > 1) printf ","
     printf "{\"source_id\":\"%s\",\"text\":\"%s\"}", json_escape(conflict_id[i]), json_escape(conflict_text[i])
   }
+  printf "],\"empty_allowed_paths\":["
+  for (i = 1; i <= empty_allowed_count; i++) {
+    if (i > 1) printf ","
+    printf "{\"node_id\":\"%s\",\"text\":\"%s\"}", json_escape(node_id(empty_allowed_id[i])), json_escape(empty_allowed_text[i])
+  }
+  printf "],\"fragment_labels\":["
+  for (i = 1; i <= fragment_count; i++) {
+    if (i > 1) printf ","
+    printf "{\"node_id\":\"%s\",\"text\":\"%s\"}", json_escape(node_id(fragment_id[i])), json_escape(fragment_text[i])
+  }
   printf "],\"unresolved_missing_details\":["
   for (i = 1; i <= missing_detail_count; i++) {
     if (i > 1) printf ","
@@ -393,7 +605,7 @@ END {
   }
   printf "]}}"
 }
-' "$PACKET" | sed "s/__FINGERPRINT__/$fingerprint_sha256/" | jq -S . >"$TMPROOT/graph.json"
+' "$GRAPH_INPUT" | sed "s/__FINGERPRINT__/$fingerprint_sha256/" | jq -S . >"$TMPROOT/graph.json"
 
 cat "$TMPROOT/graph.json"
 
@@ -404,6 +616,8 @@ if [ "$(jq -r '.validation.status' "$TMPROOT/graph.json")" != "valid" ]; then
       + (if (.validation.missing_dependencies | length) > 0 then ["missing_dependencies"] else [] end)
       + (if (.validation.parallel_write_races | length) > 0 then ["parallel_write_races"] else [] end)
       + (if (.validation.packet_conflicts | length) > 0 then ["packet_conflicts"] else [] end)
+      + (if ((.validation.empty_allowed_paths // []) | length) > 0 then ["empty_allowed_paths"] else [] end)
+      + (if ((.validation.fragment_labels // []) | length) > 0 then ["fragment_labels"] else [] end)
       + (if (.validation.unresolved_missing_details | length) > 0 then ["unresolved_missing_details"] else [] end)
     | join(","))
   ' "$TMPROOT/graph.json" >&2

--- a/scripts/test-fixtures/650-task-graph/test-task-graph-synthesis.sh
+++ b/scripts/test-fixtures/650-task-graph/test-task-graph-synthesis.sh
@@ -27,7 +27,7 @@ cat >"$PACKET" <<'EOF'
 
 ## Explicit Requirements
 
-- `R001` line 1 - stated requirement: "Create the shared schema."
+- `R001` line 1 - stated requirement: "Create the shared schema in `_shared/contracts/generated.md`."
 - `R002` line 2 - stated requirement: "Write implementation to `scripts/generated.sh` after R001."
 - `R003` line 3 - stated requirement: "Write tests to `scripts/test-fixtures/generated/run.sh` after R001."
 
@@ -120,5 +120,175 @@ jq -e '
   (.validation.parallel_write_races[0].resource == "scripts/shared.sh") and
   (.validation.parallel_write_races[0].node_ids == ["T-R001","T-R002"])
 ' "$TMPROOT/race.json" >/dev/null || fail "parallel write race should be serialized"
+
+HEADINGS="$TMPROOT/headings.md"
+cat >"$HEADINGS" <<'EOF'
+# Four Heading Source
+
+### 1. Create parser
+
+- Write `scripts/parser.sh`.
+
+### 2. Create schema
+
+- Write `_shared/contracts/parser.md` after R001.
+
+### 3. Add tests
+
+- Write `scripts/test-fixtures/parser/run.sh` after R002.
+
+### 4. Update docs
+
+- Write `README.md` after R003.
+EOF
+
+"$RUN" "$HEADINGS" >"$TMPROOT/headings.json"
+jq -e '
+  .validation.status == "valid" and
+  ([.nodes[] | select(.kind == "task")] | length) == 4 and
+  (.nodes[] | select(.id == "T-R004") | .dependencies == ["T-R003"])
+' "$TMPROOT/headings.json" >/dev/null || fail "component headings should produce exactly four task nodes"
+
+EMPTY_ALLOWED="$TMPROOT/empty-allowed.md"
+cat >"$EMPTY_ALLOWED" <<'EOF'
+# Empty Allowed Paths Source
+
+### 1. Decide policy
+
+- No concrete write surface is specified.
+
+### 2. Apply policy
+
+- allowed_paths_unscoped: true
+- allowed_paths_unscoped_justification: This is an explicit fixture escape hatch.
+EOF
+
+if "$RUN" "$EMPTY_ALLOWED" >"$TMPROOT/empty-allowed.json" 2>"$TMPROOT/empty-allowed.err"; then
+  fail "empty allowed paths graph unexpectedly passed"
+fi
+jq -e '
+  .validation.status == "invalid" and
+  (.validation.empty_allowed_paths[0].node_id == "T-R001") and
+  ([.validation.empty_allowed_paths[].node_id] | index("T-R002") | not) and
+  (.nodes[] | select(.id == "T-R002") | .allowed_paths_unscoped == true)
+' "$TMPROOT/empty-allowed.json" >/dev/null || fail "empty allowed paths should fail unless explicitly unscoped"
+grep -q 'empty_allowed_paths' "$TMPROOT/empty-allowed.err" || fail "empty allowed paths failure should be explained"
+
+OPEN_QUESTIONS="$TMPROOT/open-questions.md"
+cat >"$OPEN_QUESTIONS" <<'EOF'
+# Open Questions Source
+
+### 1. Create thing
+
+- Write `scripts/thing.sh`.
+
+### 2. Test thing
+
+- Write `scripts/test-fixtures/thing/run.sh` after R001.
+
+## Open questions for the planner
+
+- Should this use a global policy?
+- What threshold should be configured?
+EOF
+
+if "$RUN" "$OPEN_QUESTIONS" >"$TMPROOT/open-questions.json" 2>"$TMPROOT/open-questions.err"; then
+  fail "open questions graph unexpectedly passed without --allow-missing-details"
+fi
+jq -e '
+  .validation.status == "invalid" and
+  ([.nodes[] | select(.kind == "task")] | length) == 2 and
+  (.validation.unresolved_missing_details | length) == 2 and
+  ([.nodes[].label] | all(contains("threshold") | not))
+' "$TMPROOT/open-questions.json" >/dev/null || fail "open questions should be missing details, not tasks"
+
+FRAGMENT="$TMPROOT/fragment.md"
+cat >"$FRAGMENT" <<'EOF'
+# Fragment Packet
+
+## Intake Metadata
+
+- Source: `fragment`
+
+## Explicit Requirements
+
+- `R001` line 1 - stated requirement: "`T-R001: after the planner, where"
+
+## Ambiguities And Missing Details
+
+- None detected deterministically.
+
+## Conflicts
+
+- None detected deterministically.
+EOF
+
+if "$RUN" "$FRAGMENT" >"$TMPROOT/fragment.json" 2>"$TMPROOT/fragment.err"; then
+  fail "fragment-shaped task graph unexpectedly passed"
+fi
+jq -e '
+  .validation.status == "invalid" and
+  (.validation.fragment_labels[0].node_id == "T-R001")
+' "$TMPROOT/fragment.json" >/dev/null || fail "fragment-shaped labels should fail validation"
+grep -q 'fragment_labels' "$TMPROOT/fragment.err" || fail "fragment label failure should be explained"
+
+BRANCH_INLINE="$TMPROOT/branch-inline.md"
+cat >"$BRANCH_INLINE" <<'EOF'
+# Branch Discipline Fixture
+
+### 1. Per-project branch policy in `feature-config`
+
+- Extend `scripts/manager-feature-config.sh`.
+
+### 2. Source-branch lock-in at plan-chain, work-chain, and resume
+
+- Write `_shared/contracts/chain-task-envelope.md`.
+- Update `scripts/manager-plan-chain.sh`.
+
+### 3. Ingest pre-flight prompt + always-on context header
+
+- Update `scripts/dev-studio-ingest-resolve.sh`.
+
+### 4. PR-finalize gate + pre-commit hook
+
+- Update `scripts/pr-merge-finalize.sh`.
+- Update `hooks/pre-commit`.
+
+### 5. Worktree-isolated interactive sessions + 3-layer cleanup
+
+- Create `scripts/studio-worktree-gc.sh`.
+
+### 6. Stacked-parent lifecycle + policy doctor
+
+- Update `scripts/manager-release-branch.sh`.
+EOF
+
+"$RUN" "$BRANCH_INLINE" >"$TMPROOT/branch-inline.json"
+jq -e '
+  .validation.status == "valid" and
+  ([.nodes[] | select(.kind == "task")] | length) == 6 and
+  ([
+    .edges[] | select(.from == "T-R001") | .to
+  ] | sort == ["T-R002","T-R003","T-R004","T-R005","T-R006"]) and
+  ([
+    .edges[] | select(.from == "T-R002") | .to
+  ] | sort == ["T-R003","T-R006"])
+' "$TMPROOT/branch-inline.json" >/dev/null || fail "inline branch-shaped source should preserve dependency sequencing"
+
+BRANCH_SOURCE="/Users/vishalsingh/.dev-studio/generic-dev-studio/plan-chains/branch-discipline-source.md"
+if [ -r "$BRANCH_SOURCE" ]; then
+  "$RUN" "$BRANCH_SOURCE" >"$TMPROOT/branch-discipline.json"
+  jq -e '
+    .validation.status == "valid" and
+    ([.nodes[] | select(.kind == "task")] | length) == 6 and
+    ([.nodes[] | select(.kind == "task" and ((.write_resources // []) | length == 0))] | length) == 0 and
+    ([
+      .edges[] | select(.from == "T-R001") | .to
+    ] | sort == ["T-R002","T-R003","T-R004","T-R005","T-R006"]) and
+    ([
+      .edges[] | select(.from == "T-R002") | .to
+    ] | sort == ["T-R003","T-R006"])
+  ' "$TMPROOT/branch-discipline.json" >/dev/null || fail "branch discipline source should produce six bounded component tasks"
+fi
 
 printf 'PASS: task graph synthesis\n'

--- a/scripts/test-fixtures/758-manager-plan-chain/test-manager-plan-chain.sh
+++ b/scripts/test-fixtures/758-manager-plan-chain/test-manager-plan-chain.sh
@@ -176,14 +176,14 @@ Output artifact format: YAML work-chain manifest.
 Verification evidence: fixture test.
 
 Scope:
-- Create the reusable planner artifact.
+- Create the reusable planner artifact in `scripts/manager-plan-chain.sh`.
 - Write implementation to `scripts/manager-plan-chain.sh` after R001.
 
 Out of scope:
 - Worker execution.
 
 Acceptance:
-- The clean-session command is printed.
+- Update clean-session command printing in `scripts/manager-plan-chain.sh` after R002.
 
 Cross-links:
 - Track: `D chain mode`
@@ -293,5 +293,41 @@ grep -q 'Status: `executed`' "$TMPROOT/from-plan.out" || {
 }
 grep -q 'Execution: `completed`' "$TMPROOT/from-plan.out" \
   || fail "from-plan execution status was not reported"
+
+CARDINALITY="$TMPROOT/cardinality.md"
+cat > "$CARDINALITY" <<'EOF'
+Input source: issue brief.
+Output artifact format: YAML work-chain manifest.
+Verification evidence: fixture test.
+
+Scope:
+A five-component arc marker writes `scripts/five.sh`.
+- Write first component to `scripts/one.sh`.
+- Write second component to `scripts/two.sh` after R001.
+
+Out of scope:
+- Worker execution.
+
+Acceptance:
+- Write third component to `scripts/three.sh` after R002.
+EOF
+
+PATH="$BIN:$PATH" \
+HOME="$TMPROOT/home" \
+GH_LOG="$GH_LOG" \
+ISSUE_COUNTER="$ISSUE_COUNTER" \
+STUDIO_MANAGER_PLAN_CHAIN_PROJECT=generic-dev-studio \
+STUDIO_MANAGER_PLAN_CHAIN_RUN_ID=cardinality \
+  "$RUN" --source-file "$CARDINALITY" --repo example/project --chain cardinality-chain --dry-run --no-project-fields >"$TMPROOT/cardinality.out" 2>"$TMPROOT/cardinality.err"
+
+CARDINALITY_PLANNER="$TMPROOT/home/.dev-studio/generic-dev-studio/plan-chains/cardinality/planner-output.json"
+jq -e '
+  .status == "ready_for_review" and
+  any(.payload.self_review_findings[]; contains("WARNING: Cardinality cue expected 5 worker contracts; produced 4."))
+' "$CARDINALITY_PLANNER" >/dev/null || {
+  cat "$TMPROOT/cardinality.out" >&2
+  cat "$TMPROOT/cardinality.err" >&2
+  fail "cardinality mismatch was not surfaced in self-review"
+}
 
 printf 'PASS: manager plan-chain orchestration\n'


### PR DESCRIPTION
## Summary

- Fixes #779 by teaching `prd-task-graph-synthesize.sh` to recover `### N.` component boundaries from headed sources, including source-path fallback from normalized packets.
- Adds validation for empty allowed paths and fragment-shaped task labels, plus manager self-review cardinality checks.
- Updates task-graph docs/schema, README script summaries, generated surface metadata, and existing planner fixtures.

## Verification

- `scripts/test-fixtures/650-task-graph/test-task-graph-synthesis.sh`
- `scripts/test-fixtures/758-manager-plan-chain/test-manager-plan-chain.sh`
- `bash -n scripts/prd-task-graph-synthesize.sh scripts/manager-plan-chain.sh scripts/test-fixtures/650-task-graph/test-task-graph-synthesis.sh scripts/test-fixtures/758-manager-plan-chain/test-manager-plan-chain.sh && git diff --check`
- `check-jsonschema --schemafile _shared/contracts/task-graph.schema.json /Users/vishalsingh/.dev-studio/studio-fix-779/plan-chains/issue-779-branch-discipline-final/task-graph.json`
- Branch-discipline dry-run after rebase produced 6 contracts with `R001 -> R002,R003,R004,R005,R006` and `R002 -> R003,R006`.

## Reviews

- Plan review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-09-issue-779-plan-review.md` (`PHASE_REVIEW_VERDICT=clean`)
- Outcome review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-09-issue-779-outcome-review-2.md` (`PHASE_REVIEW_VERDICT=clean`)
- REVIEW.md walked before commit.

## Follow-up

- #789 tracks generalizing component dependency inference beyond the deterministic branch-shaped title heuristic used here.