### PR TITLE
Fix auto host eligibility bypass

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-09T12:50:27Z",
+  "generated_at": "2026-05-09T15:49:35Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T12:50:24Z",
+  "generated_at": "2026-05-09T15:49:35Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -5461,7 +5461,7 @@ git_metadata_strategy_for_host() {
 }
 
 host_resolver_bypassed() {
-  case "${STUDIO_BYPASS_HOST_RESOLVER:-0}" in
+  case "${STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY:-0}" in
     1|true|TRUE|yes|YES) return 0 ;;
     *) return 1 ;;
   esac
@@ -5678,6 +5678,35 @@ EOF
   return 1
 }
 
+resolve_auto_worker_host_with_bypass() {
+  local candidates profile runner_host eligibility_json record
+  candidates=$(host_profile_list_for_capability worker) || return 1
+  profile=$(printf '%s\n' "$candidates" | sed -n '1p')
+  if [ -z "$profile" ]; then
+    printf 'studio-chain-runner: no auto worker host profile available for bypassed host eligibility\n' >&2
+    return 1
+  fi
+
+  runner_host=$(chain_runner_host_for_profile "$profile")
+  if ! chain_runner_host_has_manifest "$runner_host"; then
+    eligibility_json=$(jq -cn \
+      --arg detail "host eligibility bypassed via STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY; first worker profile $profile has no capabilities manifest for runner host $runner_host" \
+      '{outcome:"unknown", detail:$detail}')
+    record=$(host_eligibility_record_json resolver "$profile" "$runner_host" false manifest-missing "$eligibility_json")
+    append_host_eligibility_record_file "$record"
+    printf 'studio-chain-runner: bypassed auto host candidate %s has no capabilities manifest for runner host %s\n' "$profile" "$runner_host" >&2
+    return 1
+  fi
+
+  printf 'studio-chain-runner: host eligibility bypassed via STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY; using first worker profile %s as runner host %s\n' "$profile" "$runner_host" >&2
+  eligibility_json=$(jq -cn \
+    --arg detail "host eligibility bypassed via STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY; first worker profile $profile selected as runner host $runner_host" \
+    '{outcome:"unknown", detail:$detail}')
+  record=$(host_eligibility_record_json resolver "$profile" "$runner_host" true bypassed "$eligibility_json")
+  append_host_eligibility_record_file "$record"
+  printf '%s\n' "$runner_host"
+}
+
 resolve_auto_worker_host_with_eligibility() {
   local candidates profile runner_host eligibility outcome detail duration_ms record
   candidates=$(host_profile_list_for_capability worker) || return 1
@@ -5746,12 +5775,8 @@ resolve_chain_worker_host() {
     return 0
   fi
   if host_resolver_bypassed; then
-    printf 'studio-chain-runner: host resolver bypassed via STUDIO_BYPASS_HOST_RESOLVER; using legacy auto host codex\n' >&2
-    eligibility_json=$(jq -cn '{outcome:"unknown", detail:"host resolver bypassed via STUDIO_BYPASS_HOST_RESOLVER; legacy auto host codex selected"}')
-    record=$(host_eligibility_record_json resolver codex codex true bypassed "$eligibility_json")
-    append_host_eligibility_record_file "$record"
-    printf 'codex\n'
-    return 0
+    resolve_auto_worker_host_with_bypass
+    return $?
   fi
   if [ "$DRY_RUN" -eq 1 ]; then
     resolve_auto_worker_host_without_smoke
@@ -5796,11 +5821,11 @@ host_preflight() {
     return 0
   fi
   if host_resolver_bypassed; then
-    eligibility=$(jq -cn '{outcome:"unknown", detail:"host eligibility preflight bypassed via STUDIO_BYPASS_HOST_RESOLVER"}')
+    eligibility=$(jq -cn '{outcome:"unknown", detail:"host eligibility preflight bypassed via STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY"}')
     record=$(host_eligibility_record_json preflight "$host" "$host" true bypassed "$eligibility")
     HOST_PREFLIGHT_LAST_DETAILS_JSON=$(host_eligibility_halt_details_json preflight "${CURRENT_CHAIN_NAME:-}" "$host" "$host" "[$record]" "host eligibility preflight bypassed for host=$host")
     append_chain_host_eligibility_record "$record"
-    printf 'studio-chain-runner: host eligibility preflight bypassed for host=%s via STUDIO_BYPASS_HOST_RESOLVER\n' "$host" >&2
+    printf 'studio-chain-runner: host eligibility preflight bypassed for host=%s via STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY\n' "$host" >&2
   else
     profile=$(chain_host_profile_for_runner_host "$host")
     eligibility=$(host_eligibility_check "$profile") || {

--- a/scripts/test-fixtures/748-chain-manifest-preflight/test-chain-manifest-preflight.sh
+++ b/scripts/test-fixtures/748-chain-manifest-preflight/test-chain-manifest-preflight.sh
@@ -140,4 +140,36 @@ grep -q '^issue view 74801 --repo example/project ' "$GH_LOG" || {
   fail "issue lookup did not use the manifest issue repo"
 }
 
+auto_bypass_manifest="$TMPROOT/auto-bypass-chain.yaml"
+cat >"$auto_bypass_manifest" <<YAML
+schema_version: 1
+target_repo_root: $project_repo
+issue_repo: example/project
+chains:
+  - name: auto-bypass-chain
+    base: main
+    branch: feature/auto-bypass-chain
+    host: auto
+    issues: [74802]
+YAML
+
+: > "$GH_LOG"
+PATH="$BIN:$PATH" GH_LOG="$GH_LOG" HOME="$HOME_DIR" STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY=1 "$RUNNER" "$auto_bypass_manifest" --dry-run >"$TMPROOT/auto-bypass.out" 2>&1
+grep -q 'STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY' "$TMPROOT/auto-bypass.out" || {
+  cat "$TMPROOT/auto-bypass.out" >&2
+  fail "auto host bypass did not report the documented bypass env"
+}
+grep -q "Host: \`claude-code\`" "$TMPROOT/auto-bypass.out" || {
+  cat "$TMPROOT/auto-bypass.out" >&2
+  fail "auto host bypass did not select the first worker profile as runner host"
+}
+if grep -q 'DRY-RUN host_eligibility_check' "$TMPROOT/auto-bypass.out"; then
+  cat "$TMPROOT/auto-bypass.out" >&2
+  fail "auto host bypass still planned an eligibility smoke check"
+fi
+if grep -q 'STUDIO_BYPASS_HOST_RESOLVER' "$TMPROOT/auto-bypass.out"; then
+  cat "$TMPROOT/auto-bypass.out" >&2
+  fail "auto host bypass leaked the retired bypass env name"
+fi
+
 printf 'PASS: chain manifest preflight\n'


### PR DESCRIPTION
## Summary
- switch host auto-resolution bypass to the documented STUDIO_BYPASS_AUTO_HOST_ELIGIBILITY env var
- make bypassed host:auto select the first worker profile in resolver order, mapped to its runner host, instead of hardcoding codex
- add regression coverage in the chain manifest preflight fixture

## Verification
- bash -n scripts/studio-chain-runner.sh scripts/test-fixtures/748-chain-manifest-preflight/test-chain-manifest-preflight.sh
- shellcheck -S error scripts/studio-chain-runner.sh scripts/test-fixtures/748-chain-manifest-preflight/test-chain-manifest-preflight.sh
- scripts/test-fixtures/748-chain-manifest-preflight/test-chain-manifest-preflight.sh
- git diff --check

## Notes
Full ShellCheck still reports existing warnings in scripts/studio-chain-runner.sh; this change adds no new error-level findings. The commit hook refreshed generated_at timestamps in docs-surface.json and _shared/schemas/capability-manifest.json.

Closes #803