### PR TITLE
lib-ledger UUIDv7 intake guard + legacy filename fallback (#820 items 1+2)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T17:16:02Z",
+  "generated_at": "2026-05-10T17:20:39Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T17:16:01Z",
+  "generated_at": "2026-05-10T17:20:39Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-ledger.sh
+++ b/scripts/lib-ledger.sh
@@ -268,6 +268,13 @@ flush_index() {
 # Resolve plans/<kind>/<uuid>.yaml for the current project. Callers that have
 # already resolved the project can set LEDGER_PROJECT_ROOT to skip the
 # resolve_project round-trip.
+#
+# #820 item 1: when the canonical-named file does not exist, scan the kind
+# directory for a sibling whose `id:` field matches the requested uuid and
+# return that path. Catches 3156-sweep-style legacy filenames where the
+# artifact lives at `<legacy>.yaml` (e.g. `T368.yaml`) but its `id:` is the
+# synthetic UUID. Writers that miss the canonical path fall through to it
+# (so newly-created artifacts always land at the canonical name).
 _artifact_path() {
   local kind="${1:?}" uuid="${2:?}"
   local root
@@ -278,7 +285,50 @@ _artifact_path() {
     project=$(resolve_project) || return 2
     root=$(resolve_project_root_for "$project") || return 2
   fi
-  printf '%s/plans/%s/%s.yaml\n' "$root" "$kind" "$uuid"
+  local canonical="$root/plans/$kind/$uuid.yaml"
+  if [ -f "$canonical" ]; then
+    printf '%s\n' "$canonical"
+    return 0
+  fi
+  local kind_dir="$root/plans/$kind"
+  if [ -d "$kind_dir" ]; then
+    local file_count
+    file_count=$(find "$kind_dir" -maxdepth 1 -type f -name '*.yaml' 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${file_count:-0}" -gt 0 ] && [ "${file_count:-0}" -le 500 ]; then
+      local match
+      match=$(grep -lE "^id:[[:space:]]+${uuid}[[:space:]]*\$" "$kind_dir"/*.yaml 2>/dev/null | head -1)
+      if [ -n "$match" ]; then
+        printf '%s\n' "$match"
+        return 0
+      fi
+    fi
+  fi
+  printf '%s\n' "$canonical"
+}
+
+# UUIDv7 enforcement (#820 item 2). RFC 9562 §5.7: 48-bit Unix-ms prefix,
+# version nibble `7`, variant bits `10` (first nibble 8/9/a/b). The 3156-sweep
+# tasks were minted with UUIDv4-marker ids (4xxx-...) and every YAML write
+# silently bypassed the schema validator — exactly the regression Phase 2's
+# validators were meant to prevent. This guard fails closed at intake so the
+# next batch can't slip through.
+#
+# Bypass: STUDIO_BYPASS_UUIDV7_CHECK=1 (legacy migrations only). Audit-logged.
+_assert_uuidv7() {
+  local uuid="${1:?_assert_uuidv7 <uuid>}"
+  case "${STUDIO_BYPASS_UUIDV7_CHECK:-0}" in
+    1|true|TRUE|yes|YES)
+      printf 'lib-ledger: STUDIO_BYPASS_UUIDV7_CHECK=1 — accepting non-UUIDv7 id %s (audit)\n' "$uuid" >&2
+      return 0
+      ;;
+  esac
+  case "$uuid" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-7[0-9a-f][0-9a-f][0-9a-f]-[89ab][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+      return 0
+      ;;
+  esac
+  printf 'lib-ledger: id %s is not a valid UUIDv7 (RFC 9562 §5.7) — refusing intake. Mint via mint_uuidv7. Bypass: STUDIO_BYPASS_UUIDV7_CHECK=1.\n' "$uuid" >&2
+  return 2
 }
 
 # ---------- DRY-RUN helper ----------
@@ -803,6 +853,7 @@ write_task_artifact() {
   local uuid="${1:?write_task_artifact <uuid> <state> <title> [k=v...]}"
   local state="${2:?}" title="${3:?}"
   shift 3
+  _assert_uuidv7 "$uuid" || return 2
 
   local f ts
   f=$(_artifact_path tasks "$uuid") || return 2
@@ -848,6 +899,8 @@ write_brief_artifact() {
   local uuid="${1:?write_brief_artifact <brief-uuid> <task-uuid> <type> <size> [k=v...]}"
   local task_uuid="${2:?}" type="${3:?}" size="${4:?}"
   shift 4
+  _assert_uuidv7 "$uuid" || return 2
+  _assert_uuidv7 "$task_uuid" || return 2
 
   # Body (multi-line prose) is special-cased as block-scalar YAML in the
   # canonical file.

--- a/scripts/test-fixtures/820-3156-ids/test-3156-ids.sh
+++ b/scripts/test-fixtures/820-3156-ids/test-3156-ids.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test-3156-ids.sh — fixture for #820 items 1 + 2.
+#
+# Exercises:
+#   - _assert_uuidv7: valid UUIDv7 accepted, UUIDv4-marker rejected, bypass envvar honored
+#   - _artifact_path: canonical UUID-named file used when present
+#   - _artifact_path: legacy-named file (T<n>.yaml with matching id:) used as fallback
+#   - _artifact_path: returns canonical when no match exists (writers create at canonical)
+
+set -u
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+TMPROOT=$(mktemp -d -t s3156-ids.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export HOME="$TMPROOT/home"
+export ACHILLES_PROJECT=fixture-proj
+PROJ_ROOT="$HOME/.dev-studio/fixture-proj"
+mkdir -p "$PROJ_ROOT/plans/tasks"
+
+pass=0
+fail=0
+assert() {
+  local name="$1" expr="$2"
+  if eval "$expr"; then
+    printf 'ok - %s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'not ok - %s\n' "$name" >&2
+    fail=$((fail + 1))
+  fi
+}
+
+# Source lib-ledger so _assert_uuidv7 and _artifact_path are available.
+# shellcheck disable=SC1090
+. "$ROOT/scripts/lib-paths.sh"
+# shellcheck disable=SC1090
+. "$ROOT/scripts/lib-ledger.sh"
+
+# ─── _assert_uuidv7 ───
+VALID="0190f52a-9000-7f01-8aaa-77fe8fa99bbb"
+INVALID4="c3680001-cf01-4a68-b368-000000000368"
+
+_assert_uuidv7 "$VALID" 2>/dev/null; rc_valid=$?
+assert "valid UUIDv7 accepted" '[ "$rc_valid" -eq 0 ]'
+
+_assert_uuidv7 "$INVALID4" 2>/dev/null; rc_v4=$?
+assert "UUIDv4-marker (4xxx) rejected" '[ "$rc_v4" -eq 2 ]'
+
+_assert_uuidv7 "not-a-uuid" 2>/dev/null; rc_garbage=$?
+assert "garbage id rejected" '[ "$rc_garbage" -eq 2 ]'
+
+STUDIO_BYPASS_UUIDV7_CHECK=1 _assert_uuidv7 "$INVALID4" 2>"$TMPROOT/bypass.err"; rc_bypass=$?
+assert "bypass envvar accepts non-UUIDv7 id" '[ "$rc_bypass" -eq 0 ]'
+assert "bypass logs an audit line" \
+  'grep -q "STUDIO_BYPASS_UUIDV7_CHECK" "$TMPROOT/bypass.err"'
+
+# ─── _artifact_path canonical ───
+canonical_uuid="0190f52a-9000-7f01-8aaa-000000aaaa01"
+canonical_file="$PROJ_ROOT/plans/tasks/${canonical_uuid}.yaml"
+printf 'id: %s\nstate: ready\n' "$canonical_uuid" > "$canonical_file"
+
+resolved=$(_artifact_path tasks "$canonical_uuid")
+assert "_artifact_path returns canonical path when file exists" \
+  '[ "$resolved" = "$canonical_file" ]'
+
+# ─── _artifact_path legacy fallback ───
+synth_uuid="c3680001-cf01-4a68-b368-000000000368"
+legacy_file="$PROJ_ROOT/plans/tasks/T368.yaml"
+printf 'id: %s\nlegacy_task_id: T368\nstate: ready\n' "$synth_uuid" > "$legacy_file"
+
+resolved=$(_artifact_path tasks "$synth_uuid")
+assert "_artifact_path falls back to legacy filename via id: scan" \
+  '[ "$resolved" = "$legacy_file" ]'
+
+# ─── _artifact_path: no match → canonical (writer creates new file there) ───
+new_uuid="0190f52a-9000-7f01-8aaa-deaddead1234"
+expected_canonical="$PROJ_ROOT/plans/tasks/${new_uuid}.yaml"
+resolved=$(_artifact_path tasks "$new_uuid")
+assert "_artifact_path returns canonical for unknown uuid (writer path)" \
+  '[ "$resolved" = "$expected_canonical" ]'
+
+if [ "$fail" -gt 0 ]; then
+  printf 'FAIL: %d test(s) failed\n' "$fail" >&2
+  exit 1
+fi
+printf 'PASS: 3156-sweep id handling (%d/%d)\n' "$pass" "$pass"


### PR DESCRIPTION
## Summary

Two coupled fixes addressing the 3156-sweep ID-format regression class:

- **`_assert_uuidv7` intake guard** wired into `write_task_artifact` + `write_brief_artifact`. Refuses non-UUIDv7 ids at intake (RFC 9562 §5.7 shape). Stops the recurrence: the 3156-sweep silently bypassed schema validation because every YAML write rejected on the validator and the recovery path used `emit_event_keyed` (no validator). Bypass: `STUDIO_BYPASS_UUIDV7_CHECK=1` (legacy migrations only; emits an audit line).
- **`_artifact_path` legacy filename fallback.** When `plans/<kind>/<uuid>.yaml` doesn't exist, scan the kind directory for a sibling whose `id:` field matches the requested uuid. Catches 3156-sweep `T<n>.yaml` files transparently; writers still land new artifacts at the canonical path so the tree converges.

## Test plan

- [x] `bash scripts/test-fixtures/820-3156-ids/test-3156-ids.sh` → 8/8 cases pass: valid UUIDv7 accepted, UUIDv4-marker rejected, garbage rejected, bypass envvar accepts + audit-logs, canonical/fallback/unknown id resolution paths.
- [x] Existing `255-task-dag` and `323-brief-quality` fixtures still pass (no regression in validator-using writer paths).
- [x] All four lints clean.

## Out of scope

A one-shot rewrite of the existing 3156-sweep artifacts (T363–T370) into UUIDv7-named files would be a follow-up. This PR fixes recurrence + makes existing legacy files transparently readable.

Refs #820 (items 1, 2)