### PR TITLE
Reviewer eligibility + phase-review preserve codex ChatGPT-OAuth auth

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-09T23:13:20Z",
+  "generated_at": "2026-05-10T16:34:41Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-09T23:13:20Z",
+  "generated_at": "2026-05-10T16:34:41Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -363,15 +363,32 @@ EOF
 
 case "$review_host" in
   codex*|*codex*)
-    review_cmd=(env -i \
-      PATH="$PATH" \
-      HOME="$reviewer_home" \
-      LANG="${LANG:-C.UTF-8}" \
-      USER="${USER:-}" \
-      ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
-      STUDIO_HOST="$review_host" \
-      REVIEW_PAYLOAD="$input" \
-      "${spawn_argv[@]}" "$prompt")
+    # See pr-reviewer-eligibility.sh: codex 0.130+ ChatGPT-OAuth fails 401 with
+    # HOME reassigned to a tmpdir OR with CODEX_HOME set explicitly even to
+    # the default $HOME/.codex. When the resolved auth_home equals the
+    # default, drop both overrides so codex auth resolves through the user's
+    # real environment. Real isolation (seeded `.codex-reviewer/`) still
+    # uses the override path.
+    if [ "$reviewer_codex_home" = "$HOME/.codex" ]; then
+      review_cmd=(env -i \
+        PATH="$PATH" \
+        HOME="$HOME" \
+        LANG="${LANG:-C.UTF-8}" \
+        USER="${USER:-}" \
+        STUDIO_HOST="$review_host" \
+        REVIEW_PAYLOAD="$input" \
+        "${spawn_argv[@]}" "$prompt")
+    else
+      review_cmd=(env -i \
+        PATH="$PATH" \
+        HOME="$reviewer_home" \
+        LANG="${LANG:-C.UTF-8}" \
+        USER="${USER:-}" \
+        ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
+        STUDIO_HOST="$review_host" \
+        REVIEW_PAYLOAD="$input" \
+        "${spawn_argv[@]}" "$prompt")
+    fi
     ;;
   *)
     review_cmd=(env -i \

--- a/scripts/pr-reviewer-eligibility.sh
+++ b/scripts/pr-reviewer-eligibility.sh
@@ -165,15 +165,41 @@ run_smoke_gate() {
   local smoke_rc
   case "$HOST" in
     codex*|*codex*)
-      ( cd "$REPO_ROOT" && env -i \
-        PATH="$PATH" \
-        HOME="$reviewer_home" \
-        LANG="${LANG:-C.UTF-8}" \
-        USER="${USER:-}" \
-        ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
-        STUDIO_HOST="$HOST" \
-        REVIEW_PAYLOAD="$payload" \
-        "${smoke_cmd[@]}" </dev/null >"$stdout_file" 2>"$stderr_file" )
+      # Codex 0.130+ ChatGPT-OAuth auth fails (401 Unauthorized) when (a) HOME
+      # is reassigned to an isolated tmpdir, or (b) CODEX_HOME is set
+      # explicitly — even to its own default $HOME/.codex. Auth state is
+      # reachable only when both are left as the user's real environment.
+      # When the resolved reviewer auth_home equals $HOME/.codex (i.e. no
+      # isolated `.codex-reviewer/` is seeded), drop both overrides so the
+      # smoke can authenticate. Real isolation (a non-default reviewer home)
+      # still uses the override path; that path requires `.codex-reviewer/`
+      # to be seeded with auth state — tracked separately.
+      local _codex_runtime_home="$reviewer_home"
+      local _codex_home_override=1
+      if [ "$reviewer_codex_home" = "$HOME/.codex" ]; then
+        _codex_runtime_home="$HOME"
+        _codex_home_override=0
+      fi
+      if [ "$_codex_home_override" = "1" ]; then
+        ( cd "$REPO_ROOT" && env -i \
+          PATH="$PATH" \
+          HOME="$_codex_runtime_home" \
+          LANG="${LANG:-C.UTF-8}" \
+          USER="${USER:-}" \
+          ${reviewer_codex_home:+CODEX_HOME="$reviewer_codex_home"} \
+          STUDIO_HOST="$HOST" \
+          REVIEW_PAYLOAD="$payload" \
+          "${smoke_cmd[@]}" </dev/null >"$stdout_file" 2>"$stderr_file" )
+      else
+        ( cd "$REPO_ROOT" && env -i \
+          PATH="$PATH" \
+          HOME="$_codex_runtime_home" \
+          LANG="${LANG:-C.UTF-8}" \
+          USER="${USER:-}" \
+          STUDIO_HOST="$HOST" \
+          REVIEW_PAYLOAD="$payload" \
+          "${smoke_cmd[@]}" </dev/null >"$stdout_file" 2>"$stderr_file" )
+      fi
       smoke_rc=$?
       ;;
     *)


### PR DESCRIPTION
## Summary

`pr-reviewer-eligibility.sh` AND `scripts/phase-review.sh` both reassigned `HOME` to a clean tmpdir AND set `CODEX_HOME` to the resolved reviewer auth_home for codex reviewers. Codex 0.130+ ChatGPT-OAuth fails 401 under either condition: it needs real `$HOME` to reach session/keychain state, AND breaks when `CODEX_HOME` is set explicitly *even to its own default* `$HOME/.codex`.

Net effect: every cross-host review against `codex-reviewer` failed (eligibility smoke or actual review run, depending on the path), `phase-review.sh` fell back to same-host `claude-reviewer`, cross-host review was unreachable on ChatGPT-subscription auth despite the user being correctly logged in. Root cause of `CROSS_HOST_SATISFIED=false` on #824's plan review — and probably every prior phase-review on this machine.

## Fix

Symmetric change in both scripts: when the resolved reviewer auth_home equals `$HOME/.codex` (no isolated `.codex-reviewer/` seeded), use real `$HOME` and omit the `CODEX_HOME` override. The isolated path is preserved unchanged for when `.codex-reviewer/` exists.

## Test plan

- [x] `bash scripts/pr-reviewer-eligibility.sh codex-reviewer` → `PR_REVIEWER_ELIGIBLE=1 / SMOKE=passed` (was `smoke_failed`).
- [x] End-to-end phase review on the #824 plan: `STUDIO_PARENT_HOST=claude-code scripts/phase-review.sh --review-host codex-reviewer --kind plan ...` → `PHASE_REVIEW_HOST=codex-reviewer / VERDICT=clean / CROSS_HOST_SATISFIED=true` (was falling back to claude-reviewer with `CROSS_HOST_SATISFIED=false`).

## Trade-off

The no-isolation branch runs with real `$HOME` — weaker tmpdir isolation than the original design. The trade-off: a working cross-host review under ChatGPT-OAuth auth is more valuable than tmpdir isolation that no other reviewer machinery actually depends on.

## Follow-up

A separate issue should track "seed `.codex-reviewer/` for proper isolation" — that's substrate documentation/helper-script work and not in scope here.