### PR TITLE
bugfix-shipped: route reviewer smoke payloads to durable runtime root (#791)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-09T10:53:09Z",
+  "generated_at": "2026-05-09T12:50:27Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T10:53:09Z",
+  "generated_at": "2026-05-09T12:50:24Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -41,9 +41,57 @@ first_line() {
   sed -n '1p' "$1" 2>/dev/null | tr '\n' ' ' | cut -c 1-240
 }
 
+sanitize_runtime_slug() {
+  local raw="$1" slug
+  slug=$(printf '%s' "$raw" | tr -cs 'A-Za-z0-9._-' '-' | sed -e 's/^-*//' -e 's/-*$//')
+  [ -n "$slug" ] && printf '%s\n' "$slug" || printf 'unknown\n'
+}
+
+eligibility_smoke_chain_task_slug() {
+  local start_path source_url repo
+  start_path="$PWD/.studio/chain-task-start.json"
+  [ -r "$start_path" ] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  source_url=$(jq -r '.source_issue.url // empty' "$start_path" 2>/dev/null || true)
+  case "$source_url" in
+    https://github.com/*/*/issues/*|https://github.com/*/*/pull/*)
+      repo=$(printf '%s\n' "$source_url" | sed -E 's#^https://github.com/[^/]+/([^/]+)/(issues|pull)/.*$#\1#')
+      ;;
+    *)
+      repo=""
+      ;;
+  esac
+  [ -n "$repo" ] || return 1
+  sanitize_runtime_slug "$repo"
+}
+
+eligibility_smoke_project_slug() {
+  local slug
+  slug=$(eligibility_smoke_chain_task_slug 2>/dev/null || true)
+  [ -n "$slug" ] || slug=$(resolve_display_name 2>/dev/null || true)
+  [ -n "$slug" ] || slug=$(resolve_project 2>/dev/null || true)
+  sanitize_runtime_slug "${slug:-unknown}"
+}
+
+eligibility_smoke_payload_parent() {
+  local project_slug
+  studio_context_resolve runtime-mutation || return 1
+  project_slug=$(eligibility_smoke_project_slug)
+  printf '%s/%s/.runtime/reviewer-payloads/eligibility-smoke\n' "$STUDIO_CONTEXT_STUDIO_HOME" "$project_slug"
+}
+
 run_smoke_gate() {
-  local tmpdir payload stdout_file stderr_file reviewer_home reviewer_codex_home reviewer_claude_home reviewer_claude_config_dir
-  tmpdir=$(mktemp -d -t pr-reviewer-smoke.XXXXXX) || fail smoke_tmp_failed "mktemp failed"
+  local tmpdir payload stdout_file stderr_file reviewer_home reviewer_codex_home reviewer_claude_home reviewer_claude_config_dir payload_parent
+  payload_parent=$(eligibility_smoke_payload_parent) \
+    || fail smoke_payload_runtime_unavailable "Studio runtime context unavailable for reviewer smoke payload"
+  mkdir -p "$payload_parent" \
+    || fail smoke_payload_runtime_unavailable "failed to create reviewer smoke payload root: $payload_parent"
+  tmpdir=$(mktemp -d "$payload_parent/run.XXXXXX") \
+    || fail smoke_payload_runtime_unavailable "failed to create reviewer smoke payload directory under $payload_parent"
+  cleanup_smoke_tmpdir() {
+    [ "${STUDIO_KEEP_REVIEWER_SMOKE_PAYLOADS:-0}" = "1" ] && return 0
+    [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"
+  }
   payload="$tmpdir/payload.md"
   stdout_file="$tmpdir/stdout"
   stderr_file="$tmpdir/stderr"
@@ -57,33 +105,33 @@ run_smoke_gate() {
     codex*|*codex*)
       export STUDIO_CONTEXT_HOST_PROFILE="$HOST"
       studio_context_resolve delegated-host-spawn || {
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_auth_unavailable "codex reviewer auth home unavailable via Studio context"
       }
       reviewer_codex_home="$STUDIO_CONTEXT_AUTH_HOME"
       [ -n "$reviewer_codex_home" ] && [ -d "$reviewer_codex_home" ] || {
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_auth_unavailable "codex reviewer auth home not found via Studio context"
       }
       ;;
     claude*|*claude*)
       export STUDIO_CONTEXT_HOST_PROFILE="$HOST"
       studio_context_resolve delegated-host-spawn || {
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_auth_unavailable "claude reviewer auth home unavailable via Studio context"
       }
       reviewer_claude_home="$STUDIO_CONTEXT_AUTH_HOME"
       [ -n "$reviewer_claude_home" ] && [ -d "$reviewer_claude_home" ] || {
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_auth_unavailable "claude reviewer auth home not found via Studio context"
       }
       reviewer_claude_config_dir="${CLAUDE_REVIEWER_CONFIG_DIR:-$reviewer_claude_home/.claude-reviewer}"
       [ -n "$reviewer_claude_config_dir" ] || {
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_auth_unavailable "claude reviewer config dir not found; set CLAUDE_REVIEWER_CONFIG_DIR or HOME"
       }
       mkdir -p "$reviewer_claude_config_dir" || {
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_auth_unavailable "failed to create claude reviewer config dir: $reviewer_claude_config_dir"
       }
       ;;
@@ -101,7 +149,7 @@ run_smoke_gate() {
       elif command -v timeout >/dev/null 2>&1; then
         timeout_argv=(timeout "$SMOKE_TIMEOUT_SEC")
       else
-        rm -rf "$tmpdir"
+        cleanup_smoke_tmpdir
         fail smoke_timeout_unavailable "reviewer smoke timeout requires gtimeout or timeout"
       fi
       ;;
@@ -146,7 +194,7 @@ run_smoke_gate() {
     local detail
     detail=$(first_line "$stderr_file")
     [ -n "$detail" ] || detail=$(first_line "$stdout_file")
-    rm -rf "$tmpdir"
+    cleanup_smoke_tmpdir
     fail smoke_failed "${detail:-reviewer smoke command exited non-zero}"
   fi
 
@@ -155,17 +203,17 @@ run_smoke_gate() {
   verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$stdout_file")
   if [ "$verdict_count" != "1" ]; then
     detail=$(first_line "$stdout_file")
-    rm -rf "$tmpdir"
+    cleanup_smoke_tmpdir
     fail smoke_no_verdict "expected exactly one STUDIO_REVIEW_VERDICT line; found $verdict_count${detail:+; first_stdout=$detail}"
   fi
   case "$verdict" in
     approved|approved_with_fixes|blocked) ;;
     *)
-      rm -rf "$tmpdir"
+      cleanup_smoke_tmpdir
       fail smoke_invalid_verdict "$verdict"
       ;;
   esac
-  rm -rf "$tmpdir"
+  cleanup_smoke_tmpdir
 }
 
 registry="$REPO_ROOT/hosts/registry.yaml"

--- a/scripts/test-fixtures/791-eligibility-smoke-payload/test-eligibility-smoke-payload.sh
+++ b/scripts/test-fixtures/791-eligibility-smoke-payload/test-eligibility-smoke-payload.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Verifies pr-reviewer-eligibility.sh materializes its smoke payload under the
+# durable Studio runtime root rather than macOS $TMPDIR (#791). Sandboxed
+# reviewer profiles cannot read /var/folders/.../T/ paths, so the payload root
+# must come from the Studio context.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t eligibility-smoke-payload.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+BIN="$TMPROOT/bin"
+REPO="$TMPROOT/chain-worktree"
+DURABLE_HOME="$TMPROOT/durable-home"
+STUDIO_ROOT="$DURABLE_HOME/.dev-studio"
+EXPECTED_PAYLOAD_PARENT="$STUDIO_ROOT/generic-dev-studio/.runtime/reviewer-payloads/eligibility-smoke"
+PAYLOAD_PATH_RECORD="$TMPROOT/payload-path.txt"
+mkdir -p "$BIN" "$REPO/.studio" "$DURABLE_HOME" "$TMPROOT/session-tmp"
+
+cat > "$REPO/.studio/chain-task-start.json" <<'JSON'
+{
+  "source_issue": {
+    "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/791"
+  }
+}
+JSON
+
+# Stub claude: assert the smoke payload lives under the durable runtime root,
+# then print the verdict the script expects.
+expected_payload_parent_q=$(printf '%q' "$EXPECTED_PAYLOAD_PARENT")
+payload_path_record_q=$(printf '%q' "$PAYLOAD_PATH_RECORD")
+{
+printf '#!/usr/bin/env bash\n'
+printf 'EXPECTED_PAYLOAD_PARENT=%s\n' "$expected_payload_parent_q"
+printf 'PAYLOAD_PATH_RECORD=%s\n' "$payload_path_record_q"
+cat <<'SH'
+case " $* " in
+  *" --help "*) printf 'claude fixture help\n'; exit 0 ;;
+esac
+[ -n "${REVIEW_PAYLOAD:-}" ] && [ -f "$REVIEW_PAYLOAD" ] || {
+  printf 'stub claude: missing or unreadable REVIEW_PAYLOAD: %s\n' "${REVIEW_PAYLOAD:-<unset>}" >&2
+  exit 3
+}
+case "$REVIEW_PAYLOAD" in
+  "$EXPECTED_PAYLOAD_PARENT"/run.*/payload.md) ;;
+  *)
+    printf 'stub claude: payload not under durable runtime root: %s\n' "$REVIEW_PAYLOAD" >&2
+    printf 'stub claude: expected %s/run.*/payload.md\n' "$EXPECTED_PAYLOAD_PARENT" >&2
+    exit 4
+    ;;
+esac
+case "$REVIEW_PAYLOAD" in
+  */pr-reviewer-smoke.*/payload.md)
+    printf 'stub claude: payload uses pre-fix mktemp path: %s\n' "$REVIEW_PAYLOAD" >&2
+    exit 5
+    ;;
+esac
+printf '%s\n' "$REVIEW_PAYLOAD" > "$PAYLOAD_PATH_RECORD"
+printf 'STUDIO_REVIEW_VERDICT=approved\n'
+SH
+} > "$BIN/claude"
+chmod +x "$BIN/claude"
+
+# Real yq is required by lib-paths.sh helpers; keep it on PATH.
+command -v yq >/dev/null 2>&1 || {
+  printf 'SKIP: yq not on PATH; pr-reviewer-eligibility requires it\n' >&2
+  exit 0
+}
+
+export PATH="$BIN:$PATH"
+export HOME="$TMPROOT/caller-home"
+export TMPDIR="$TMPROOT/session-tmp"
+export STUDIO_CONTEXT_STUDIO_HOME="$STUDIO_ROOT"
+export STUDIO_CONTEXT_REPO_ROOT="$REPO"
+export STUDIO_CONTEXT_PROJECT_SLUG="generic-dev-studio"
+export STUDIO_REVIEWER_SMOKE_TIMEOUT_SEC=0
+mkdir -p "$HOME"
+
+out="$TMPROOT/out.txt"
+err="$TMPROOT/err.txt"
+if ! (cd "$REPO" && bash "$ROOT/scripts/pr-reviewer-eligibility.sh" claude-reviewer >"$out" 2>"$err"); then
+  printf 'FAIL: pr-reviewer-eligibility rejected the durable payload handoff\n' >&2
+  printf '%s\n' '--- stdout ---' >&2
+  sed -n '1,80p' "$out" >&2 || true
+  printf '%s\n' '--- stderr ---' >&2
+  sed -n '1,120p' "$err" >&2 || true
+  exit 1
+fi
+
+grep -q '^PR_REVIEWER_ELIGIBLE=1' "$out" || {
+  printf 'FAIL: eligibility did not report PR_REVIEWER_ELIGIBLE=1\n' >&2
+  sed -n '1,40p' "$out" >&2 || true
+  exit 1
+}
+
+[ -s "$PAYLOAD_PATH_RECORD" ] || {
+  printf 'FAIL: stub claude did not observe a payload path\n' >&2
+  exit 1
+}
+
+# Confirm the recorded path is under the durable runtime root and not under
+# macOS $TMPDIR — the regression class fixed for #634 / commit 54bfa3e.
+recorded=$(head -1 "$PAYLOAD_PATH_RECORD")
+case "$recorded" in
+  "$EXPECTED_PAYLOAD_PARENT"/run.*/payload.md) ;;
+  *)
+    printf 'FAIL: recorded payload not under durable runtime root: %s\n' "$recorded" >&2
+    exit 1
+    ;;
+esac
+case "$recorded" in
+  */pr-reviewer-smoke.*/payload.md)
+    printf 'FAIL: payload uses pre-fix mktemp path: %s\n' "$recorded" >&2
+    exit 1
+    ;;
+esac
+
+# Verify cleanup happened by default (no STUDIO_KEEP_REVIEWER_SMOKE_PAYLOADS).
+[ -e "$recorded" ] && {
+  printf 'FAIL: smoke payload not cleaned up after success: %s\n' "$recorded" >&2
+  exit 1
+}
+
+# Verify keep-payloads escape hatch retains the directory.
+keep_record="$TMPROOT/keep-payload-path.txt"
+sed -i.bak "s|$PAYLOAD_PATH_RECORD|$keep_record|" "$BIN/claude"
+rm -f "$BIN/claude.bak"
+STUDIO_KEEP_REVIEWER_SMOKE_PAYLOADS=1 \
+  bash -c "cd \"$REPO\" && bash \"$ROOT/scripts/pr-reviewer-eligibility.sh\" claude-reviewer" \
+  >"$TMPROOT/keep-out.txt" 2>"$TMPROOT/keep-err.txt" || {
+    printf 'FAIL: keep-payloads run did not pass eligibility\n' >&2
+    sed -n '1,80p' "$TMPROOT/keep-err.txt" >&2 || true
+    exit 1
+  }
+keep_path=$(head -1 "$keep_record" 2>/dev/null || true)
+[ -n "$keep_path" ] && [ -e "$keep_path" ] || {
+  printf 'FAIL: STUDIO_KEEP_REVIEWER_SMOKE_PAYLOADS=1 did not retain payload: %s\n' "$keep_path" >&2
+  exit 1
+}
+
+printf 'PASS: pr-reviewer-eligibility smoke payload uses durable Studio runtime root\n'


### PR DESCRIPTION
## Summary

- Mirrors the 54bfa3e fix (closes #634) for the missed surface in `scripts/pr-reviewer-eligibility.sh`. Smoke payload now materializes under `\$STUDIO_CONTEXT_STUDIO_HOME/<project_slug>/.runtime/reviewer-payloads/eligibility-smoke/run.XXXX/payload.md` so sandboxed reviewer profiles can read it.
- Adds `scripts/test-fixtures/791-eligibility-smoke-payload/test-eligibility-smoke-payload.sh` proving the durable-path handoff and the `STUDIO_KEEP_REVIEWER_SMOKE_PAYLOADS=1` escape hatch.
- Unblocks every `phase-review.sh` / `pr-headless-review.sh` / `task-invoke-argus.sh` workflow that wedges when no reviewer host can pass eligibility.

## Test plan

- [x] `bash -n scripts/pr-reviewer-eligibility.sh`
- [x] `shellcheck -S warning scripts/pr-reviewer-eligibility.sh scripts/test-fixtures/791-eligibility-smoke-payload/test-eligibility-smoke-payload.sh`
- [x] `bash scripts/test-fixtures/791-eligibility-smoke-payload/test-eligibility-smoke-payload.sh`
- [x] `bash scripts/test-fixtures/342-precommit-review/test-precommit-review.sh` (regression)
- [x] `bash scripts/test-fixtures/342-precommit-review/test-precommit-review-blocked.sh` (regression)
- [x] `bash scripts/test-fixtures/342-precommit-review/test-precommit-review-bypass.sh` (regression)
- [x] `bash scripts/test-fixtures/342-precommit-review/test-precommit-review-chain-runner-readability.sh` (regression)
- [ ] After merge: re-run `scripts/manager-plan-chain.sh --source-file <brief> --chain host-agnostic-runtime-resolver` and confirm phase review reaches a verdict instead of \`PHASE_REVIEW_FALLBACK_FAILURES\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)