### PR TITLE
node-pick documented escape hatches: STUDIO_DISPATCH_FORCE_LOCAL + _PIN (#820 item 6)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T17:12:52Z",
+  "generated_at": "2026-05-10T17:16:02Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T17:12:51Z",
+  "generated_at": "2026-05-10T17:16:01Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/node-pick.sh
+++ b/scripts/node-pick.sh
@@ -30,9 +30,19 @@
 #   writes a single line with the dispatch reason for the caller to fold
 #   into its event payloads. One of:
 #     healthy | fallback:unreachable | fallback:no-role | fallback:disabled
+#     | fallback:secret-scope | forced-local | pinned
 #   Callers (build/test gates) pre-create the file, read it after the
 #   pick, and tag `studio.dispatch.reason` on their gate events. Keeping
 #   stdout = node-id preserves the long-standing caller contract.
+#
+# Escape hatches (#820 item 6):
+#   STUDIO_DISPATCH_FORCE_LOCAL=1 — bypass node selection; return `local`
+#     immediately. Use when the user wants laptop-only execution without
+#     editing nodes.json. Race-safe vs other Achilles instances.
+#   STUDIO_DISPATCH_PIN=<node-id> — explicit pin. The named node must
+#     exist + be enabled + carry the requested role/scopes. Mismatch is a
+#     hard error (exit 2), not a silent fallback — the user's intent stays
+#     visible.
 #
 # R14: every fallback path emits `node_fallback` so analytics can tell
 # "ran locally because we wanted to" from "fell back because the mini was
@@ -77,6 +87,57 @@ _emit_fallback() {
 }
 
 REGISTRY="$(resolve_runtime_global)/nodes.json"
+
+# #820 item 6: documented escape hatches.
+#
+# STUDIO_DISPATCH_FORCE_LOCAL=1 — bypass node selection entirely; return
+# `local` immediately with reason `forced-local`. Use when the user wants
+# laptop-only execution without editing nodes.json (which races other
+# Achilles instances).
+case "${STUDIO_DISPATCH_FORCE_LOCAL:-0}" in
+  1|true|TRUE|yes|YES)
+    _record_reason "forced-local"
+    _emit_fallback "forced-local"
+    echo "local"
+    exit 0
+    ;;
+esac
+
+# STUDIO_DISPATCH_PIN=<node-id> — explicit pin. The named node must exist
+# in the registry, be enabled, and carry the requested role (and any
+# requested secret scopes). On any mismatch this is a HARD ERROR — pinning
+# a broken node should not silently fall back, otherwise the user's
+# operational intent is hidden. Use STUDIO_DISPATCH_FORCE_LOCAL=1 instead
+# when the goal is "skip remote dispatch."
+if [ -n "${STUDIO_DISPATCH_PIN:-}" ]; then
+  if [ ! -r "$REGISTRY" ]; then
+    printf 'node-pick: STUDIO_DISPATCH_PIN=%s but registry %s is unreadable\n' "$STUDIO_DISPATCH_PIN" "$REGISTRY" >&2
+    exit 2
+  fi
+  command -v jq >/dev/null 2>&1 || { printf 'error: jq required\n' >&2; exit 2; }
+  pinned=$(jq -r --arg id "$STUDIO_DISPATCH_PIN" --arg role "$ROLE" --arg req "$REQUIRED_SCOPES" '
+    .nodes[]?
+    | select(.id == $id)
+    | select(.enabled != false)
+    | select(.roles? // [] | index($role))
+    | (if $req == "" then .id else
+        ($req | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $r
+        | select(($r - (.secret_scopes // [])) == [])
+        | .id
+       end)
+  ' "$REGISTRY" 2>/dev/null | head -1)
+  if [ -z "$pinned" ]; then
+    printf 'node-pick: STUDIO_DISPATCH_PIN=%s does not match any enabled node with role=%s' \
+      "$STUDIO_DISPATCH_PIN" "$ROLE" >&2
+    [ -n "$REQUIRED_SCOPES" ] && printf ' scopes=%s' "$REQUIRED_SCOPES" >&2
+    printf ' (use STUDIO_DISPATCH_FORCE_LOCAL=1 for local-only)\n' >&2
+    exit 2
+  fi
+  _record_reason "pinned"
+  printf '%s\n' "$pinned"
+  exit 0
+fi
+
 if [ ! -r "$REGISTRY" ]; then
   _record_reason "fallback:unreachable"
   _emit_fallback "fallback:unreachable"

--- a/scripts/test-fixtures/820-node-pick-escape/test-node-pick-escape.sh
+++ b/scripts/test-fixtures/820-node-pick-escape/test-node-pick-escape.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# test-node-pick-escape.sh — fixture for #820 item 6.
+#
+# Verifies the documented escape hatches:
+#   STUDIO_DISPATCH_FORCE_LOCAL=1 — return `local` immediately, reason `forced-local`.
+#   STUDIO_DISPATCH_PIN=<id>      — return that id when valid, hard-error otherwise.
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+PICK="$ROOT/scripts/node-pick.sh"
+TMPROOT=$(mktemp -d -t node-pick-escape.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export HOME="$TMPROOT/home"
+mkdir -p "$HOME/.dev-studio/.runtime"
+REGISTRY="$HOME/.dev-studio/.runtime/nodes.json"
+
+# Synthesize a small registry: one healthy worker mini, plus a disabled node.
+cat > "$REGISTRY" <<'JSON'
+{
+  "nodes": [
+    {"id": "mini", "host": "10.0.0.10", "enabled": true, "roles": ["worker", "release"], "secret_scopes": ["asc"]},
+    {"id": "spare", "host": "10.0.0.20", "enabled": false, "roles": ["worker"], "secret_scopes": []}
+  ]
+}
+JSON
+
+pass=0
+fail=0
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Case 1: STUDIO_DISPATCH_FORCE_LOCAL=1 returns local immediately.
+out=$(STUDIO_DISPATCH_FORCE_LOCAL=1 "$PICK" worker 2>"$TMPROOT/c1.err")
+rc=$?
+assert "force-local returns 'local'" '[ "$out" = "local" ]'
+assert "force-local exits 0" '[ "$rc" -eq 0 ]'
+
+# With reason file set, captures `forced-local`.
+reason_file="$TMPROOT/reason1"
+STUDIO_DISPATCH_FORCE_LOCAL=1 STUDIO_DISPATCH_REASON_FILE="$reason_file" "$PICK" worker >/dev/null
+assert "force-local reason file says 'forced-local'" \
+  '[ "$(cat "$reason_file" 2>/dev/null)" = "forced-local" ]'
+
+# Case 2: STUDIO_DISPATCH_PIN to a valid node returns that id.
+out=$(STUDIO_DISPATCH_PIN=mini "$PICK" worker 2>"$TMPROOT/c2.err")
+rc=$?
+assert "pin to valid node returns the id" '[ "$out" = "mini" ]'
+assert "pin to valid node exits 0" '[ "$rc" -eq 0 ]'
+
+reason_file="$TMPROOT/reason2"
+STUDIO_DISPATCH_PIN=mini STUDIO_DISPATCH_REASON_FILE="$reason_file" "$PICK" worker >/dev/null
+assert "valid pin reason file says 'pinned'" \
+  '[ "$(cat "$reason_file" 2>/dev/null)" = "pinned" ]'
+
+# Case 3: STUDIO_DISPATCH_PIN to a disabled node is a hard error.
+out=$(STUDIO_DISPATCH_PIN=spare "$PICK" worker 2>"$TMPROOT/c3.err")
+rc=$?
+assert "pin to disabled node exits 2 (hard error)" '[ "$rc" -eq 2 ]'
+assert "pin to disabled node names the node in the error" \
+  'grep -q "spare" "$TMPROOT/c3.err"'
+assert "pin to disabled node mentions force-local fallback hint" \
+  'grep -q "FORCE_LOCAL" "$TMPROOT/c3.err"'
+
+# Case 4: STUDIO_DISPATCH_PIN to a non-existent node is a hard error.
+out=$(STUDIO_DISPATCH_PIN=ghost "$PICK" worker 2>"$TMPROOT/c4.err")
+rc=$?
+assert "pin to ghost node exits 2 (hard error)" '[ "$rc" -eq 2 ]'
+
+# Case 5: pin without the required scope is a hard error.
+out=$(STUDIO_DISPATCH_PIN=mini "$PICK" --requires-secret-scope slack worker 2>"$TMPROOT/c5.err")
+rc=$?
+assert "pin without required scope exits 2" '[ "$rc" -eq 2 ]'
+assert "pin without required scope mentions scopes" \
+  'grep -q "scopes=slack" "$TMPROOT/c5.err"'
+
+# Case 6: pin WITH a satisfied scope succeeds.
+out=$(STUDIO_DISPATCH_PIN=mini "$PICK" --requires-secret-scope asc worker 2>"$TMPROOT/c6.err")
+rc=$?
+assert "pin with satisfied scope returns the id" '[ "$out" = "mini" ]'
+assert "pin with satisfied scope exits 0" '[ "$rc" -eq 0 ]'
+
+# Case 7: force-local takes precedence over pin (defensive — both set).
+out=$(STUDIO_DISPATCH_FORCE_LOCAL=1 STUDIO_DISPATCH_PIN=ghost "$PICK" worker 2>"$TMPROOT/c7.err")
+rc=$?
+assert "force-local + invalid pin: force-local wins" '[ "$out" = "local" ]'
+assert "force-local + invalid pin: exits 0" '[ "$rc" -eq 0 ]'
+
+if [ "$fail" -gt 0 ]; then
+  printf 'FAIL: %d test(s) failed\n' "$fail" >&2
+  exit 1
+fi
+printf 'PASS: node-pick escape (%d/%d)\n' "$pass" "$pass"


### PR DESCRIPTION
## Summary

Two documented escape hatches in `scripts/node-pick.sh` so the user can override dispatch routing without editing `~/.dev-studio/.runtime/nodes.json` (which races other Achilles instances):

- **`STUDIO_DISPATCH_FORCE_LOCAL=1`** — return `local` immediately, reason `forced-local`. Bypasses selection entirely.
- **`STUDIO_DISPATCH_PIN=<node-id>`** — explicit pin. Hard error (exit 2) on mismatch, with the offending node/scope named in stderr; never a silent fallback.

Force-local wins over an invalid pin (defensive: emergency override is unconditional).

## Background

T368 forced the user to edit `nodes.json` to disable m1mini, run the build, then restore — fragile and not race-safe. `STUDIO_DISPATCH_PIN` was guessed but didn't exist.

## Test plan

- [x] `bash scripts/test-fixtures/820-node-pick-escape/test-node-pick-escape.sh` → 16/16 cases pass: force-local + reason file, pin valid + reason, pin disabled/ghost/no-scope = hard error, pin + matching scope = success, force-local + invalid pin = force-local wins.
- [x] All four lints clean.

Refs #820 (item 6)