### PR TITLE
Document v0.13.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ timeline
              : v0.11.0 — Studio v2 router + release flow hardening
              : v0.11.1 — active role shortcuts + role help
              : v0.12.0 — reviewed work chains + commit taxonomy
+             : v0.13.0 — host-aware work chains
     Coming next : Issue graph hygiene — duplicate, blocked-by, caused-by, urgent triage
     Deferred : Knowledge layer — memory-query + synthesis across debriefs
              : Lu Ban — a dedicated architect agent for design dialogue
@@ -41,6 +42,7 @@ timeline
 
 ### Story so far
 
+- **[v0.13.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.13.0)** — Work chains can now choose a healthy worker host instead of assuming one hardcoded CLI. Host profiles, eligibility smoke checks, and typed halt details make auto-selection explainable, while durable reviewer payloads, startup diagnostics, stale-report warnings, and doctor recommendations make long-chain recovery less dependent on the original session. The release also rounds out chain monitor, iOS execution, release handoff, and GitHub-home normalization work so cross-host chains have a clearer operational trail.
 - **[v0.12.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.12.0)** — Studio work can now move from rough planning to reviewed, dependency-aware chains with less session babysitting. The manager work-chain front door, PRD normalization, task-graph synthesis, selective rule packs, checkpoint-aware resumes, and telemetry digests make long arcs easier to launch, audit, and recover. Commit messages now carry a release-friendly taxonomy, TestFlight/App Store drafts can use that metadata directly, and feature-branch merge gates are shared across chain, worktree, and PR paths so dependent branches rebase or retarget instead of quietly accumulating merge commits.
 - **[v0.11.1](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.11.1)** — The `/dev-studio` router is easier to use after a role is selected. Once a session lands in `manager`, short follow-up commands like `status`, `ingest`, `reconcile`, `guard`, and `audit` can keep using that role while the context is clear. `/dev-studio help` shows the role index, `/dev-studio <role> help` shows examples for that role, and bare checkpoint routing still lands in manager unless the role is explicit.
 - **[v0.11.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.11.0)** — The studio now runs through one canonical `/dev-studio` router instead of the old top-level role surfaces. Manager, worker, reviewer, performance, QA, flow-test, release, and host-adapter work all resolve through v2 role contracts with dedicated substrate for events, context budgets, project profiles, checkpoints, and handoffs. Long chains are easier to resume and audit, Projects-board planning is visible from the CLI, review gates are clearer, and release flows now leave a stronger trail through TestFlight tags, App Store PR lifecycle handling, Slack handoffs, withdrawn/superseded states, and release-attempt transaction logs.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-09T15:49:35Z",
+  "generated_at": "2026-05-09T15:58:52Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T15:49:35Z",
+  "generated_at": "2026-05-09T15:58:52Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- add v0.13.0 to the README roadmap timeline
- prepend the v0.13.0 Story so far paragraph
- include hook-refreshed generated timestamp metadata

## Verification
- git diff --check

Release prep for v0.13.0.