### PR TITLE
task-build-gate preserves failure logs + reframes short success_marker_absent (#820 items 4+5)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T17:08:57Z",
+  "generated_at": "2026-05-10T17:12:52Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T17:08:57Z",
+  "generated_at": "2026-05-10T17:12:51Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/task-build-gate.sh
+++ b/scripts/task-build-gate.sh
@@ -314,6 +314,51 @@ start_data=$(printf '{"mode":"%s","worktree":"%s","attempt":%s%s}' "$MODE" "$WOR
 emit_event_keyed achilles task build_check_started "$TASK_ID" "$start_data" >/dev/null 2>&1 || true
 trap '_emit_aborted_if_open; _release_task_lock' EXIT INT TERM
 
+# #820 item 5: preserve build_log + build_json on failure for postmortem.
+# Successful runs still rm; failure runs move the artifacts under
+# <runtime-global>/logs/build/<task>-<ts>-<status>.log.
+# Auto-prune anything older than 7 days so the dir doesn't grow without bound.
+_preserve_failed_build_log() {
+  local status="${1:-failed}" project_slug
+  project_slug=$(resolve_project 2>/dev/null || printf 'unknown')
+  local dest_dir="$(resolve_runtime_global)/logs/build/$project_slug"
+  mkdir -p "$dest_dir" 2>/dev/null || { rm -f "$build_log" "$build_json" 2>/dev/null; return 0; }
+  local ts dest_log dest_json
+  ts=$(date -u +%Y%m%dT%H%M%SZ)
+  dest_log="$dest_dir/${TASK_ID:-unknown}-${ts}-${status}.log"
+  dest_json="$dest_dir/${TASK_ID:-unknown}-${ts}-${status}.json"
+  if [ -s "$build_log" ]; then
+    mv -f "$build_log" "$dest_log" 2>/dev/null || rm -f "$build_log" 2>/dev/null
+    printf 'task-build-gate: preserved failure build_log: %s\n' "$dest_log" >&2
+  else
+    rm -f "$build_log" 2>/dev/null
+  fi
+  if [ -s "$build_json" ]; then
+    mv -f "$build_json" "$dest_json" 2>/dev/null || rm -f "$build_json" 2>/dev/null
+  else
+    rm -f "$build_json" 2>/dev/null
+  fi
+  find "$dest_dir" -type f -mtime +7 -delete 2>/dev/null || true
+}
+
+# #820 item 4: a 6–30s "success_marker_absent" is almost always a source-sync /
+# shim / harvest failure on the worker side, NOT a real build that mysteriously
+# missed the marker. Real Xcode builds take minutes. Reframe the diagnosis
+# below this wall-time floor as `dispatch_failed` so postmortem looks at the
+# right surface (rsync exit code, ssh failure, sync-worker.sh state) instead
+# of chasing a phantom Xcode bug.
+#
+# Override: STUDIO_BUILD_GATE_MIN_WALL_S=<seconds> (default 60). Set to 0 to
+# disable the floor (e.g. for fixture testing with synthetic logs).
+_under_min_wall_floor() {
+  local wall_s="${1:-0}"
+  local floor="${STUDIO_BUILD_GATE_MIN_WALL_S:-60}"
+  case "$floor" in
+    ''|*[!0-9]*) floor=60 ;;
+  esac
+  [ "$floor" -gt 0 ] && [ "$wall_s" -lt "$floor" ]
+}
+
 # ---------- lsp-only ----------
 #
 # Pure read analysis — no lock, no cleanup. The check is the union of errors
@@ -473,11 +518,14 @@ if [ "$HARVESTED" = "1" ]; then
     data=$(printf '%s' "$data" | jq -c --argjson failover "$failover_json" '. + {failover:$failover}')
     _emit_terminal build_check_failed "$data"
     gate_announce_done build "$NODE_ID" "$TASK_ID" failed "$GATE_DUR_S"
-    rm -f "$build_log" 2>/dev/null || true
+    _preserve_failed_build_log "$failure_reason"
     exit 2
   fi
   if [ "$success_marker_present" -eq 0 ]; then
     log_tail_json=$(_json_string_from_file_tail "$build_log" 200)
+    # #820 item 4: harvest path runs after the original dispatch — wall time
+    # is not meaningful here, so the floor doesn't apply. Diagnosis stays
+    # success_marker_absent.
     _emit_build_harness_failed success_marker_absent "$BUILD_STATUS" "$log_tail_json"
     failover_json=$(_failover_json_for_failure success_marker_absent "$BUILD_STATUS" "$build_log")
     data=$(printf '{"mode":"full-green","node":"%s","errors":%s,"warnings":%s,"scheme":"%s","attempt":%s,"reason":"success_marker_absent","xcode_exit_code":%s,"log_tail":%s,"harvested":true%s}' \
@@ -485,7 +533,7 @@ if [ "$HARVESTED" = "1" ]; then
     data=$(printf '%s' "$data" | jq -c --argjson failover "$failover_json" '. + {failover:$failover}')
     _emit_terminal build_check_failed "$data"
     gate_announce_done build "$NODE_ID" "$TASK_ID" failed "$GATE_DUR_S"
-    rm -f "$build_log" 2>/dev/null || true
+    _preserve_failed_build_log success_marker_absent
     exit 2
   fi
   rm -f "$build_log" 2>/dev/null || true
@@ -814,20 +862,28 @@ if [ "$BUILD_STATUS" -ne 0 ]; then
   fi
   _emit_terminal build_check_failed "$data"
   gate_announce_done build "$NODE_ID" "$TASK_ID" failed "$GATE_DUR_S"
-  rm -f "$build_log" "$build_json" 2>/dev/null || true
+  _preserve_failed_build_log "$failure_reason"
   exit 2
 fi
 
 if [ "$success_marker_present" -eq 0 ]; then
+  # #820 item 4: under the wall-time floor, success_marker_absent is almost
+  # always a dispatch-side failure (source-sync, ssh, shim missing). Reframe
+  # so postmortem looks at the right surface. Above the floor, the original
+  # diagnosis stands.
+  marker_reason=success_marker_absent
+  if [ "$IS_LOCAL" != "1" ] && _under_min_wall_floor "$GATE_DUR_S"; then
+    marker_reason=dispatch_failed
+  fi
   log_tail_json=$(_json_string_from_file_tail "$build_log" 200)
-  _emit_build_harness_failed success_marker_absent "$BUILD_STATUS" "$log_tail_json"
-  failover_json=$(_failover_json_for_failure success_marker_absent "$BUILD_STATUS" "$build_log")
-  data=$(printf '{"mode":"full-green","node":"%s","errors":%s,"warnings":%s,"scheme":"%s","attempt":%s,"reason":"success_marker_absent","xcode_exit_code":%s,"log_tail":%s,"errors_json":%s%s}' \
-    "$NODE_ID" "$err_count" "$warn_count" "$SCHEME" "$ATTEMPT" "$BUILD_STATUS" "$log_tail_json" "$errors_json" "$DISPATCH_FIELDS")
+  _emit_build_harness_failed "$marker_reason" "$BUILD_STATUS" "$log_tail_json"
+  failover_json=$(_failover_json_for_failure "$marker_reason" "$BUILD_STATUS" "$build_log")
+  data=$(printf '{"mode":"full-green","node":"%s","errors":%s,"warnings":%s,"scheme":"%s","attempt":%s,"reason":"%s","xcode_exit_code":%s,"log_tail":%s,"errors_json":%s,"wall_s":%s%s}' \
+    "$NODE_ID" "$err_count" "$warn_count" "$SCHEME" "$ATTEMPT" "$marker_reason" "$BUILD_STATUS" "$log_tail_json" "$errors_json" "$GATE_DUR_S" "$DISPATCH_FIELDS")
   data=$(printf '%s' "$data" | jq -c --argjson failover "$failover_json" '. + {failover:$failover}')
   _emit_terminal build_check_failed "$data"
   gate_announce_done build "$NODE_ID" "$TASK_ID" failed "$GATE_DUR_S"
-  rm -f "$build_log" "$build_json" 2>/dev/null || true
+  _preserve_failed_build_log "$marker_reason"
   exit 2
 fi
 

--- a/scripts/test-fixtures/820-build-gate-postmortem/test-build-gate-postmortem.sh
+++ b/scripts/test-fixtures/820-build-gate-postmortem/test-build-gate-postmortem.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test-build-gate-postmortem.sh — fixture for #820 items 4 + 5.
+#
+# Exercises the helper functions in isolation:
+#   - _preserve_failed_build_log moves build_log + build_json under
+#     <runtime-global>/logs/build/<project>/<task>-<ts>-<status>.log.
+#   - _under_min_wall_floor classifies short remote dispatches correctly.
+#   - 7-day retention prune fires on each invocation.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TARGET="$ROOT/scripts/task-build-gate.sh"
+TMPROOT=$(mktemp -d -t build-gate-pm.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export HOME="$TMPROOT/home"
+export ACHILLES_PROJECT=fixture-proj
+mkdir -p "$HOME/.dev-studio/.runtime"
+
+pass=0
+fail=0
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Source lib-paths so _preserve_failed_build_log can resolve runtime-global.
+# shellcheck disable=SC1090
+. "$ROOT/scripts/lib-paths.sh"
+
+# Extract the two helpers from the script into the current shell so we can
+# call them directly. The script as a whole has too many side effects to
+# source whole.
+eval "$(awk '
+  /^_preserve_failed_build_log\(\) \{/,/^}$/ { print }
+  /^_under_min_wall_floor\(\) \{/,/^}$/ { print }
+' "$TARGET")"
+
+# ─── Wall-time floor ───
+TASK_ID="T999"
+assert "default 60s floor: 30s under remote dispatch is below floor" \
+  '_under_min_wall_floor 30'
+assert "default 60s floor: 90s above floor" \
+  '! _under_min_wall_floor 90'
+
+STUDIO_BUILD_GATE_MIN_WALL_S=10
+assert "explicit 10s floor: 5s below" '_under_min_wall_floor 5'
+assert "explicit 10s floor: 20s above" '! _under_min_wall_floor 20'
+
+STUDIO_BUILD_GATE_MIN_WALL_S=0
+assert "floor=0 disables the check (60s no longer below)" \
+  '! _under_min_wall_floor 60'
+
+unset STUDIO_BUILD_GATE_MIN_WALL_S
+
+# ─── Preserve failed build_log ───
+build_log="$TMPROOT/build.log"
+build_json="${build_log}.json"
+printf 'xcodebuild output\nerror: thing happened\n' > "$build_log"
+printf '{"errors":[{"message":"thing"}]}\n' > "$build_json"
+
+_preserve_failed_build_log dispatch_failed >/dev/null 2>&1
+preserve_dir="$(resolve_runtime_global)/logs/build/fixture-proj"
+assert "preserved log directory exists" '[ -d "$preserve_dir" ]'
+assert "preserved log file is present" \
+  '[ -n "$(ls "$preserve_dir"/T999-*-dispatch_failed.log 2>/dev/null)" ]'
+assert "preserved json sidecar is present" \
+  '[ -n "$(ls "$preserve_dir"/T999-*-dispatch_failed.json 2>/dev/null)" ]'
+assert "preserved log content matches" \
+  'grep -q "thing happened" "$preserve_dir"/T999-*-dispatch_failed.log'
+assert "original build_log path is gone (moved, not copied)" \
+  '! [ -f "$build_log" ]'
+
+# Empty build_log gets removed without a destination file.
+build_log="$TMPROOT/empty.log"
+build_json="${build_log}.json"
+: > "$build_log"
+: > "$build_json"
+_preserve_failed_build_log build_invocation_failed >/dev/null 2>&1
+assert "empty log removed, no destination file written for it" \
+  '! [ -n "$(ls "$preserve_dir"/T999-*-build_invocation_failed.log 2>/dev/null)" ]'
+
+# Retention prune: synthesize an old file (mtime 8 days ago) and confirm it
+# disappears on next preserve invocation.
+old_log="$preserve_dir/T999-19990101T000000Z-old.log"
+printf 'old\n' > "$old_log"
+touch -t 199901010000.00 "$old_log"
+build_log="$TMPROOT/build2.log"
+build_json="${build_log}.json"
+printf 'newer xcodebuild output\n' > "$build_log"
+_preserve_failed_build_log success_marker_absent >/dev/null 2>&1
+assert "retention prune removes 8-day-old log" \
+  '! [ -f "$old_log" ]'
+
+if [ "$fail" -gt 0 ]; then
+  printf 'FAIL: %d test(s) failed\n' "$fail" >&2
+  exit 1
+fi
+printf 'PASS: build-gate postmortem (%d/%d)\n' "$pass" "$pass"


### PR DESCRIPTION
## Summary

Two coupled fixes from #820:

- **Item 5: failure-log preservation.** `task-build-gate.sh` now moves `$build_log` + `$build_json` to `<runtime-global>/logs/build/<project>/<task>-<ts>-<status>.log` on every failure exit instead of `rm -f`. 7-day retention enforced. Successful exits still rm.
- **Item 4: dispatch-failure reframing.** When a remote dispatch returns `success_marker_absent` under `STUDIO_BUILD_GATE_MIN_WALL_S` seconds (default 60), the diagnosis is reframed to `dispatch_failed` so postmortem looks at source-sync / ssh / shim instead of chasing a phantom Xcode bug. `wall_s` is added to the event payload for auditability.

## Background

T368's m1mini investigation took 30+ minutes because the only diagnostic existed in a temp file the script had just `rm -f`'d. Three consecutive dispatches returned `success_marker_absent` at 6–30s wall — far too short to have run a real Zaps build (8–15 min) — but the diagnosis aimed at Xcode. Both gaps hit every remote dispatch on every Achilles task.

## Test plan

- [x] `bash scripts/test-fixtures/820-build-gate-postmortem/test-build-gate-postmortem.sh` → 12/12 cases pass: default/explicit/disabled wall-time floor, log + sidecar preservation, empty-log short-circuit, retention prune.
- [x] `bash -n scripts/task-build-gate.sh` clean.
- [x] All four lints clean.

## Out of scope

The harvested-path `success_marker_absent` doesn't apply the floor (wall time isn't meaningful — the original dispatch produced the build). Source-sync smoke-test in `node-pick health` (also mentioned in #820 item 4) is a separate concern; this PR addresses the diagnostic-routing half.

Refs #820 (items 4, 5)