### PR TITLE
resolve_project() resolves project slug from inside worktrees (#820 P0 item 3)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T16:34:41Z",
+  "generated_at": "2026-05-10T15:58:08Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T16:34:41Z",
+  "generated_at": "2026-05-10T15:58:08Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-paths.sh
+++ b/scripts/lib-paths.sh
@@ -72,7 +72,25 @@ error: no project resolved.
 EOF
     return 1
   }
-  basename "$top"
+  # #820: inside an Achilles worktree (~/.dev-studio/<slug>/worktrees/<wt>),
+  # git rev-parse --show-toplevel returns the worktree's own toplevel and
+  # `basename` yields <wt> (e.g. "T368") instead of the project slug, orphaning
+  # events to ~/.dev-studio/T368/events/. Resolve from the *main* checkout via
+  # --git-common-dir, which points at the primary repo's .git for worktrees
+  # and at <top>/.git for ordinary checkouts — so the same logic works in
+  # both cases.
+  local common_dir main_top
+  common_dir=$(git -C "$top" rev-parse --git-common-dir 2>/dev/null) || {
+    basename "$top"
+    return 0
+  }
+  case "$common_dir" in
+    /*) ;;
+    *) common_dir="$top/$common_dir" ;;
+  esac
+  # `dirname <main>/.git` -> <main>; cd-resolve handles trailing-slash quirks.
+  main_top=$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd -P) || main_top=$(dirname "$common_dir")
+  basename "$main_top"
 }
 
 resolve_inbox_root() {

--- a/scripts/test-fixtures/820-resolve-project-worktree/test-resolve-project-worktree.sh
+++ b/scripts/test-fixtures/820-resolve-project-worktree/test-resolve-project-worktree.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# test-resolve-project-worktree.sh — fixture for #820.
+#
+# Verifies resolve_project() returns the project slug (not the worktree dir
+# name) when invoked from inside a git worktree.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t resolve-project-wt.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+pass=0
+fail=0
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Set up a fake project repo + worktree inside it. Mirrors the studio layout:
+#   <main>/turnip-ios            (main checkout)
+#   <main>/turnip-ios/worktrees/T368  (worktree, branch feature-x)
+mkdir -p "$TMPROOT/turnip-ios"
+cd "$TMPROOT/turnip-ios"
+git init -q -b main
+git config user.email a@b.c
+git config user.name test
+printf 'x\n' > README.md
+git add README.md
+git commit -q -m initial
+mkdir -p worktrees
+git worktree add -q -b feature-x worktrees/T368 main >/dev/null
+
+# Case 1: inside the main checkout, resolve_project must return "turnip-ios".
+result_main=$(cd "$TMPROOT/turnip-ios" && bash -c "
+  source '$ROOT/scripts/lib-paths.sh' && resolve_project
+")
+assert "main checkout resolves project to 'turnip-ios'" \
+  '[ "$result_main" = "turnip-ios" ]'
+
+# Case 2: inside the worktree at worktrees/T368, resolve_project must return
+# "turnip-ios" — NOT "T368". This is the #820 regression.
+result_wt=$(cd "$TMPROOT/turnip-ios/worktrees/T368" && bash -c "
+  source '$ROOT/scripts/lib-paths.sh' && resolve_project
+")
+assert "worktree resolves project to 'turnip-ios' (not 'T368') — #820" \
+  '[ "$result_wt" = "turnip-ios" ]'
+
+# Case 3: ACHILLES_PROJECT env var still wins over both.
+result_env=$(cd "$TMPROOT/turnip-ios/worktrees/T368" && ACHILLES_PROJECT=override bash -c "
+  source '$ROOT/scripts/lib-paths.sh' && resolve_project
+")
+assert "ACHILLES_PROJECT override still beats worktree resolution" \
+  '[ "$result_env" = "override" ]'
+
+# Case 4: outside any git repo, resolve_project errors. Use a temp dir that
+# has no .git ancestor (mktemp under TMPROOT works since TMPROOT itself has
+# no .git in its parent chain).
+result_norepo_rc=0
+(cd "$TMPROOT" && bash -c "
+  source '$ROOT/scripts/lib-paths.sh' && resolve_project
+" >/dev/null 2>&1) || result_norepo_rc=$?
+assert "non-repo resolve_project returns non-zero" \
+  '[ "$result_norepo_rc" -ne 0 ]'
+
+if [ "$fail" -gt 0 ]; then
+  printf 'FAIL: %d test(s) failed\n' "$fail" >&2
+  exit 1
+fi
+printf 'PASS: resolve_project worktree (%d/%d)\n' "$pass" "$pass"


### PR DESCRIPTION
## Summary

Fixes the most contained P0 item in #820: `resolve_project()` returned the worktree dir name (e.g. `T368`) instead of the project slug (`turnip-ios`) when called from inside `~/.dev-studio/<slug>/worktrees/<wt>`. That orphaned 21 T368 events to `~/.dev-studio/T368/events/...` where chanakya's inbox-sweep couldn't see them.

The fix resolves the project from `--git-common-dir` instead of `--show-toplevel`. For worktrees, `--git-common-dir` points at the *main* repo's `.git`; for ordinary checkouts, it returns `<top>/.git`. `basename(dirname(common_dir))` yields the right answer in both cases.

## Test plan

- [x] `bash scripts/test-fixtures/820-resolve-project-worktree/test-resolve-project-worktree.sh` — 4/4 cases pass:
  - main checkout returns `turnip-ios`
  - worktree returns `turnip-ios` (not `T368`) — the #820 regression
  - `ACHILLES_PROJECT` env override still wins
  - non-repo invocation still errors

## Out of scope

This is **one** of seven items in #820. The remaining six (UUIDv7 intake lint, build-log preservation, jsonl-merge safe primitive, dispatch escape hatch, m1mini diagnostics, lint for `jq -s` on jsonl globs) are independent and will ship as separate PRs.

Refs #820 (P0 item 3)