### PR TITLE
Project ingest resolves through login-home under synthetic HOME (#822)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T15:58:08Z",
+  "generated_at": "2026-05-10T14:00:55Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T15:58:08Z",
+  "generated_at": "2026-05-10T14:00:55Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/dev-studio-ingest-resolve.sh
+++ b/scripts/dev-studio-ingest-resolve.sh
@@ -76,6 +76,13 @@ source_project=$(basename "$source_root")
 destination_project=$source_project
 
 if [ -n "$to_project" ]; then
+  # `--to dev-studio` is a common shorthand for the studio destination; normalize
+  # so it routes through the studio-feedback path instead of being treated as a
+  # project slug literal (which would write a project ingest dir named
+  # "dev-studio"). See #822.
+  if [ "$to_project" = "dev-studio" ]; then
+    to_project=generic-dev-studio
+  fi
   destination_project=$to_project
 elif [ "$scope" = "studio" ]; then
   destination_project=generic-dev-studio
@@ -97,7 +104,7 @@ if [ "$scope" = "project" ] && [ "$resolved_scope" = "studio" ]; then
 fi
 
 artifact_kind=project-ingest
-artifact_root="$(resolve_project_root_for "$destination_project")/ingest"
+artifact_root="$(resolve_project_ingest_root_for "$destination_project")"
 public_issue_repo=null
 requires_privacy_scrub=false
 

--- a/scripts/lib-paths.sh
+++ b/scripts/lib-paths.sh
@@ -543,6 +543,41 @@ resolve_feedback_data_home() {
   printf '%s\n' "${HOME:-}"
 }
 
+# Resolve the stable home for project-scoped durable content (ingest records,
+# durable artifacts shared across hosts). Mirrors resolve_feedback_data_home:
+# host launchers may run under a synthetic HOME (~/.codex-homes/...), but
+# project ingest must land in the login-home Studio root so records stay
+# host-agnostic and visible across Claude/Codex/other adapters. Per-project
+# *runtime* state (events, locks, .runtime, plans) keeps using
+# resolve_project_root_for — it stays host-local because it is
+# session-scoped, not durable cross-host content.
+resolve_project_ingest_data_home() {
+  case "${STUDIO_BYPASS_INGEST_LOGIN_HOME:-0}" in
+    1|true|TRUE|yes|YES)
+      printf '%s\n' "${HOME:-}"
+      return 0
+      ;;
+  esac
+
+  if studio_home_is_synthetic "${HOME:-}"; then
+    local login_home
+    login_home=$(resolve_user_login_home 2>/dev/null || true)
+    if [ -n "$login_home" ] && [ -d "$login_home" ]; then
+      printf '%s\n' "$login_home"
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "${HOME:-}"
+}
+
+# Per-project ingest root — durable, host-agnostic destination for
+# /dev-studio manager ingest project records. See #822.
+resolve_project_ingest_root_for() {
+  local project="${1:?usage: resolve_project_ingest_root_for <slug>}"
+  printf '%s\n' "$(resolve_project_ingest_data_home)/.dev-studio/$project/ingest"
+}
+
 # Studio-self feedback inbox for a given source-project slug. Feedback records
 # authored in any project route here (see CLAUDE.md "Analysis sessions and
 # privacy"); generic-dev-studio is the destination because that's where the

--- a/scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
+++ b/scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh
@@ -7,6 +7,7 @@ RUN="$ROOT/scripts/dev-studio-ingest-resolve.sh"
 TMPROOT=$(mktemp -d -t ingest-resolver.XXXXXX)
 trap 'rm -rf "$TMPROOT"' EXIT
 export STUDIO_BYPASS_FEEDBACK_LOGIN_HOME=1
+export STUDIO_BYPASS_INGEST_LOGIN_HOME=1
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -97,6 +98,44 @@ printf '%s\n' "$synthetic_home_json" | jq -e \
    and .artifact_root == ($login_home + "/.dev-studio/generic-dev-studio/feedback-inbox/sample-app")' >/dev/null || {
   printf '%s\n' "$synthetic_home_json" >&2
   fail "synthetic HOME studio feedback did not resolve through login home"
+}
+
+synthetic_home_project_json=$(
+  env -u STUDIO_BYPASS_INGEST_LOGIN_HOME \
+    HOME="$TMPROOT/.codex-homes/personal" \
+    PATH="$TMPROOT/bin:$PATH" \
+    "$RUN" --cwd "$TMPROOT/sample-app"
+)
+printf '%s\n' "$synthetic_home_project_json" | jq -e \
+  --arg login_home "$TMPROOT/login-home" \
+  '.scope == "project"
+   and .destination_project == "sample-app"
+   and .artifact_kind == "project-ingest"
+   and .artifact_root == ($login_home + "/.dev-studio/sample-app/ingest")' >/dev/null || {
+  printf '%s\n' "$synthetic_home_project_json" >&2
+  fail "synthetic HOME project ingest did not resolve through login home (#822)"
+}
+
+synthetic_home_project_bypass_json=$(
+  HOME="$TMPROOT/.codex-homes/personal" \
+    PATH="$TMPROOT/bin:$PATH" \
+    "$RUN" --cwd "$TMPROOT/sample-app"
+)
+printf '%s\n' "$synthetic_home_project_bypass_json" | jq -e \
+  --arg synthetic "$TMPROOT/.codex-homes/personal" \
+  '.artifact_root == ($synthetic + "/.dev-studio/sample-app/ingest")' >/dev/null || {
+  printf '%s\n' "$synthetic_home_project_bypass_json" >&2
+  fail "STUDIO_BYPASS_INGEST_LOGIN_HOME=1 should keep ingest in synthetic HOME for tests/isolation"
+}
+
+dev_studio_alias_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --to dev-studio)
+printf '%s\n' "$dev_studio_alias_json" | jq -e \
+  '.destination_project == "generic-dev-studio"
+   and .scope == "studio"
+   and .artifact_kind == "studio-ingest"
+   and .requires_privacy_scrub == true' >/dev/null || {
+  printf '%s\n' "$dev_studio_alias_json" >&2
+  fail "--to dev-studio did not normalize to generic-dev-studio (#822)"
 }
 
 explicit_project_json=$(HOME="$TMPROOT/home" "$RUN" --cwd "$TMPROOT/sample-app" --to other-app)


### PR DESCRIPTION
## Summary

- `/dev-studio manager ingest` now writes project records to the durable login-home Studio root (`~/.dev-studio/<project>/ingest`) instead of the active Codex synthetic home (`~/.codex-homes/personal/.dev-studio/<project>/ingest`).
- `--to dev-studio` normalizes to `generic-dev-studio` so the shorthand routes through the studio-feedback path instead of being a literal project slug.
- New helpers `resolve_project_ingest_data_home` / `resolve_project_ingest_root_for` in `scripts/lib-paths.sh` mirror the existing `resolve_feedback_data_home` pattern; opt out for tests / isolation with `STUDIO_BYPASS_INGEST_LOGIN_HOME=1`.

## Scope notes

Per-project **runtime** state (events, locks, `.runtime`, plans) keeps using `resolve_project_root_for` and stays host-local — session-scoped, not durable cross-host content. Only durable ingest records redirect. Cross-host runtime visibility is out of scope here; #710 phase work owns it.

## Test plan

- [x] `bash scripts/test-fixtures/578-ingest-resolver/test-dev-studio-ingest-resolve.sh` — extended with synthetic-HOME project case, bypass-env case, `--to dev-studio` alias case
- [x] `lint-runtime-paths.sh`, `lint-gh-wrapper.sh`, `lint-synthetic-home.sh`, `lint-host-agnostic.sh` clean (W_ARGUS_SECRET_SCOPE warning is pre-existing, unrelated)
- [x] zsh portability smoke (`zsh -c '. scripts/lib-paths.sh && resolve_project_ingest_root_for sample-app'`)
- [x] commit-msg lint passed

Closes #822