### PR TITLE
Plan-chain fails fast on inline prompts referencing readable paths (#823)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T15:52:22Z",
+  "generated_at": "2026-05-10T15:55:22Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T15:52:21Z",
+  "generated_at": "2026-05-10T15:55:21Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/manager-plan-chain.sh
+++ b/scripts/manager-plan-chain.sh
@@ -1285,6 +1285,57 @@ if [ "${#POSITIONAL[@]}" -gt 0 ]; then
   fi
 fi
 
+# #823: inline refinement prompts that *reference* prior plan/review artifacts
+# previously got synthesized as a single worker task with empty allowed_paths
+# and stopped later as needs_context with no actionable instruction. Detect
+# this class early — if the inline goal text contains readable file paths, the
+# user almost certainly meant to feed those files as structured input. Fail
+# fast with a clear redirect to --source-file / --from-plan instead of
+# producing a bogus one-task decomposition.
+#
+# Bypass: STUDIO_PLAN_CHAIN_ALLOW_INLINE_PATHS=1 (for prompts that legitimately
+# mention paths as prose, not as input artifacts).
+if [ -z "$SOURCE_FILE" ] && [ -z "$ISSUE_NUMBER" ] && [ -z "$FROM_PLAN" ] && [ -n "$SOURCE_TEXT" ]; then
+  case "${STUDIO_PLAN_CHAIN_ALLOW_INLINE_PATHS:-0}" in
+    1|true|TRUE|yes|YES) ;;
+    *)
+      _inline_path_hits=""
+      for _tok in $SOURCE_TEXT; do
+        case "$_tok" in
+          /*.md|/*.yaml|/*.yml|/*.json|/*.txt \
+          |\~/*.md|\~/*.yaml|\~/*.yml|\~/*.json|\~/*.txt \
+          |./*.md|./*.yaml|./*.yml|./*.json|./*.txt \
+          |../*.md|../*.yaml|../*.yml|../*.json|../*.txt)
+            _expanded="${_tok/#\~/$HOME}"
+            if [ -r "$_expanded" ]; then
+              _inline_path_hits="${_inline_path_hits}${_inline_path_hits:+ }$_tok"
+            fi
+            ;;
+        esac
+      done
+      if [ -n "$_inline_path_hits" ]; then
+        cat >&2 <<EOF
+manager-plan-chain: inline goal text references readable file path(s):
+  $_inline_path_hits
+
+Inline prompts get synthesized as a single worker task with empty
+allowed_paths and stop later as needs_context. If those paths are the
+intended input, rerun with structured input:
+
+  --source-file <path>     for a PRD / brief / refinement doc
+  --from-plan <path>       for an existing planner / task-graph artifact
+  --issue <n>              to load from a GitHub issue
+
+If the path text is prose (not input), bypass with:
+  STUDIO_PLAN_CHAIN_ALLOW_INLINE_PATHS=1
+EOF
+        exit 2
+      fi
+      unset _inline_path_hits _tok _expanded
+      ;;
+  esac
+fi
+
 TARGET_REPO_ROOT=${TARGET_REPO_ROOT:-$(git -C "${PWD:-$REPO_ROOT}" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$REPO_ROOT")}
 TARGET_REPO_ROOT=$(cd "$TARGET_REPO_ROOT" && pwd -P)
 [ -n "$PROJECT" ] || PROJECT=$(basename "$TARGET_REPO_ROOT")

--- a/scripts/test-fixtures/823-plan-chain-inline-paths/test-plan-chain-inline-paths.sh
+++ b/scripts/test-fixtures/823-plan-chain-inline-paths/test-plan-chain-inline-paths.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# test-plan-chain-inline-paths.sh — fixture for #823.
+#
+# Verifies manager-plan-chain.sh fails fast with an actionable message when
+# inline goal text references readable file paths, and respects the bypass
+# envvar.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUN="$ROOT/scripts/manager-plan-chain.sh"
+TMPROOT=$(mktemp -d -t plan-chain-inline.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Make a readable artifact-shaped file.
+artifact="$TMPROOT/2026-05-10-foo-outcome-review.md"
+printf '# review\n' > "$artifact"
+
+# Case 1: inline prompt that references an existing readable path -> fail with redirect.
+out=$("$RUN" "regenerate plan from review at $artifact and address blockers" 2> "$TMPROOT/c1.err" || printf 'rc=%s\n' "$?")
+assert "inline path reference fails non-zero" \
+  'grep -q "rc=2" <<< "$out"'
+assert "error message names the offending path" \
+  'grep -Fq "$artifact" "$TMPROOT/c1.err"'
+assert "error suggests --source-file redirect" \
+  'grep -q -- "--source-file <path>" "$TMPROOT/c1.err"'
+assert "error documents the bypass envvar" \
+  'grep -q "STUDIO_PLAN_CHAIN_ALLOW_INLINE_PATHS" "$TMPROOT/c1.err"'
+
+# Case 2: inline prompt with NO paths -> path detection should not fire.
+# (We can't run end-to-end without gh / planner; just confirm the detector
+#  does not trigger by checking the early-exit error string is absent.)
+"$RUN" "build a widget that does X" >"$TMPROOT/c2.out" 2>"$TMPROOT/c2.err" || true
+assert "plain inline prompt does not trip path detector" \
+  '! grep -q "references readable file path" "$TMPROOT/c2.err"'
+
+# Case 3: inline prompt referencing a NON-existent path -> should not trip
+# (we only fail when the path is actually readable; otherwise it's just prose).
+"$RUN" "do something with /tmp/does-not-exist-$$.md" >"$TMPROOT/c3.out" 2>"$TMPROOT/c3.err" || true
+assert "non-readable path reference is not flagged" \
+  '! grep -q "references readable file path" "$TMPROOT/c3.err"'
+
+# Case 4: bypass envvar lets the inline prompt through despite path reference.
+STUDIO_PLAN_CHAIN_ALLOW_INLINE_PATHS=1 "$RUN" "regenerate from $artifact" \
+  >"$TMPROOT/c4.out" 2>"$TMPROOT/c4.err" || true
+assert "bypass=1 disables the path-detection guard" \
+  '! grep -q "references readable file path" "$TMPROOT/c4.err"'
+
+if [ "$fail" -gt 0 ]; then
+  printf 'FAIL: %d test(s) failed\n' "$fail" >&2
+  exit 1
+fi
+printf 'PASS: plan-chain inline-paths (%d/%d)\n' "$pass" "$pass"


### PR DESCRIPTION
## Summary

- `manager-plan-chain` now detects inline goal text that references readable file paths and fails fast with an actionable redirect to `--source-file` / `--from-plan` / `--issue`.
- Previously the prompt would be synthesized as a single worker task with empty `allowed_paths` and stop later as `needs_context` with no instruction.
- Heuristic: whitespace-delimited tokens shaped like absolute / home-relative / dot-relative paths ending in `.md|.yaml|.yml|.json|.txt`, where the resolved path is readable. Tokens that don't resolve are treated as prose and pass through.
- Bypass: `STUDIO_PLAN_CHAIN_ALLOW_INLINE_PATHS=1` for prompts that legitimately reference paths as prose.

## Test plan

- [x] `bash scripts/test-fixtures/823-plan-chain-inline-paths/test-plan-chain-inline-paths.sh` — 7/7 cases pass.
- [x] Lints clean.

Closes #823