### PR TITLE
bugfix-shipped: tighten planner allowed_paths derivation (#793)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-09T15:58:52Z",
+  "generated_at": "2026-05-09T18:29:11Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T15:58:52Z",
+  "generated_at": "2026-05-09T18:29:11Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/prd-task-graph-synthesize.sh
+++ b/scripts/prd-task-graph-synthesize.sh
@@ -173,12 +173,31 @@ function add_resource(list, value,    n, existing, i) {
 }
 
 function resource_like(value) {
-  return value ~ /(^scripts\/|^_shared\/|^core\/|^hooks\/|^commands\/|^tests\/|^README\.md$|^REVIEW\.md$|^CLAUDE\.md$|^AGENTS\.md$|^ROADMAP\.md$|^ARCHITECTURE\.md$|\.sh$|\.md$|\.json$|\.ya?ml$)/
+  if (value ~ /[[:space:]]|--|"|>|<|\$\(|\$\{|;|&&|\|\|/) {
+    return 0
+  }
+  if (value ~ /^\.[A-Za-z0-9]+$/) {
+    return 0
+  }
+  return value ~ /(^scripts\/|^_shared\/|^core\/|^hooks\/|^commands\/|^tests\/|^README\.md$|^REVIEW\.md$|^CLAUDE\.md$|^AGENTS\.md$|^ROADMAP\.md$|^ARCHITECTURE\.md$|^hosts\/|[A-Za-z0-9_-]+\.sh$|[A-Za-z0-9_-]+\.md$|[A-Za-z0-9_-]+\.json$|[A-Za-z0-9_-]+\.ya?ml$)/
+}
+
+function resources_from_title(title,    rest, value, out) {
+  rest = title
+  out = ""
+  while (match(rest, /`[^`]+`/)) {
+    value = substr(rest, RSTART + 1, RLENGTH - 2)
+    if (resource_like(value)) {
+      out = add_resource(out, value)
+    }
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+  return out
 }
 
 function resources_from(text, mode,    l, rest, value, out) {
   l = lower(text)
-  if (mode == "write" && l !~ /(^|[^[:alnum:]_])(write|writes|modify|modifies|touch|touches|update|updates|create|creates|emit|emits|produce|produces)([^[:alnum:]_]|$)/) {
+  if (mode == "write" && l !~ /(^|[^[:alnum:]_])(write|writes|written|modify|modifies|modified|touch|touches|touched|update|updates|updated|create|creates|created|produce|produces|produced|edit|edits|edited|add|adds|added|document|documents|documented|populate|populates|populated|replace|replaces|replaced|materialize|materializes|materialized|archive|archives|archived|live|lives|located|defined|defines)([^[:alnum:]_]|$)/) {
     return ""
   }
   rest = text
@@ -202,6 +221,65 @@ function resources_anywhere(text,    rest, value, out) {
       out = add_resource(out, value)
     }
     rest = substr(rest, RSTART + RLENGTH)
+  }
+  return out
+}
+
+function resources_in_component_body(body,    rest, line, in_reference_section, paragraph, out, found_resources, fr, found_arr, ended) {
+  rest = body
+  out = ""
+  in_reference_section = 0
+  paragraph = ""
+  while (match(rest, /\n[^\n]*/)) {
+    line = substr(rest, RSTART + 1, RLENGTH - 1)
+    rest = substr(rest, RSTART + RLENGTH)
+    if (line ~ /^####?[[:space:]]/) {
+      if (paragraph != "") {
+        found_resources = resources_from(paragraph, "write")
+        if (found_resources != "") {
+          split(found_resources, found_arr, ",")
+          for (fr in found_arr) out = add_resource(out, found_arr[fr])
+        }
+        paragraph = ""
+      }
+      if (lower(line) ~ /(edges and prior art|edges and references|reference|references|verification|inventory|prior art|non-goals|out of scope|scope \(out\))/) {
+        in_reference_section = 1
+      } else {
+        in_reference_section = 0
+      }
+      continue
+    }
+    if (in_reference_section) continue
+    if (line ~ /^[[:space:]]*$/) {
+      if (paragraph != "") {
+        found_resources = resources_from(paragraph, "write")
+        if (found_resources != "") {
+          split(found_resources, found_arr, ",")
+          for (fr in found_arr) out = add_resource(out, found_arr[fr])
+        }
+        paragraph = ""
+      }
+      continue
+    }
+    if (line ~ /^[[:space:]]*[-*][[:space:]]/) {
+      if (paragraph != "") {
+        found_resources = resources_from(paragraph, "write")
+        if (found_resources != "") {
+          split(found_resources, found_arr, ",")
+          for (fr in found_arr) out = add_resource(out, found_arr[fr])
+        }
+      }
+      paragraph = line
+      continue
+    }
+    paragraph = paragraph " " line
+  }
+  if (paragraph != "") {
+    found_resources = resources_from(paragraph, "write")
+    if (found_resources != "") {
+      split(found_resources, found_arr, ",")
+      for (fr in found_arr) out = add_resource(out, found_arr[fr])
+    }
   }
   return out
 }
@@ -424,7 +502,14 @@ END {
   for (i = 1; i <= node_count; i++) {
     source_id = node_order[i]
     if (component_mode == 1 && node_kind[source_id] == "task") {
-      found_resources = resources_anywhere(component_body[source_id])
+      title_resources = resources_from_title(component_title[source_id])
+      if (title_resources != "") {
+        split(title_resources, title_arr, ",")
+        for (fr in title_arr) {
+          node_writes[source_id] = add_resource(node_writes[source_id], title_arr[fr])
+        }
+      }
+      found_resources = resources_in_component_body(component_body[source_id])
       fallback_resources = fallback_component_resources(component_title[source_id])
       if (found_resources != "") {
         split(found_resources, found_arr, ",")

--- a/scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
+++ b/scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Regression fixture for #793 — prd-task-graph-synthesize.sh used to scrape
+# every backticked path-shaped token from a component body, conflating writes
+# with references, verification commands, format alternates, and section-level
+# pattern references. This fixture pins the corrected behavior:
+#
+# - Bare extension tokens (`.json`) do NOT land in write_resources.
+# - Shell-command literals (`grep -n "X" foo.sh`) do NOT land in
+#   write_resources.
+# - Reference sections (Edges and prior art, Verification) suppress backtick
+#   extraction.
+# - Title backticked paths land in write_resources.
+# - Body backticked paths require a write-verb in the same paragraph, so
+#   "pattern reference" tokens stay out.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUN="$ROOT/scripts/prd-task-graph-synthesize.sh"
+TMPROOT=$(mktemp -d -t planner-hygiene.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+[ -x "$RUN" ] || fail "scripts/prd-task-graph-synthesize.sh is not executable"
+command -v jq >/dev/null 2>&1 || { printf 'SKIP: jq required\n'; exit 0; }
+
+SOURCE="$TMPROOT/polluted-source.md"
+GRAPH="$TMPROOT/graph.json"
+
+cat >"$SOURCE" <<'EOF'
+# Test arc — write/reference disambiguation
+
+## Why
+
+Reproduces the path-extraction failure modes from #793. Each component is
+authored to look plausible while embedding the four classic pollutants:
+references, verification commands, alternates, and pattern references.
+
+## Scope (in)
+
+### 1. Schema + default profile file
+
+- The schema spec is created at `_shared/contracts/test-schema.md`.
+- The default profile file is created at `_shared/profiles/default.yaml`
+  (alternate format `.json` discussed but YAML wins; planner picks).
+- Inventory of consumer scripts (read-only for this arc):
+  - `scripts/foo-consumer.sh`
+  - `scripts/bar-consumer.sh`
+
+### 2. Resolver library (`scripts/lib-test-resolver.sh`)
+
+- Library file: writes will land at `scripts/lib-test-resolver.sh`.
+- Pattern reference: see `scripts/lib-studio-context.sh` for the sourceable
+  shell library convention used elsewhere in the studio.
+
+### 3. Eligibility library (`scripts/lib-test-eligibility.sh`)
+
+- Library file: writes to `scripts/lib-test-eligibility.sh`.
+- Verification command: `grep -n "STUDIO_HOST" scripts/lib-test-resolver.sh`
+  proves the library wires up correctly.
+
+### 4. Chain runner integration
+
+Touches `scripts/test-chain-runner.sh` (line 5612 literal removal).
+
+### 5. Halt-record schema
+
+Updates `_shared/contracts/test-envelope.md` and `scripts/lib-test-run-state.sh`
+across multiple wrapped lines. The reviewer surfaces the resolved host in
+`scripts/test-chain-monitor.sh` user-facing output as well.
+
+### 6. Documentation
+
+- Document `STUDIO_BYPASS_TEST_HYGIENE=1` in `CLAUDE.md`.
+- Update `hosts/ADAPTER-SPEC.md` with a forward pointer.
+- No new top-level rules in `REVIEW.md`. The block-tier rules are deferred.
+
+## Edges and prior art in the repo
+
+- `scripts/foo-consumer.sh` — read-only inventory reference.
+- `scripts/lib-studio-context.sh` — pattern reference, not a write target.
+- `scripts/test-chain-runner.sh:5612` — anchor line for the integration.
+
+## Verification
+
+- `bash -n scripts/lib-test-resolver.sh`
+- `grep -n "STUDIO_HOST" scripts/lib-test-eligibility.sh`
+EOF
+
+"$RUN" "$SOURCE" >"$GRAPH" 2>"$TMPROOT/synth.err" \
+  || { sed -n '1,40p' "$TMPROOT/synth.err" >&2; fail "synthesis exited non-zero"; }
+
+# Helper: read write_resources for a node id
+writes_for() {
+  jq -r --arg id "$1" '.nodes[] | select(.id == $id) | .write_resources | join(",")' "$GRAPH"
+}
+
+t1=$(writes_for T-R001)
+t2=$(writes_for T-R002)
+t3=$(writes_for T-R003)
+t4=$(writes_for T-R004)
+t5=$(writes_for T-R005)
+t6=$(writes_for T-R006)
+
+# Each assertion checks one of the original 10 fatal items from #793.
+
+# T-R001: must NOT contain bare `.json` (alternate-format token).
+case ",$t1," in *,.json,*) fail "T-R001 contains bare .json (alternate token leaked)";; esac
+
+# T-R001: must NOT contain consumer-inventory scripts (read-only references).
+case ",$t1," in
+  *,scripts/foo-consumer.sh,*) fail "T-R001 leaked consumer inventory script";;
+  *,scripts/bar-consumer.sh,*) fail "T-R001 leaked consumer inventory script";;
+esac
+
+# T-R001: SHOULD contain the legitimate write targets.
+case ",$t1," in
+  *,_shared/contracts/test-schema.md,*) :;;
+  *) fail "T-R001 missing _shared/contracts/test-schema.md (got: $t1)";;
+esac
+case ",$t1," in
+  *,_shared/profiles/default.yaml,*) :;;
+  *) fail "T-R001 missing _shared/profiles/default.yaml (got: $t1)";;
+esac
+
+# T-R002: must contain its named library (regression: was missing).
+case ",$t2," in
+  *,scripts/lib-test-resolver.sh,*) :;;
+  *) fail "T-R002 missing scripts/lib-test-resolver.sh (got: $t2)";;
+esac
+
+# T-R002: must NOT contain pattern-reference path lib-studio-context.sh.
+case ",$t2," in
+  *,scripts/lib-studio-context.sh,*) fail "T-R002 leaked pattern-reference path";;
+esac
+
+# T-R003: must contain its named library and NOT the verification grep command.
+case ",$t3," in
+  *,scripts/lib-test-eligibility.sh,*) :;;
+  *) fail "T-R003 missing scripts/lib-test-eligibility.sh (got: $t3)";;
+esac
+
+# T-R003 / T-R004: must NOT contain the literal "grep -n ..." shell command.
+for w in "$t3" "$t4" "$t5"; do
+  case "$w" in
+    *grep*-n*) fail "shell command literal leaked into write_resources: $w";;
+  esac
+done
+
+# T-R004: must NOT have any path containing whitespace or shell syntax.
+for w in "$t1" "$t2" "$t3" "$t4" "$t5" "$t6"; do
+  case "$w" in
+    *' '*|*'--'*|*'>'*|*'$('*) fail "shell-syntax write_resource leaked: $w";;
+  esac
+done
+
+# T-R005: paragraph-wrap must not drop paths from a multi-line write paragraph.
+case ",$t5," in
+  *,_shared/contracts/test-envelope.md,*) :;;
+  *) fail "T-R005 missing _shared/contracts/test-envelope.md (got: $t5)";;
+esac
+case ",$t5," in
+  *,scripts/lib-test-run-state.sh,*) :;;
+  *) fail "T-R005 missing scripts/lib-test-run-state.sh (got: $t5)";;
+esac
+
+# T-R006: must contain CLAUDE.md (Document verb), must NOT contain REVIEW.md
+# (negation phrasing — "No new top-level rules in REVIEW.md").
+case ",$t6," in
+  *,CLAUDE.md,*) :;;
+  *) fail "T-R006 missing CLAUDE.md (got: $t6)";;
+esac
+case ",$t6," in
+  *,REVIEW.md,*) fail "T-R006 leaked REVIEW.md (forbidden by source brief)";;
+esac
+case ",$t6," in
+  *,hosts/ADAPTER-SPEC.md,*) :;;
+  *) fail "T-R006 missing hosts/ADAPTER-SPEC.md (got: $t6)";;
+esac
+
+# Validation must report no parallel-write races and not leave empty
+# allowed_paths arrays for the contracts above.
+empty_count=$(jq '[.validation.empty_allowed_paths[]?] | length' "$GRAPH")
+[ "$empty_count" = "0" ] || fail "validation reported $empty_count empty allowed_paths nodes"
+
+printf 'PASS: planner allowed_paths hygiene rejects shell syntax, bare extensions, references, and negation phrasing\n'


### PR DESCRIPTION
## Summary

- Fixes the path-extraction sloppiness in \`scripts/prd-task-graph-synthesize.sh\` that produced 10 fatal items from the 2026-05-09 cross-host plan review.
- Paragraph-level extraction with verb-gated body scan, title backtick extraction, reference-section suppression (Edges and prior art / Verification / Inventory / Non-goals), and stricter \`resource_like()\` (rejects shell syntax + bare extensions).
- Catches 8 of 10 originally-fatal items end-to-end on the host-agnostic-runtime-resolver source brief. Two residual items (env-var-templated paths, "Tests in ..." phrasing) documented in the commit body as known limits.

## Test plan

- [x] \`bash -n scripts/prd-task-graph-synthesize.sh\`
- [x] \`shellcheck -S warning scripts/prd-task-graph-synthesize.sh\`
- [x] \`bash scripts/test-fixtures/650-task-graph/test-task-graph-synthesis.sh\` (pre-existing fixture, regression)
- [x] \`bash scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh\` (new fixture pinning all six failure shapes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)