### PR TITLE
jsonl-merge safe primitive + lint + events append-only contract (#820 items 7.1+7.2+7.4)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -268,6 +268,19 @@ if [ -x "$SCRIPTS/lint-synthetic-home.sh" ]; then
   fi
 fi
 
+# Gate 2o — jsonl-merge linter (#820 item 7.2). Block the dangerous
+# `cat ... | jq -s 'sort_by ...'` shape that silently destroys ndjson on
+# control-char input. Use scripts/jsonl-merge.sh instead.
+if [ -x "$SCRIPTS/lint-jsonl-merge.sh" ]; then
+  "$SCRIPTS/lint-jsonl-merge.sh" --staged
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf '\npre-commit: dangerous `jq -s sort_by|unique|group_by|add` over ndjson found — use scripts/jsonl-merge.sh (control-char safe, refuses to lose records) per #820\n' >&2
+    printf 'bypass (emergencies only): STUDIO_BYPASS_JSONL_MERGE_LINT=1 git commit ...\n' >&2
+    exit 1
+  fi
+fi
+
 # Gate 3 — privacy.
 #
 # Reject commits whose staged diff references another project's runtime path.

--- a/_shared/contracts/events.md
+++ b/_shared/contracts/events.md
@@ -8,6 +8,8 @@ type: reference
 
 All agents write to a shared append-only event log. Chanakya tails it on wake.
 
+**Append-only is a hard contract (#820 item 7.4).** No tool may rewrite an event-log file in place — that operation has no safe primitive in this codebase, and the naive shape (`cat $a $b | jq -s 'sort_by(.ts) | unique' > merged; mv merged → canonical`) is silently destructive when any record carries control characters (build-log payloads, multi-line error strings). T368 cleanup lost a day's canonical events to exactly that pattern. To merge ndjson files **outside** `events/`, use `scripts/jsonl-merge.sh`; it parses with python (control-char safe), refuses to lose records, retains a timestamped `.bak` under runtime-global logs for 7 days, and **explicitly refuses** to write to any path under `<project>/events/`. Inside `events/`, only `cat >> canonical` is sanctioned; readers (Chanakya tail, sweep aggregators) sort and dedupe at read time. `scripts/lint-jsonl-merge.sh --staged` blocks the dangerous shape at commit time.
+
 ## File Location
 
 ```

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T14:00:55Z",
+  "generated_at": "2026-05-10T17:08:57Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T14:00:55Z",
+  "generated_at": "2026-05-10T17:08:57Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/jsonl-merge.sh
+++ b/scripts/jsonl-merge.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# jsonl-merge.sh — safe ndjson merge primitive (#820 item 7.1).
+#
+# Replaces the recurring shell pattern
+#
+#   cat "$canon" "$stray" | jq -c -s 'sort_by(.ts) | unique | .[]' > "$canon.merged"
+#   mv "$canon.merged" "$canon"
+#
+# whose failure mode is silent and catastrophic: any record carrying control
+# characters (embedded \n in build-log payloads, multi-line error messages)
+# breaks `jq -s` parse, the merged file is written empty, and `mv` then
+# overwrites the canonical file with a 0-byte result. The bak file is the only
+# recovery anchor and is typically `rm`'d in the next step. This is exactly
+# how the T368 cleanup lost a day's canonical event log (#333 item 7).
+#
+# Behavior
+# ========
+# - Uses Python's json module instead of jq. python3 handles control chars
+#   unconditionally and surfaces a structured error per line on parse failure.
+# - Sorts merged records by `ts` if every record has it; otherwise input order
+#   is preserved (deterministic concatenation, deduped by full line content).
+# - Dedupes by `idempotency_key` if every record has it; otherwise by the
+#   full canonical-encoded line.
+# - Writes to a sibling `.tmp` file, validates the temp parses as ndjson and
+#   has at least as many lines as the canonical input (or is non-empty when
+#   inputs were non-empty), then renames atomically. Refuses the rename if the
+#   merged file would lose records.
+# - Keeps a timestamped `.bak` for 7 days under the runtime-global
+# lint-runtime-paths:allow next-line — descriptive comment naming the bak path; runtime resolver is used in the actual write below.
+#   `~/.dev-studio/<project>/.runtime/logs/jsonl-merge/<basename>-<ts>.bak` location.
+# - REFUSES to write to any path under `<project>/events/`. Event logs are
+#   append-only by contract (Behavior Invariant #9, achilles/SKILL.md);
+#   in-place merge is the wrong primitive there. Use `cat >> canonical` and
+#   read with downstream sort/dedupe.
+#
+# Usage
+# =====
+#   scripts/jsonl-merge.sh <out> <in1> [<in2> ...]
+#
+# Exit codes
+# ==========
+#   0  success
+#   1  output path under events/ — refused
+#   2  input unreadable
+#   3  parse failure on input
+#   4  merged temp parse-validate failure (output not written)
+#   5  merged temp would lose records (output not written)
+
+set -u
+umask 022
+
+usage() {
+  printf 'usage: jsonl-merge.sh <out> <in1> [<in2> ...]\n' >&2
+  exit 2
+}
+
+[ "$#" -ge 2 ] || usage
+
+OUT="$1"; shift
+
+# Refuse writes under any project's events/ directory. Match either a
+# canonical resolver-shaped path or an explicit `events/<date>.jsonl`
+# segment to catch test fixtures and ad-hoc paths.
+# lint-runtime-paths:allow next-line — case-pattern matches a literal substring; not a path formula.
+case "$OUT" in
+  *"/.dev-studio/"*"/events/"*|*"/events/"*.jsonl)
+    printf 'jsonl-merge: refusing to write to events path: %s\n' "$OUT" >&2
+    printf 'jsonl-merge: event logs are append-only — use `cat >> canonical` and dedupe at read time.\n' >&2
+    exit 1
+    ;;
+esac
+
+# Verify all inputs exist + are readable before any work.
+for in_file in "$@"; do
+  if [ ! -r "$in_file" ]; then
+    printf 'jsonl-merge: input unreadable: %s\n' "$in_file" >&2
+    exit 2
+  fi
+done
+
+# Bak directory under runtime-global so audit history survives per-project sweeps.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=lib-paths.sh
+. "$SCRIPT_DIR/lib-paths.sh"
+RUNTIME_GLOBAL=$(resolve_runtime_global)
+BAK_ROOT="$RUNTIME_GLOBAL/logs/jsonl-merge"
+mkdir -p "$BAK_ROOT" 2>/dev/null || true
+BAK_TS=$(date -u +%Y%m%dT%H%M%SZ)
+
+OUT_DIR=$(dirname "$OUT")
+[ -d "$OUT_DIR" ] || mkdir -p "$OUT_DIR"
+TMP="$OUT.tmp.$$"
+
+# Snapshot existing output (if any) into bak before overwriting.
+if [ -f "$OUT" ]; then
+  bak_path="$BAK_ROOT/$(basename "$OUT").$BAK_TS.bak"
+  cp -p "$OUT" "$bak_path" 2>/dev/null || true
+fi
+
+# Prune bak files older than 7 days. Best-effort.
+find "$BAK_ROOT" -type f -name '*.bak' -mtime +7 -delete 2>/dev/null || true
+
+# Total non-empty input lines (for the "would lose records" guard).
+input_total=0
+for in_file in "$@"; do
+  count=$(grep -c -E '.' "$in_file" 2>/dev/null || printf '0')
+  input_total=$(( input_total + count ))
+done
+
+# Run the Python merger. Reads all inputs, parses each line as JSON, sorts
+# by ts when uniformly present, dedupes by idempotency_key when uniformly
+# present (else by full canonical line), writes ndjson to $TMP.
+python3 - "$TMP" "$@" <<'PY'
+import json, sys
+
+out_path = sys.argv[1]
+in_paths = sys.argv[2:]
+
+records = []
+for p in in_paths:
+    with open(p, "r", encoding="utf-8", errors="replace") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as e:
+                sys.stderr.write(f"jsonl-merge: parse error in {p}:{lineno}: {e}\n")
+                sys.exit(3)
+            records.append(obj)
+
+# Determine sort + dedupe keys.
+all_have_ts = bool(records) and all(isinstance(r, dict) and "ts" in r for r in records)
+all_have_idem = bool(records) and all(isinstance(r, dict) and "idempotency_key" in r for r in records)
+
+if all_have_idem:
+    seen = {}
+    for r in records:
+        seen[r["idempotency_key"]] = r
+    records = list(seen.values())
+else:
+    seen_lines = set()
+    deduped = []
+    for r in records:
+        key = json.dumps(r, sort_keys=True, separators=(",", ":"))
+        if key in seen_lines:
+            continue
+        seen_lines.add(key)
+        deduped.append(r)
+    records = deduped
+
+if all_have_ts:
+    records.sort(key=lambda r: r["ts"])
+
+with open(out_path, "w", encoding="utf-8") as fh:
+    for r in records:
+        fh.write(json.dumps(r, separators=(",", ":")))
+        fh.write("\n")
+PY
+py_rc=$?
+
+if [ "$py_rc" -ne 0 ]; then
+  rm -f "$TMP"
+  exit "$py_rc"
+fi
+
+# Validate the merged temp parses as ndjson + meets the records-not-lost guard.
+# Re-parse every line; refuse the rename if any line fails.
+if ! python3 - "$TMP" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    for lineno, line in enumerate(fh, start=1):
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        json.loads(line)
+PY
+then
+  rm -f "$TMP"
+  exit 4
+fi
+
+# Records-not-lost guard: merged file's deduped count must be ≤ input total
+# (we never magically gain rows) AND > 0 if inputs were non-empty.
+merged_count=$(grep -c -E '.' "$TMP" 2>/dev/null || printf '0')
+if [ "$input_total" -gt 0 ] && [ "$merged_count" -eq 0 ]; then
+  rm -f "$TMP"
+  printf 'jsonl-merge: merged temp is empty despite non-empty inputs — refusing\n' >&2
+  exit 5
+fi
+
+mv -f "$TMP" "$OUT"
+printf 'jsonl-merge: %s ← %d input(s), %d records out (deduped from %d)\n' \
+  "$OUT" "$#" "$merged_count" "$input_total" >&2

--- a/scripts/lint-jsonl-merge.sh
+++ b/scripts/lint-jsonl-merge.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# lint-jsonl-merge.sh — flag the dangerous `jq -s 'sort_by(...) | unique'`
+# merge pattern in shell scripts (#820 item 7.2).
+#
+# The pattern looks like
+#
+#   cat $a $b | jq -c -s 'sort_by(.ts) | unique | .[]' > $out
+#
+# whose failure mode is silent and catastrophic: control characters in any
+# input record break `jq -s`, the merged file is written empty, and the
+# typical follow-up `mv merged → canonical; rm bak` overwrites the canonical
+# file before anyone checks. This is how T368 cleanup lost a day's events.
+#
+# Use `scripts/jsonl-merge.sh` instead — it parses with python (control-char
+# safe), validates the temp file, refuses to lose records, and refuses to
+# write under any project's events/ directory.
+#
+# Modes:
+#   scripts/lint-jsonl-merge.sh --staged
+#   scripts/lint-jsonl-merge.sh --strict
+#   scripts/lint-jsonl-merge.sh <file> ...
+#
+# Allow annotation (per-line carve-out):
+#   # lint-jsonl-merge:allow next-line — <reason>
+#
+# Bypass (emergency/debug-only):
+#   STUDIO_BYPASS_JSONL_MERGE_LINT=1
+#
+# Scope: scripts/*.sh, core/**/*.sh, hooks/* (text shell scripts).
+# Always-exempt: scripts/jsonl-merge.sh, scripts/lint-jsonl-merge.sh,
+# scripts/test-fixtures/**.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT="${LINT_JSONL_MERGE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+if [ "${STUDIO_BYPASS_JSONL_MERGE_LINT:-0}" = "1" ]; then
+  printf 'lint-jsonl-merge: STUDIO_BYPASS_JSONL_MERGE_LINT=1 — skipping (audit)\n' >&2
+  exit 0
+fi
+
+ERRORS=0
+emit_error() { printf '%s\n' "$1"; ERRORS=$((ERRORS + 1)); }
+
+in_scope() {
+  case "$1" in
+    scripts/*.sh) return 0 ;;
+    hooks/*)
+      case "$1" in
+        */*.json) return 1 ;;
+      esac
+      return 0 ;;
+    core/*)
+      case "$1" in
+        *.sh) return 0 ;;
+      esac ;;
+  esac
+  return 1
+}
+
+exempt_by_rule() {
+  case "$1" in
+    scripts/jsonl-merge.sh) return 0 ;;
+    scripts/lint-jsonl-merge.sh) return 0 ;;
+    scripts/test-fixtures/*) return 0 ;;
+  esac
+  return 1
+}
+
+# Match `jq` invocations with `-s` (or `-cs`, `-sc`, `-c -s`, etc.) where
+# the program string mentions sort_by, unique, group_by, or add — the
+# merge-suggesting jq builtins. This catches the dangerous shape without
+# flagging benign array constructions like `jq -s '.'` or `jq -s 'length'`.
+match_dangerous() {
+  local line="$1"
+  # Quick reject: require a jq invocation with an -s short-flag DIRECTLY on
+  # the jq command (so `paste -sd ... | jq -r ...` doesn't false-positive).
+  # Allow these shapes: `jq -s`, `jq -cs`, `jq -sc`, `jq -c -s`, `jq -s -c`.
+  case "$line" in
+    *'jq -s '*|*'jq -s'$'\t'*|*'jq -s'*"'"*|*'jq -cs '*|*'jq -cs'$'\t'*|*'jq -cs'*"'"*|*'jq -sc '*|*'jq -sc'$'\t'*|*'jq -sc'*"'"*|*'jq -c -s '*|*'jq -s -c '*) ;;
+    *) return 1 ;;
+  esac
+  # Confirm one of the merge-suggesting builtins appears anywhere on the
+  # same line (heuristic; multi-line jq programs are rare in our corpus).
+  case "$line" in
+    *sort_by*|*unique*|*group_by*) return 0 ;;
+  esac
+  return 1
+}
+
+has_allow_annotation() {
+  case "$1$2" in
+    *'lint-jsonl-merge:allow'*) return 0 ;;
+  esac
+  return 1
+}
+
+scan_whole_file() {
+  local rel="$1"
+  local abs
+  case "$rel" in
+    /*) abs="$rel" ;;
+    *)  abs="$REPO_ROOT/$rel" ;;
+  esac
+  [ -f "$abs" ] || return 0
+
+  local lineno=0 prev=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    if match_dangerous "$line"; then
+      if has_allow_annotation "$line" "$prev"; then
+        prev="$line"; continue
+      fi
+      emit_error "E_JSONL_MERGE_JQ_S:$rel:$lineno:dangerous \`jq -s 'sort_by|unique|group_by|add'\` over ndjson | use scripts/jsonl-merge.sh — \`jq -s\` parse-fails silently on control chars and the typical merge-then-mv shape destroys the canonical file"
+    fi
+    prev="$line"
+  done < "$abs"
+}
+
+scan_staged() {
+  while IFS= read -r line; do
+    case "$line" in
+      diff' '--git' '*)
+        cur_file="${line##* b/}"
+        in_scope_flag=0
+        if in_scope "$cur_file" && ! exempt_by_rule "$cur_file"; then
+          in_scope_flag=1
+        fi
+        ;;
+      @@*)
+        line_num=$(printf '%s\n' "$line" | sed -E 's/^@@.*\+([0-9]+)(,[0-9]+)? @@.*/\1/')
+        line_num=$((line_num - 1)) ;;
+      \+\+*|---*) ;;
+      ' '*) line_num=$((line_num + 1)) ;;
+      \-*) ;;
+      \+*)
+        line_num=$((line_num + 1))
+        [ "$in_scope_flag" = "1" ] || continue
+        added="${line:1}"
+        if match_dangerous "$added"; then
+          if has_allow_annotation "$added" ""; then continue; fi
+          emit_error "E_JSONL_MERGE_JQ_S:$cur_file:$line_num:dangerous \`jq -s 'sort_by|unique|group_by|add'\` over ndjson | use scripts/jsonl-merge.sh"
+        fi
+        ;;
+    esac
+  done < <(git -C "$REPO_ROOT" diff --cached --no-color --unified=0 -- 'scripts/*.sh' 'core/**/*.sh' 'hooks/*' 2>/dev/null)
+}
+
+MODE=""
+case "${1:-}" in
+  --staged) MODE=staged ;;
+  --strict) MODE=strict ;;
+  "")
+    if git -C "$REPO_ROOT" diff --cached --quiet 2>/dev/null; then
+      MODE=strict
+    else
+      MODE=staged
+    fi
+    ;;
+  *)
+    MODE=adhoc
+    ;;
+esac
+
+case "$MODE" in
+  staged) scan_staged ;;
+  strict)
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      in_scope "$f" || continue
+      exempt_by_rule "$f" && continue
+      scan_whole_file "$f"
+    done < <(cd "$REPO_ROOT" && find scripts core hooks -type f \( -name '*.sh' -o -path 'hooks/*' \) 2>/dev/null | grep -v '\.json$')
+    ;;
+  adhoc)
+    for f in "$@"; do scan_whole_file "$f"; done
+    ;;
+esac
+
+if [ "$ERRORS" -gt 0 ]; then
+  printf 'lint-jsonl-merge: %d error(s) — fix or annotate with `# lint-jsonl-merge:allow next-line — <reason>`; emergency bypass: STUDIO_BYPASS_JSONL_MERGE_LINT=1\n' "$ERRORS" >&2
+  exit 1
+fi

--- a/scripts/test-fixtures/820-jsonl-safety/test-jsonl-safety.sh
+++ b/scripts/test-fixtures/820-jsonl-safety/test-jsonl-safety.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# test-jsonl-safety.sh — fixture for #820 items 7.1 + 7.2 + 7.4.
+#
+# Exercises:
+#   - jsonl-merge.sh: happy merge with ts sort + idempotency-key dedupe
+#   - jsonl-merge.sh: control-character payload survives (the regression class)
+#   - jsonl-merge.sh: refuses to write under <project>/events/
+#   - jsonl-merge.sh: refuses to lose records (parse-fail input → exit 3)
+#   - jsonl-merge.sh: keeps a .bak under runtime-global logs
+#   - lint-jsonl-merge.sh: flags `jq -s sort_by` shape, ignores benign jq -s
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+MERGE="$ROOT/scripts/jsonl-merge.sh"
+LINT="$ROOT/scripts/lint-jsonl-merge.sh"
+TMPROOT=$(mktemp -d -t jsonl-safety.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.dev-studio/.runtime"
+
+pass=0
+fail=0
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# ─── jsonl-merge.sh ───
+mkdir -p "$TMPROOT/m"
+A="$TMPROOT/m/a.jsonl"
+B="$TMPROOT/m/b.jsonl"
+OUT="$TMPROOT/m/merged.jsonl"
+cat > "$A" <<'JSON'
+{"ts":"2026-05-10T10:00:00Z","idempotency_key":"k1","msg":"alpha"}
+{"ts":"2026-05-10T10:02:00Z","idempotency_key":"k2","msg":"beta"}
+JSON
+cat > "$B" <<'JSON'
+{"ts":"2026-05-10T10:01:00Z","idempotency_key":"k3","msg":"gamma"}
+{"ts":"2026-05-10T10:00:00Z","idempotency_key":"k1","msg":"alpha-dup"}
+JSON
+
+"$MERGE" "$OUT" "$A" "$B" >/dev/null 2>&1
+assert "happy merge produces 3 deduped records (k1 dup folded)" \
+  '[ "$(wc -l < "$OUT" | tr -d " ")" = "3" ]'
+assert "happy merge sorts by ts" \
+  'head -1 "$OUT" | grep -q "10:00:00"'
+assert "happy merge dedupes by idempotency_key (single k1)" \
+  '[ "$(grep -c "\"idempotency_key\":\"k1\"" "$OUT")" = "1" ]'
+
+# Control-char payload — the regression class. jq -s would die here; python
+# json handles it (serialized \n).
+CTRL="$TMPROOT/m/ctrl.jsonl"
+printf '{"ts":"2026-05-10T11:00:00Z","msg":"line1\\nline2","idempotency_key":"c1"}\n' > "$CTRL"
+"$MERGE" "$TMPROOT/m/ctrl-out.jsonl" "$CTRL" >/dev/null 2>&1
+assert "control-char payload survives merge" \
+  '[ "$(wc -l < "$TMPROOT/m/ctrl-out.jsonl" | tr -d " ")" = "1" ]'
+
+# Events refusal.
+mkdir -p "$HOME/.dev-studio/proj1/events"
+EV_OUT="$HOME/.dev-studio/proj1/events/2026-05-10.jsonl"
+"$MERGE" "$EV_OUT" "$A" 2>"$TMPROOT/ev.err"
+ev_rc=$?
+assert "events path refused with exit 1" \
+  '[ "$ev_rc" -eq 1 ]'
+assert "events refusal mentions append-only" \
+  'grep -q "append-only" "$TMPROOT/ev.err"'
+assert "events refusal does not create the output" \
+  '! [ -f "$EV_OUT" ]'
+
+# Parse-fail on malformed input.
+BAD="$TMPROOT/m/bad.jsonl"
+printf '{not valid json\n' > "$BAD"
+"$MERGE" "$TMPROOT/m/bad-out.jsonl" "$BAD" 2>/dev/null
+bad_rc=$?
+assert "parse failure exits 3" '[ "$bad_rc" -eq 3 ]'
+assert "parse failure leaves no output" \
+  '! [ -f "$TMPROOT/m/bad-out.jsonl" ]'
+
+# Bak retention.
+echo '{"ts":"2026-05-10T09:00:00Z","msg":"old"}' > "$OUT"
+"$MERGE" "$OUT" "$A" >/dev/null 2>&1
+assert "bak written under runtime-global logs/jsonl-merge/" \
+  '[ -n "$(ls "$HOME/.dev-studio/.runtime/logs/jsonl-merge"/*.bak 2>/dev/null)" ]'
+
+# ─── lint-jsonl-merge.sh ───
+LINT_REPO="$TMPROOT/lint-repo"
+mkdir -p "$LINT_REPO/scripts"
+cat > "$LINT_REPO/scripts/dangerous.sh" <<'SH'
+#!/usr/bin/env bash
+cat $a $b | jq -c -s 'sort_by(.ts) | unique | .[]' > merged.jsonl
+SH
+cat > "$LINT_REPO/scripts/benign.sh" <<'SH'
+#!/usr/bin/env bash
+jq -s '.' a.json b.json
+echo $items | jq -r '[.x] | group_by(.y)' | paste -sd, -
+SH
+LINT_JSONL_MERGE_REPO_ROOT="$LINT_REPO" bash "$LINT" --strict > "$TMPROOT/lint.out" 2>&1
+lint_rc=$?
+assert "lint flags dangerous jq -s sort_by" \
+  'grep -q "scripts/dangerous.sh" "$TMPROOT/lint.out"'
+assert "lint does NOT flag benign jq -s . or jq -r with downstream paste -sd" \
+  '! grep -q "scripts/benign.sh" "$TMPROOT/lint.out"'
+assert "lint exits non-zero on dangerous match" '[ "$lint_rc" -eq 1 ]'
+
+# Allow annotation suppresses the flag.
+cat > "$LINT_REPO/scripts/annotated.sh" <<'SH'
+#!/usr/bin/env bash
+# lint-jsonl-merge:allow next-line — historical comparison, not a real merge.
+result=$(cat a b | jq -s 'sort_by(.ts) | unique')
+SH
+LINT_JSONL_MERGE_REPO_ROOT="$LINT_REPO" bash "$LINT" --strict > "$TMPROOT/lint2.out" 2>&1
+assert "allow annotation suppresses lint" \
+  '! grep -q "scripts/annotated.sh" "$TMPROOT/lint2.out"'
+
+if [ "$fail" -gt 0 ]; then
+  printf 'FAIL: %d test(s) failed\n' "$fail" >&2
+  exit 1
+fi
+printf 'PASS: jsonl-safety (%d/%d)\n' "$pass" "$pass"


### PR DESCRIPTION
## Summary

Three coupled fixes from #820:

- **`scripts/jsonl-merge.sh`** — safe ndjson merge primitive. Parses with python (control-char safe), sorts by `ts`, dedupes by `idempotency_key`, validates the temp + records-not-lost guard, keeps 7-day `.bak`, **refuses** to write under any `<project>/events/`.
- **`scripts/lint-jsonl-merge.sh`** — flags the dangerous `jq -s 'sort_by|unique|group_by|add'` shape over ndjson at commit time. Per-line carve-out + emergency bypass envvar.
- **`_shared/contracts/events.md`** — documents the append-only contract as a hard rule, with the T368/#333 regression case cited.

## Background

T368 cleanup destroyed a day's canonical event log when `cat $a $b | jq -c -s 'sort_by(.ts) | unique | .[]' > merged; mv merged → canonical` parse-failed on a control character in a build-log payload. The merged file went to 0 bytes; mv overwrote canonical; the next `rm bak` deleted the only recovery anchor. This PR makes that pattern impossible going forward.

## Test plan

- [x] `bash scripts/test-fixtures/820-jsonl-safety/test-jsonl-safety.sh` → 14/14 cases pass: happy merge with sort+dedupe, control-char payload survives, events path refused, parse-fail leaves no output, bak retention, lint flags dangerous shape, lint ignores benign `jq -s '.'`, allow-annotation honored.
- [x] All four lints clean (`lint-runtime-paths`, `lint-gh-wrapper`, `lint-synthetic-home`, `lint-jsonl-merge`).
- [x] commit-msg lint passed.

Refs #820 (items 7.1, 7.2, 7.4)