### PR TITLE
studio chain: artifact-cleanup-audit (Phase 1)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,6 +31,10 @@
 #       special casing (`case "$HOME"`, `[ "$HOME" = ... ]`, raw
 #       `.codex-homes` references) outside scripts/lib-studio-context.sh /
 #       scripts/lib-paths.sh (#710 Phase C3, #816).
+#   2o. lint-artifact-cleanup.sh --staged — block new artifact-producing
+#       call sites (xcodebuild, -derivedDataPath, git worktree add,
+#       mktemp -d) that don't route through scripts/lib-artifact-cleanup.sh
+#       `register_artifact` or an approved janitor (#710 / T-R004, #849).
 #   3.  privacy gate — reject if staged diff leaks another project's runtime.
 #
 # Main-branch commit guard bypass: `STUDIO_BYPASS_MAIN_COMMIT_GUARD=1 git commit ...`.
@@ -39,7 +43,8 @@
 # Runtime path lint bypass: `STUDIO_BYPASS_RUNTIME_PATH_LINT=1 git commit ...`.
 # GH wrapper lint bypass: `STUDIO_BYPASS_GH_WRAPPER_LINT=1 git commit ...`.
 # Synthetic-home lint bypass: `STUDIO_BYPASS_SYNTHETIC_HOME_LINT=1 git commit ...`.
-# Emergency bypass: `ARCH_LINT=0 git commit ...` skips gates 2/2b/2c/2d/2e/2f/2g/2h/2i/2j/2k/2l/2m/2n/3.
+# Artifact-cleanup lint bypass: `STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1 git commit ...`.
+# Emergency bypass: `ARCH_LINT=0 git commit ...` skips gates 2/2b/2c/2d/2e/2f/2g/2h/2i/2j/2k/2l/2m/2n/2o/3.
 # Gates 1+1b (manifest regens) always run because stale manifests leak
 # downstream.
 # LLM review is not part of the default hook path. Run
@@ -268,6 +273,7 @@ if [ -x "$SCRIPTS/lint-synthetic-home.sh" ]; then
   fi
 fi
 
+<<<<<<< HEAD
 # Gate 2o — jsonl-merge linter (#820 item 7.2). Block the dangerous
 # `cat ... | jq -s 'sort_by ...'` shape that silently destroys ndjson on
 # control-char input. Use scripts/jsonl-merge.sh instead.
@@ -277,6 +283,17 @@ if [ -x "$SCRIPTS/lint-jsonl-merge.sh" ]; then
   if [ "$rc" -ne 0 ]; then
     printf '\npre-commit: dangerous `jq -s sort_by|unique|group_by|add` over ndjson found — use scripts/jsonl-merge.sh (control-char safe, refuses to lose records) per #820\n' >&2
     printf 'bypass (emergencies only): STUDIO_BYPASS_JSONL_MERGE_LINT=1 git commit ...\n' >&2
+    exit 1
+  fi
+fi
+
+# Gate 2p — artifact-cleanup linter (#710 / T-R004, #849).
+if [ -x "$SCRIPTS/lint-artifact-cleanup.sh" ]; then
+  "$SCRIPTS/lint-artifact-cleanup.sh" --staged
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    printf '\npre-commit: new artifact-producing call site found without cleanup wiring — route through scripts/lib-artifact-cleanup.sh `register_artifact` or an approved janitor (studio-ios-artifact-janitor / node-janitor / fleet-cleanup / sweep-janitor) per CLAUDE.md §Where workflow rules live\n' >&2
+    printf 'bypass (emergencies only): STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1 git commit ...\n' >&2
     exit 1
   fi
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -273,7 +273,6 @@ if [ -x "$SCRIPTS/lint-synthetic-home.sh" ]; then
   fi
 fi
 
-<<<<<<< HEAD
 # Gate 2o — jsonl-merge linter (#820 item 7.2). Block the dangerous
 # `cat ... | jq -s 'sort_by ...'` shape that silently destroys ndjson on
 # control-char input. Use scripts/jsonl-merge.sh instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ If the user asks "where were we" or similar, invoke `/resume-plan` — it reads 
 | `REVIEW.md` | Diff-review rules with tier (block / ask / warn) |
 | `RELEASES.md` / `THEMES.md` | Release procedure, theme taxonomy |
 | `_shared/rules/*.md`, `_shared/standards/*.md` | Cross-agent discipline, lint contracts |
-| `scripts/` + pre-commit hooks (`hooks/`, `~/.githooks/`) | Mechanical enforcement |
+| `scripts/` + pre-commit hooks (`hooks/`, `~/.githooks/`) | Mechanical enforcement (lint gates: `lint-runtime-paths.sh`, `lint-gh-wrapper.sh`, `lint-synthetic-home.sh`, `lint-artifact-cleanup.sh`) |
 | GitHub issues (label: `enhancement`, `track:*`, `roadmap`) | Tracked work that hasn't shipped yet |
 | Assistant memory (`~/.claude-personal/projects/<hash>/memory/`) | User-specific *context* that genuinely belongs to the user-assistant relationship — preferences, identity hints, prior-session breadcrumbs. **Not workflow rules.** |
 
@@ -221,6 +221,38 @@ a stderr audit line when set. Per-line carve-outs use
 are captured in `scripts/lint-synthetic-home-allowlist.txt` and tracked under
 #710 Phase E for migration; the bypass and the annotation are user-controlled
 and must not be used silently by an assistant.
+
+## Artifact cleanup (hard rule)
+
+Studio shell-script workflows MUST clean their own filesystem state on terminal
+exit (success and failure). Artifact classes covered: Xcode DerivedData
+(default + custom `-derivedDataPath`), git worktrees, `~/.dev-studio/<project>/**`
+ephemeral scratch, `/tmp` and `mktemp` directories, booted simulator devices
+(`xcrun simctl boot`), xcresult bundles, archives, and IPAs. Existing janitor
+scripts (`studio-ios-artifact-janitor.sh`, `node-janitor.sh`,
+`fleet-cleanup.sh`, `sweep-janitor.sh`) remain as a periodic safety net;
+primary enforcement lives in per-workflow EXIT traps registered through the
+shared primitive.
+
+The shared primitive is `scripts/lib-artifact-cleanup.sh` (`register_artifact
+<kind> <path> [--keep-on-handoff]` plus EXIT-trap `finalize_artifacts`). It
+honors `STUDIO_KEEP_ARTIFACTS=1` as a full-retain user override and stamps
+ownership/TTL metadata under a registry directory derived through
+`project_state_dir` from `scripts/lib-paths.sh` (no raw `$HOME/.dev-studio/...`
+formulas).
+
+The wrapper requirement is mechanically enforced by
+`scripts/lint-artifact-cleanup.sh`, which blocks new commits in `scripts/*.sh`,
+`core/**/*.sh`, and `hooks/*` that call `xcodebuild`, `-derivedDataPath`,
+`git worktree add`, or `mktemp -d` without (a) `register_artifact` on the
+same/adjacent line, (b) routing through an approved wrapper (the existing
+janitors plus `scripts/lib-artifact-cleanup.sh` itself), or (c) per-line
+carve-out `# lint-artifact-cleanup:allow next-line — <reason>`.
+`STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1` is the emergency/debug lever for the
+pre-commit gate; it emits a stderr audit line when set. Pre-existing call
+sites are captured in `scripts/lint-artifact-cleanup-allowlist.txt` and
+tracked under #854 (umbrella) for migration; the bypass and the annotation
+are user-controlled and must not be used silently by an assistant.
 
 ## Backlog
 

--- a/_shared/audits/2026-05-10-artifact-cleanup-audit.md
+++ b/_shared/audits/2026-05-10-artifact-cleanup-audit.md
@@ -1,0 +1,160 @@
+---
+name: 2026-05-10-artifact-cleanup-audit
+description: Public summary of the studio shell-script artifact-producing call site audit at baseline SHA cdbc6e9 (chain artifact-cleanup-audit, issue #846 / T-R001). Documents offender taxonomy, per-workflow-surface counts, and explicit handoff cases.
+type: audit
+---
+
+# Artifact Cleanup Audit — Studio Scripts (Public Summary)
+
+**Baseline commit SHA:** `cdbc6e9`
+**Audit date:** 2026-05-10
+**Issue:** #846 (chain `artifact-cleanup-audit`, task graph node `T-R001`)
+
+This is the public, abstracted summary of an audit of artifact-producing call
+sites across the studio's shell-script corpus. The detailed file:line inventory
+lives in a private working file under `~/.dev-studio/<project>/analysis/`; this
+public summary intentionally omits any project-private context and reports
+counts and verdicts only.
+
+## Scope
+
+**Audit corpus (globs):**
+
+- `scripts/**/*.sh`
+- `core/**/*.sh` — empty at baseline
+- `hooks/*` — no artifact-producing call sites at baseline
+
+`_shared/**` had no `.sh` files at baseline and was excluded.
+
+## Offender criteria
+
+A call site is an **offender** if it creates filesystem state in one of the
+artifact classes below AND does not:
+
+- (a) install an `EXIT`/`INT`/`TERM` trap that finalizes that state, or
+- (b) opt in to one of the existing janitors (per-platform iOS-artifact janitor,
+  node janitor, fleet cleanup, sweep janitor), or
+- (c) hand off ownership to a downstream task that finalizes it.
+
+### Verdict taxonomy
+
+- `clean` — trap-cleaned on EXIT/INT/TERM (and/or RETURN), full coverage.
+- `clean-on-success-only` — explicit `rm` after use, but no trap; signals or
+  early-returns between create and rm leak.
+- `leaks-always` — no cleanup of any kind on any path.
+- `janitor-but-not-scheduled` — cleanup relies on a janitor whose schedule or
+  opt-in is not visible from the call site itself.
+- `handoff` — ownership documented to pass to a downstream worker/task.
+- `rename-consumed` — not an offender; mktemp in atomic-write
+  (`tmp=$(mktemp ...) ... mv "$tmp" "$target"`) pattern.
+
+### Artifact classes scanned
+
+1. xcodebuild DerivedData (default + custom `-derivedDataPath`).
+2. `git worktree add` targets.
+3. Per-project ephemeral runtime scratch (chain task envelopes, worker
+   summaries not promoted to durable state, perf traces, qa/flow recordings,
+   planner artifacts).
+4. `/tmp` and `mktemp -d` directories.
+5. Simulator devices booted via `xcrun simctl boot`.
+6. `.xcresult` bundles, `.xcarchive` archives, `.ipa` files.
+
+## Per-workflow-surface counts
+
+Counts below are call sites, not files. Sub-issue mapping aligns with the
+planned cluster slices for this arc.
+
+| Workflow surface (planned sub-issue) | clean | clean-on-success-only | leaks-always | janitor-but-not-scheduled | handoff |
+|---|---:|---:|---:|---:|---:|
+| chain-runner + worker (T-R002) | ~12 | 18 | 13 | 6 | 4 |
+| perf / review wrapper (T-R003) | 6 | 1 | 0 | 2 | 1 |
+| qa + flow (T-R004 cluster) | 0 | 0 | 0 | 0 | 0 |
+| release / TestFlight (T-R005) | 0 | 0 | 4 | 1 | 0 |
+| structural primitive (T-R006) | 19 | 6 | ~30 | 0 | 0 |
+
+Totals (production scripts): ≈37 clean, ≈25 clean-on-success-only, ≈47
+leaks-always, ≈9 janitor-but-not-scheduled, ≈5 documented handoffs. Test
+fixtures (~80 scripts) all use the canonical `TMPROOT + trap rm -rf`
+pattern and contribute zero offenders.
+
+## Headline findings
+
+- **Long-tail of untrapped `mktemp`.** The single largest class of offenders is
+  short-lived `mktemp` files used for one-shot JSON or row buffers in long-lived
+  control-plane scripts. They are individually small but compound under signal
+  paths and SIGINT exits. ~47 leaks-always sites in production scripts.
+- **Archive class has a high-blast-radius leak.** The release/TestFlight
+  workflow produces a multi-GB `.xcarchive` per push and never removes it.
+  Single highest-priority offender by bytes-leaked-per-run.
+- **Simulator state is not finalized.** Simulator boots in the perf/review
+  surface have no corresponding shutdown. Long-running workers accumulate
+  simulator state until host reboot or manual `simctl shutdown all`.
+- **xcresult retention is correct but fragile.** The result-bundle on the
+  perf/review path is documented as a downstream consumer's concern; the
+  consumer does remove it, but worker death between produce and consume leaks.
+- **DerivedData is janitor-managed but unscheduled at the call site.**
+  `-derivedDataPath` is set via env in five chain-runner+worker call sites; the
+  iOS-artifact janitor handles cleanup, but the dependency on the janitor being
+  invoked is implicit at the call site (no annotation, no fail-closed path).
+- **Test fixtures are exemplary.** Every test fixture follows
+  `TMPROOT=$(mktemp -d -t ...) ; trap 'rm -rf "$TMPROOT"' EXIT`. This is the
+  pattern that production-script offenders should converge on.
+
+## Handoff cases (legitimate cross-task retention)
+
+These call sites intentionally outlive their producer; downstream owners take
+finalization responsibility. They are not offenders.
+
+- **Chain worktrees.** Created by the chain-runner / per-task worktree setup;
+  cleaned by the chain runner's PR-merge / cleanup phase per the chain task
+  envelope contract.
+- **Per-chain planner outputs.** Planner JSON and review markdown live under
+  the per-project `plan-chains/<id>/` runtime root for the duration of the
+  chain; chain runner owns retention TTL.
+- **Per-task xcresult on the perf/review path.** Producer documents the bundle
+  as the downstream verdict-emitter's concern.
+- **Private chain-runner control artifacts.** `.studio/chain-task-start.json`
+  and `.studio/chain-worker-summary.json` are envelope-private to the parent
+  runner per the chain task contract; workers never delete them.
+
+## Mapping to planned sub-issues
+
+- **T-R002 (chain-runner + worker cleanup).** ~37 sites across chain-runner
+  control plane, task gates (build/test/swift-test), and worktree setup.
+  Highest-density surface; mix of clean-on-success-only and leaks-always.
+  Includes the simulator-boot site if perf/review work is bundled.
+- **T-R003 (perf / review wrapper cleanup).** ~10 sites; mostly already trap-
+  cleaned. Remaining gaps are the xcresult handoff (worker-death edge), the
+  simulator-boot finalize, and DerivedData annotation.
+- **T-R004 (qa + flow cleanup).** No artifact-producing production scripts at
+  baseline; qa-engineer and flow-tester surfaces exist only as role contracts
+  and test fixtures. Sub-issue is preventative — establish the cleanup contract
+  before runtime scripts land.
+- **T-R005 (release / TestFlight cleanup).** Small site count (≈5) but the
+  largest blast radius. The `.xcarchive` leak is the single most expensive
+  offender.
+- **T-R006 (structural primitive).** Library-level `mktemp` users
+  (`lib-chain-monitor-*`, `lib-chain-run-state`, `lib-stepwise`,
+  `lib-fixtures`, etc.) where the right fix is a shared
+  `mktemp_traced` / `register_for_cleanup` helper, not per-site traps.
+
+## Recommendations
+
+1. Land the lint allowlist (`scripts/lint-artifact-cleanup-allowlist.txt`)
+   seeded with the leaks-always + clean-on-success-only sets, then migrate by
+   priority order: release `.xcarchive` → simulator boots → result-bundle
+   handoff → control-plane `mktemp`.
+2. Adopt a shared cleanup primitive (`register_for_cleanup` + single trap) for
+   T-R006 rather than per-site traps; this collapses ~30 leaks-always sites
+   into one structural fix.
+3. Add an explicit `# lint-artifact-cleanup:allow next-line — janitor=<name>`
+   annotation for every janitor-managed call site, so the dependency is local
+   and auditable.
+4. Treat the simulator-boot/shutdown asymmetry as a contract issue: no boot
+   without a paired finalize step, even on aborted runs.
+
+## Reproducibility
+
+This audit was produced from the working tree at commit `cdbc6e9`. Re-running
+the same grep-based methodology at the same SHA reproduces the call-site
+counts. The methodology and corpus globs are stable across re-runs.

--- a/_shared/audits/2026-05-10-artifact-cleanup-issues.md
+++ b/_shared/audits/2026-05-10-artifact-cleanup-issues.md
@@ -1,0 +1,39 @@
+---
+name: artifact-cleanup-issues
+description: Issue tracker for the studio artifact-cleanup migration (umbrella #854 plus per-surface Phase 2 sub-issues). Consumed by T-R005 / #851 for the CLAUDE.md citation.
+type: audit-tracker
+---
+
+# Artifact-cleanup migration: issue tracker
+
+**Baseline:** `cdbc6e9` (commit_before).
+**Audit source:** `_shared/audits/2026-05-10-artifact-cleanup-audit.md`.
+**Created by:** T-R002 (executed manually from parent session due to chain-runner subprocess permission boundary; see #852).
+
+## Structured registry
+
+```yaml
+umbrella:
+  number: 854
+  url: https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/854
+sub_issues:
+  - surface: structural
+    number: 855
+    url: https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/855
+  - surface: chain-runner
+    number: 856
+    url: https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/856
+  - surface: perf
+    number: 857
+    url: https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/857
+  - surface: qa-flow
+    number: 858
+    url: https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/858
+  - surface: release-tf
+    number: 859
+    url: https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/859
+```
+
+## Human-readable summary
+
+Phase 2 work-chain will pick these up after Phase 1 (#845) merges. Each sub-issue links the relevant offender rows in the audit report and proposes a fix shape using the new `register_artifact` primitive (#848) plus the lint gate seeded from the audit (#849). CLAUDE.md "Artifact cleanup (hard rule)" section (#851 / pending) cites #854 as the migration tracker.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T19:29:09Z",
+  "generated_at": "2026-05-10T19:30:50Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T17:27:57Z",
+  "generated_at": "2026-05-10T18:42:27Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T19:39:43Z",
+  "generated_at": "2026-05-10T17:27:57Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T19:30:50Z",
+  "generated_at": "2026-05-10T19:59:59Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T18:54:49Z",
+  "generated_at": "2026-05-10T19:29:09Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T18:42:27Z",
+  "generated_at": "2026-05-10T18:54:49Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T19:30:50Z",
+  "generated_at": "2026-05-10T19:59:59Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T18:42:26Z",
+  "generated_at": "2026-05-10T18:54:49Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T19:29:09Z",
+  "generated_at": "2026-05-10T19:30:50Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T18:54:49Z",
+  "generated_at": "2026-05-10T19:29:09Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T17:27:56Z",
+  "generated_at": "2026-05-10T18:42:26Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T19:39:42Z",
+  "generated_at": "2026-05-10T17:27:56Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-artifact-cleanup.sh
+++ b/scripts/lib-artifact-cleanup.sh
@@ -111,7 +111,10 @@ register_artifact() {
     printf 'register_artifact: usage: register_artifact <kind> <path> [--keep-on-handoff]\n' >&2
     return 2
   fi
-  local kind="$1" path="$2" handoff="0"
+  # NOTE: never use `local path` here — zsh ties `path` to `PATH`, so a
+  # local would temporarily wipe PATH inside this function and any trap
+  # callees, breaking command lookup for sed/rm/etc. Use art_path.
+  local kind="$1" art_path="$2" handoff="0"
   shift 2
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -123,13 +126,13 @@ register_artifact() {
     esac
   done
 
-  if [ -z "$kind" ] || [ -z "$path" ]; then
+  if [ -z "$kind" ] || [ -z "$art_path" ]; then
     printf 'register_artifact: <kind> and <path> must be non-empty\n' >&2
     return 2
   fi
 
   _LAC_KINDS+=("$kind")
-  _LAC_PATHS+=("$path")
+  _LAC_PATHS+=("$art_path")
   _LAC_HANDOFFS+=("$handoff")
   _lac_install_trap
 }
@@ -138,7 +141,8 @@ register_artifact() {
 # artifact and own its lifecycle. TSV (kind, path, owner_pid, ts_iso)
 # keeps the format greppable without a yq/jq dependency.
 _lac_write_handoff_record() {
-  local kind="$1" path="$2"
+  # zsh-safe: art_path instead of path.
+  local kind="$1" art_path="$2"
   local dir record ts
   dir=$(_lac_registry_dir) || return 1
   mkdir -p "$dir/handoff" 2>/dev/null || return 1
@@ -146,7 +150,7 @@ _lac_write_handoff_record() {
   # One file per record so concurrent writers from sibling processes
   # never clobber each other; filename is unique per (pid, count).
   record="$dir/handoff/$$-${#_LAC_KINDS[@]}-$(date +%s 2>/dev/null || echo n).tsv"
-  printf '%s\t%s\t%s\t%s\n' "$kind" "$path" "$$" "$ts" > "$record" 2>/dev/null
+  printf '%s\t%s\t%s\t%s\n' "$kind" "$art_path" "$$" "$ts" > "$record" 2>/dev/null
 }
 
 # Public: finalize all registered artifacts. Safe to call multiple times.
@@ -159,22 +163,32 @@ finalize_artifacts() {
     1|true|TRUE|yes|YES) keep_all="1" ;;
   esac
 
-  local i count="${#_LAC_PATHS[@]}"
-  i=0
-  while [ "$i" -lt "$count" ]; do
-    local kind="${_LAC_KINDS[$i]}" path="${_LAC_PATHS[$i]}" handoff="${_LAC_HANDOFFS[$i]}"
+  # Portable iteration across bash (0-indexed) and zsh (1-indexed by
+  # default): walk the parallel arrays via the @ expansion plus a counter
+  # we maintain ourselves, so we never index by an integer that differs
+  # between shells. zsh-safe: art_path instead of path.
+  local kind art_path handoff
+  local idx=0
+  for art_path in "${_LAC_PATHS[@]}"; do
+    if [ -n "${ZSH_VERSION:-}" ]; then
+      kind="${_LAC_KINDS[$((idx + 1))]}"
+      handoff="${_LAC_HANDOFFS[$((idx + 1))]}"
+    else
+      kind="${_LAC_KINDS[$idx]}"
+      handoff="${_LAC_HANDOFFS[$idx]}"
+    fi
 
     if [ "$keep_all" = "1" ]; then
       printf 'studio: STUDIO_KEEP_ARTIFACTS=1 — retaining %s artifact: %s\n' \
-        "$kind" "$path" >&2
+        "$kind" "$art_path" >&2
     elif [ "$handoff" = "1" ]; then
-      _lac_write_handoff_record "$kind" "$path" || true
+      _lac_write_handoff_record "$kind" "$art_path" || true
       # Intentionally NO rm — ownership transferred.
     else
-      if [ -n "$path" ] && [ -e "$path" ]; then
-        rm -rf -- "$path" 2>/dev/null || true
+      if [ -n "$art_path" ] && [ -e "$art_path" ]; then
+        rm -rf -- "$art_path" 2>/dev/null || true
       fi
     fi
-    i=$((i + 1))
+    idx=$((idx + 1))
   done
 }

--- a/scripts/lib-artifact-cleanup.sh
+++ b/scripts/lib-artifact-cleanup.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# lib-artifact-cleanup.sh — shared cleanup primitive for studio scripts.
+#
+# Sourced by callers that produce disposable runtime artifacts (tmp dirs,
+# scratch files, xcresult bundles, derived data, log files) and want them
+# torn down deterministically when the calling shell exits — successful or
+# not. Replaces hand-rolled `trap 'rm -rf "$tmp"' EXIT` snippets that drift
+# in subtle ways across callers (kind, retention, host-flip handoff).
+#
+# API:
+#   register_artifact <kind> <path> [--keep-on-handoff]
+#       Track <path> for cleanup at shell exit. <kind> is a short label
+#       ("xcresult", "tmpdir", "log", "derived-data") used for the audit
+#       line and registry metadata. --keep-on-handoff transfers ownership
+#       to the registry's handoff dir (the artifact is NOT deleted by this
+#       process; a follow-up chained task is expected to consume it and
+#       run its own cleanup). The EXIT trap is installed lazily on the
+#       first register_artifact call — the file is side-effect-free until
+#       then, so any studio script can source it unconditionally.
+#
+#   finalize_artifacts
+#       Idempotent. Walks the in-memory registry and either deletes,
+#       hands off, or audits each entry. Normally invoked automatically
+#       by the EXIT trap; callers can invoke it directly for early
+#       teardown (e.g. before re-exec).
+#
+# Environment:
+#   STUDIO_KEEP_ARTIFACTS=1
+#       Retain everything; emit a stderr audit line per artifact and
+#       skip both deletion and handoff. Useful for post-mortem
+#       inspection without smearing a half-finalized state into the
+#       handoff dir.
+#
+# Path policy:
+#   The handoff registry dir is derived via resolve_project_root from
+#   scripts/lib-paths.sh; raw runtime-path formulas are forbidden in
+#   this file (lint-runtime-paths.sh would block such a line).
+#
+# Sourceability:
+#   No `set -e` here; callers may or may not run with strict mode.
+#   No EXIT trap installed at source time — only the first
+#   register_artifact call wires it up.
+
+# Idempotent re-source guard. Sourcing the file twice (e.g. through two
+# different libraries) must not reset the in-memory registry or stack
+# duplicate EXIT traps.
+if [ -n "${_STUDIO_ARTIFACT_CLEANUP_LOADED:-}" ]; then
+  return 0 2>/dev/null || true
+fi
+_STUDIO_ARTIFACT_CLEANUP_LOADED=1
+
+# Resolve lib-paths.sh relative to this script. BASH_SOURCE-aware so
+# `source scripts/lib-artifact-cleanup.sh` from any cwd works.
+_lac_script_dir() {
+  local src="${BASH_SOURCE[0]:-$0}"
+  cd "$(dirname "$src")" 2>/dev/null && pwd
+}
+
+# Source lib-paths.sh once, lazily. Sourcing a second time is a no-op
+# in practice (its functions get redefined to identical bodies) but we
+# guard anyway to keep this file's "no side effects until used"
+# contract crisp.
+_lac_load_paths() {
+  if [ -n "${_LAC_PATHS_LOADED:-}" ]; then
+    return 0
+  fi
+  local dir
+  dir=$(_lac_script_dir) || return 1
+  # shellcheck source=/dev/null
+  . "$dir/lib-paths.sh" || return 1
+  _LAC_PATHS_LOADED=1
+}
+
+# Parallel arrays scoped to this process. Index N across both arrays
+# describes one registered artifact.
+_LAC_KINDS=()
+_LAC_PATHS=()
+_LAC_HANDOFFS=()    # "1" if --keep-on-handoff was passed, else "0"
+_LAC_TRAP_INSTALLED=0
+_LAC_FINALIZED=0
+
+_lac_install_trap() {
+  [ "$_LAC_TRAP_INSTALLED" -eq 1 ] && return 0
+  # Composed trap: preserve any pre-existing EXIT trap by chaining it.
+  # Callers that already set their own EXIT handler keep it; ours runs
+  # alongside.
+  local existing
+  existing=$(trap -p EXIT 2>/dev/null | sed -n "s/^trap -- '\(.*\)' EXIT$/\1/p")
+  if [ -n "$existing" ]; then
+    # shellcheck disable=SC2064 # intentional early expansion of $existing
+    trap "$existing; finalize_artifacts" EXIT
+  else
+    trap finalize_artifacts EXIT
+  fi
+  _LAC_TRAP_INSTALLED=1
+}
+
+# Build the handoff registry dir. Lazily created (mkdir -p) only when
+# we actually need to write a handoff record, so register_artifact
+# without --keep-on-handoff stays filesystem-quiet on the registry side.
+_lac_registry_dir() {
+  _lac_load_paths || return 1
+  local root
+  root=$(resolve_project_root 2>/dev/null) || return 1
+  printf '%s\n' "$root/.runtime/state/artifact-cleanup"
+}
+
+# Public: register an artifact for end-of-shell cleanup.
+register_artifact() {
+  if [ "$#" -lt 2 ]; then
+    printf 'register_artifact: usage: register_artifact <kind> <path> [--keep-on-handoff]\n' >&2
+    return 2
+  fi
+  local kind="$1" path="$2" handoff="0"
+  shift 2
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --keep-on-handoff) handoff="1"; shift ;;
+      *)
+        printf 'register_artifact: unknown flag: %s\n' "$1" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  if [ -z "$kind" ] || [ -z "$path" ]; then
+    printf 'register_artifact: <kind> and <path> must be non-empty\n' >&2
+    return 2
+  fi
+
+  _LAC_KINDS+=("$kind")
+  _LAC_PATHS+=("$path")
+  _LAC_HANDOFFS+=("$handoff")
+  _lac_install_trap
+}
+
+# Stamp a handoff record so a follow-up chained task can find the
+# artifact and own its lifecycle. TSV (kind, path, owner_pid, ts_iso)
+# keeps the format greppable without a yq/jq dependency.
+_lac_write_handoff_record() {
+  local kind="$1" path="$2"
+  local dir record ts
+  dir=$(_lac_registry_dir) || return 1
+  mkdir -p "$dir/handoff" 2>/dev/null || return 1
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+  # One file per record so concurrent writers from sibling processes
+  # never clobber each other; filename is unique per (pid, count).
+  record="$dir/handoff/$$-${#_LAC_KINDS[@]}-$(date +%s 2>/dev/null || echo n).tsv"
+  printf '%s\t%s\t%s\t%s\n' "$kind" "$path" "$$" "$ts" > "$record" 2>/dev/null
+}
+
+# Public: finalize all registered artifacts. Safe to call multiple times.
+finalize_artifacts() {
+  [ "$_LAC_FINALIZED" -eq 1 ] && return 0
+  _LAC_FINALIZED=1
+
+  local keep_all="0"
+  case "${STUDIO_KEEP_ARTIFACTS:-0}" in
+    1|true|TRUE|yes|YES) keep_all="1" ;;
+  esac
+
+  local i count="${#_LAC_PATHS[@]}"
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    local kind="${_LAC_KINDS[$i]}" path="${_LAC_PATHS[$i]}" handoff="${_LAC_HANDOFFS[$i]}"
+
+    if [ "$keep_all" = "1" ]; then
+      printf 'studio: STUDIO_KEEP_ARTIFACTS=1 — retaining %s artifact: %s\n' \
+        "$kind" "$path" >&2
+    elif [ "$handoff" = "1" ]; then
+      _lac_write_handoff_record "$kind" "$path" || true
+      # Intentionally NO rm — ownership transferred.
+    else
+      if [ -n "$path" ] && [ -e "$path" ]; then
+        rm -rf -- "$path" 2>/dev/null || true
+      fi
+    fi
+    i=$((i + 1))
+  done
+}

--- a/scripts/lint-artifact-cleanup-allowlist.txt
+++ b/scripts/lint-artifact-cleanup-allowlist.txt
@@ -1,0 +1,79 @@
+# lint-artifact-cleanup allowlist (issue #849 baseline).
+#
+# Files listed here pre-date the lint and are permitted to retain raw
+# `xcodebuild`, `-derivedDataPath`, `git worktree add`, and `mktemp -d`
+# call sites that do not route through scripts/lib-artifact-cleanup.sh
+# `register_artifact` in --strict (whole-tree) mode. Pre-commit (--staged)
+# mode still rejects newly-added lines containing the patterns even in
+# these files — the allowlist only suppresses retroactive flagging of
+# pre-existing content.
+#
+# Seed is drawn from the T-R001 artifact-cleanup audit
+# (_shared/audits/2026-05-10-artifact-cleanup-audit.md, baseline SHA
+# cdbc6e9). Migration of these files to the cleanup primitive is tracked
+# under #710 Phase E and the per-surface sub-issues (T-R002 chain-runner+
+# worker, T-R003 perf/review, T-R005 release/TF, T-R006 structural). Do
+# not add new entries here without an explicit migration plan.
+#
+# Format: one repo-relative path per line. Lines starting with `#` and
+# blank lines are ignored. Approved-wrapper carve-outs
+# (scripts/lib-artifact-cleanup.sh, scripts/studio-ios-artifact-janitor.sh,
+# scripts/node-janitor.sh, scripts/fleet-cleanup.sh,
+# scripts/sweep-janitor.sh) and scripts/test-fixtures/** are exempt by
+# rule, not by this allowlist.
+
+scripts/add-skill.sh
+scripts/analyze-feedback-ingest.sh
+scripts/argus-axe-verify.sh
+scripts/argus-run-tests.sh
+scripts/bootstrap.sh
+scripts/check-xcode-parity.sh
+scripts/configure.sh
+scripts/field-workflow-report.sh
+scripts/graduation-scan.sh
+scripts/ingest-feedback.sh
+scripts/init-worker-manifest.sh
+scripts/install-recipe.sh
+scripts/issue-body-edit.sh
+scripts/lib-build-queue.sh
+scripts/lib-chain-monitor-slack-list.sh
+scripts/lib-dispatch-harvest.sh
+scripts/lib-host-eligibility.sh
+scripts/lib-paths.sh
+scripts/lib-remote-failure.sh
+scripts/lib-stepwise.sh
+scripts/lint-build-invocations.sh
+scripts/lint-runtime-paths.sh
+scripts/manager-reconcile.sh
+scripts/manager-release-branch.sh
+scripts/migrate-ledger.sh
+scripts/node-diagnose.sh
+scripts/node-parity.sh
+scripts/node-warmup.sh
+scripts/phase-review.sh
+scripts/pr-headless-review.sh
+scripts/pr-reviewer-eligibility.sh
+scripts/prd-task-graph-synthesize.sh
+scripts/pre-commit-review.sh
+scripts/rollback-recipe.sh
+scripts/rule-pack-resolve.sh
+scripts/studio-chain-doctor.sh
+scripts/studio-chain-rule-gates.sh
+scripts/studio-chain-runner.sh
+scripts/studio-chain-telemetry-digest.sh
+scripts/studio-checkpoint.sh
+scripts/studio-ios-check-failover.sh
+scripts/studio-ios-check-router.sh
+scripts/studio-pr-baseline-report.sh
+scripts/studio-tf-push.sh
+scripts/studio-weekly.sh
+scripts/swift-test-gate.sh
+scripts/sync-worker.sh
+scripts/task-build-gate.sh
+scripts/task-merge.sh
+scripts/task-test-gate.sh
+scripts/task-worktree-setup.sh
+scripts/test-suggestion-engine.sh
+scripts/v2-router-lint.sh
+scripts/v2-skill-route.sh
+scripts/xcodebuild-shim.sh

--- a/scripts/lint-artifact-cleanup.sh
+++ b/scripts/lint-artifact-cleanup.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# lint-artifact-cleanup.sh — block new artifact-producing call sites that
+# don't route through the shared cleanup primitive (#710 / T-R004, #849).
+#
+# scripts/lib-artifact-cleanup.sh centralizes deterministic cleanup of
+# disposable runtime artifacts (tmp dirs, xcresult bundles, xcarchives,
+# derived-data trees, ephemeral git worktrees). Hand-rolled mktemp/xcodebuild/
+# worktree-add call sites without an EXIT trap drift in subtle ways across
+# callers and silently leak filesystem state — `studio-tf-push.sh` leaking
+# multi-GB xcarchives per push, simulator-booted DerivedData accumulating
+# under long-lived workers, untrapped tmpdirs in slack-list / chain-runner
+# loops. The T-R001 audit (`_shared/audits/2026-05-10-artifact-cleanup-audit.md`)
+# inventoried the corpus; this lint blocks new offenders from accreting on
+# top of the baseline.
+#
+# Modes:
+#   scripts/lint-artifact-cleanup.sh --staged    # pre-commit: scan added
+#                                                # lines in the staged diff
+#   scripts/lint-artifact-cleanup.sh --strict    # CI: scan whole tree, but
+#                                                # honor the baseline
+#                                                # allowlist for files that
+#                                                # pre-date the lint
+#   scripts/lint-artifact-cleanup.sh <file> ...  # ad-hoc whole-file scan
+#
+# Scope (per #849 acceptance):
+#   scripts/*.sh, core/**/*.sh, hooks/* (text shell scripts)
+#
+# Always-exempt (approved wrappers / resolver layer / this lint):
+#   - scripts/lib-artifact-cleanup.sh         (the cleanup primitive itself;
+#                                              owns its registry scratch
+#                                              under mktemp -d)
+#   - scripts/studio-ios-artifact-janitor.sh  (approved janitor)
+#   - scripts/node-janitor.sh                 (approved janitor)
+#   - scripts/fleet-cleanup.sh                (approved janitor)
+#   - scripts/sweep-janitor.sh                (approved janitor)
+#   - scripts/lint-artifact-cleanup.sh        (this lint)
+#   - scripts/test-fixtures/**                (synthetic data, polluted
+#                                              samples; behavioral fixtures
+#                                              clean up their own sandbox)
+#
+# Allowlist (baseline of pre-existing files):
+#   scripts/lint-artifact-cleanup-allowlist.txt
+#   - --strict mode skips listed files entirely (don't break the world).
+#   - --staged mode still flags newly-added lines in those files; existing
+#     content is invisible to a staged-diff scan, so the baseline is
+#     irrelevant there.
+#
+# Allow annotation (per-line carve-out for documentation/tests):
+#   # lint-artifact-cleanup:allow next-line — <reason>
+#
+# Approved-context substrings (single-line carve-outs — recognized as
+# canonical cleanup-primitive use rather than ad-hoc artifact creation):
+#   - register_artifact                  (the cleanup primitive helper)
+#   - lint-artifact-cleanup:allow        (per-line annotation)
+#
+# Detected patterns (E_ARTIFACT_CLEANUP_UNREGISTERED):
+#   1. `xcodebuild` invocation (as a command word, not a string literal in
+#      a comment or echo) — produces DerivedData / archives / result bundles
+#   2. Literal `-derivedDataPath` flag — explicitly relocates DerivedData
+#      to a path that must be cleaned
+#   3. Literal `git worktree add` — produces a worktree the caller owns
+#   4. Literal `mktemp -d` — produces a disposable tmp dir
+#
+# Bypass (user-controlled, emergency/debug-only):
+#   STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1 git commit ...
+#   The lint emits a stderr audit line when the bypass fires; assistants
+#   must not set the bypass silently.
+#
+# Error format: <CODE>:<file>:<line>:<detail>
+# Exit 0: clean. Exit 1: at least one BLOCK violation.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# Repo root: env override (used by the test fixture against synthetic
+# throwaway repos), else the script's own repo. Mirrors the C1/C2/C3 siblings.
+if [ -n "${LINT_ARTIFACT_CLEANUP_REPO_ROOT:-}" ]; then
+  REPO_ROOT=$(cd "$LINT_ARTIFACT_CLEANUP_REPO_ROOT" && pwd)
+else
+  REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+fi
+ALLOWLIST_FILE="$SCRIPT_DIR/lint-artifact-cleanup-allowlist.txt"
+
+if [ "${STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT:-0}" = "1" ]; then
+  printf 'lint-artifact-cleanup: STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1 — skipping (audit)\n' >&2
+  exit 0
+fi
+
+ERRORS=0
+emit_error() { printf '%s\n' "$1"; ERRORS=$((ERRORS + 1)); }
+
+in_scope() {
+  local p="$1"
+  case "$p" in
+    scripts/*.sh) return 0 ;;
+    hooks/*)
+      case "$p" in
+        */*.json) return 1 ;;
+      esac
+      return 0
+      ;;
+    core/*)
+      case "$p" in
+        *.sh) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+exempt_by_rule() {
+  case "$1" in
+    scripts/lib-artifact-cleanup.sh)         return 0 ;;
+    scripts/studio-ios-artifact-janitor.sh)  return 0 ;;
+    scripts/node-janitor.sh)                 return 0 ;;
+    scripts/fleet-cleanup.sh)                return 0 ;;
+    scripts/sweep-janitor.sh)                return 0 ;;
+    scripts/lint-artifact-cleanup.sh)        return 0 ;;
+    scripts/test-fixtures/*)                 return 0 ;;
+  esac
+  return 1
+}
+
+ALLOWLIST=""
+if [ -f "$ALLOWLIST_FILE" ]; then
+  ALLOWLIST=$(awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    { sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, ""); print }
+  ' "$ALLOWLIST_FILE")
+fi
+
+allowlisted() {
+  [ -z "$ALLOWLIST" ] && return 1
+  printf '%s\n' "$ALLOWLIST" | grep -Fxq -- "$1"
+}
+
+has_approved_context() {
+  case "$1" in
+    *register_artifact*)              return 0 ;;
+    *'lint-artifact-cleanup:allow'*)  return 0 ;;
+  esac
+  return 1
+}
+
+is_comment_line() {
+  local stripped="${1#"${1%%[![:space:]]*}"}"
+  case "$stripped" in
+    \#*) return 0 ;;
+  esac
+  return 1
+}
+
+# Detect the four pattern classes on a single line. Returns 0 + sets
+# MATCH_DETAIL when the line contains a banned pattern outside an approved
+# wrapper / annotation context.
+MATCH_DETAIL=""
+match_offender() {
+  local line="$1"
+  MATCH_DETAIL=""
+
+  # Class 3: `git worktree add` (check before plain xcodebuild to keep
+  # detail accurate when a single line contains multiple tokens).
+  case "$line" in
+    *'git worktree add'*)
+      MATCH_DETAIL='`git worktree add` without register_artifact / approved wrapper'
+      return 0
+      ;;
+  esac
+
+  # Class 2: `-derivedDataPath` literal flag.
+  case "$line" in
+    *-derivedDataPath*)
+      MATCH_DETAIL='`-derivedDataPath` without register_artifact / approved wrapper'
+      return 0
+      ;;
+  esac
+
+  # Class 4: `mktemp -d` literal.
+  case "$line" in
+    *'mktemp -d'*)
+      MATCH_DETAIL='`mktemp -d` without register_artifact / approved wrapper'
+      return 0
+      ;;
+  esac
+
+  # Class 1: `xcodebuild` as a command word. Match when preceded by start
+  # of line, whitespace, `;`, `&`, `|`, `(`, or backtick — i.e. the token
+  # is being executed rather than appearing inside a longer identifier or
+  # string literal containing the word.
+  if [[ "$line" =~ (^|[[:space:]\;\&\|\(\`\$])xcodebuild([[:space:]]|\"|$) ]]; then
+    MATCH_DETAIL='`xcodebuild` invocation without register_artifact / approved wrapper'
+    return 0
+  fi
+
+  return 1
+}
+
+scan_whole_file() {
+  local rel="$1"
+  local abs
+  case "$rel" in
+    /*) abs="$rel" ;;
+    *)  abs="$REPO_ROOT/$rel" ;;
+  esac
+  [ -f "$abs" ] || return 0
+
+  local lineno=0 prev=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    if is_comment_line "$line"; then
+      prev="$line"
+      continue
+    fi
+    if match_offender "$line"; then
+      if has_approved_context "$line" || has_approved_context "$prev"; then
+        prev="$line"
+        continue
+      fi
+      emit_error "E_ARTIFACT_CLEANUP_UNREGISTERED:$rel:$lineno:$MATCH_DETAIL | route through scripts/lib-artifact-cleanup.sh \`register_artifact\` or an approved janitor (studio-ios-artifact-janitor / node-janitor / fleet-cleanup / sweep-janitor); per CLAUDE.md §Where workflow rules live"
+    fi
+    prev="$line"
+  done < "$abs"
+}
+
+scan_staged_diff() {
+  local files
+  files=$(git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=ACMR 2>/dev/null \
+    | while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        if in_scope "$f" && ! exempt_by_rule "$f"; then
+          printf '%s\n' "$f"
+        fi
+      done)
+  [ -z "$files" ] && return 0
+
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    local diff
+    diff=$(git -C "$REPO_ROOT" diff --cached --unified=0 -- "$f" 2>/dev/null) || continue
+    [ -z "$diff" ] && continue
+
+    local new_line=0 prev_added="" in_hunk=0
+    while IFS= read -r dline || [ -n "$dline" ]; do
+      case "$dline" in
+        '+++ '*|'--- '*) continue ;;
+        '@@'*)
+          local hunk="$dline"
+          local plus="${hunk#*+}"
+          plus="${plus%%,*}"
+          plus="${plus%% *}"
+          new_line="$plus"
+          prev_added=""
+          in_hunk=1
+          continue
+          ;;
+        '-'*) continue ;;
+        '+'*)
+          [ "$in_hunk" -eq 1 ] || continue
+          local content="${dline#+}"
+          if ! is_comment_line "$content" && match_offender "$content"; then
+            if ! has_approved_context "$content" && ! has_approved_context "$prev_added"; then
+              emit_error "E_ARTIFACT_CLEANUP_UNREGISTERED:$f:$new_line:$MATCH_DETAIL | route through scripts/lib-artifact-cleanup.sh \`register_artifact\` or an approved janitor (studio-ios-artifact-janitor / node-janitor / fleet-cleanup / sweep-janitor); per CLAUDE.md §Where workflow rules live"
+            fi
+          fi
+          prev_added="$content"
+          new_line=$((new_line + 1))
+          ;;
+        *)
+          [ "$in_hunk" -eq 1 ] && new_line=$((new_line + 1))
+          ;;
+      esac
+    done <<<"$diff"
+  done <<<"$files"
+}
+
+run_strict() {
+  local files
+  files=$(git -C "$REPO_ROOT" ls-files 2>/dev/null \
+    | while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        if in_scope "$f" && ! exempt_by_rule "$f" && ! allowlisted "$f"; then
+          printf '%s\n' "$f"
+        fi
+      done)
+  [ -z "$files" ] && return 0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    scan_whole_file "$f"
+  done <<<"$files"
+}
+
+run_files() {
+  local target
+  for target in "$@"; do
+    [ -z "$target" ] && continue
+    local rel="$target"
+    case "$target" in
+      "$REPO_ROOT"/*) rel="${target#"$REPO_ROOT/"}" ;;
+      /*) rel="$target" ;;
+    esac
+    if [ -f "$rel" ]; then
+      if exempt_by_rule "$rel"; then
+        continue
+      fi
+      scan_whole_file "$rel"
+    elif [ -f "$REPO_ROOT/$rel" ]; then
+      if exempt_by_rule "$rel"; then
+        continue
+      fi
+      scan_whole_file "$rel"
+    fi
+  done
+}
+
+mode="${1:-}"
+case "$mode" in
+  --staged)   scan_staged_diff ;;
+  --strict)   run_strict ;;
+  "" )        run_strict ;;
+  --help|-h)
+    sed -n '2,80p' "$0" >&2
+    exit 0
+    ;;
+  *)          run_files "$@" ;;
+esac
+
+if [ "$ERRORS" -gt 0 ]; then
+  printf 'lint-artifact-cleanup: %s error(s) — route disposable artifacts through scripts/lib-artifact-cleanup.sh `register_artifact` (or an approved janitor); per-line carve-out: `# lint-artifact-cleanup:allow next-line — <reason>`; emergency bypass: STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1\n' "$ERRORS" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/lint-artifact-cleanup.sh
+++ b/scripts/lint-artifact-cleanup.sh
@@ -137,9 +137,29 @@ allowlisted() {
 }
 
 has_approved_context() {
+  # Only same-line context counts. The previous-line allowance the lint
+  # used to accept (`register_artifact` on the line above) was a false
+  # negative — it accepted any earlier register call regardless of which
+  # artifact it referenced, which let unrelated `mktemp -d` / `xcodebuild`
+  # / etc. slip through. If a register_artifact appears on a different
+  # line than the offender, the author should either combine onto one
+  # line with `;` or use the explicit per-line annotation
+  # `# lint-artifact-cleanup:allow next-line — <reason>` placed on the
+  # line immediately above.
   case "$1" in
     *register_artifact*)              return 0 ;;
     *'lint-artifact-cleanup:allow'*)  return 0 ;;
+  esac
+  return 1
+}
+
+# Recognize the explicit per-line annotation only when it is on the
+# physically-previous line. This is intentionally narrower than
+# has_approved_context: an arbitrary register_artifact above an offender
+# is NOT a carve-out, but `# lint-artifact-cleanup:allow next-line` IS.
+has_prev_line_annotation() {
+  case "$1" in
+    *'lint-artifact-cleanup:allow'*) return 0 ;;
   esac
   return 1
 }
@@ -214,7 +234,11 @@ scan_whole_file() {
       continue
     fi
     if match_offender "$line"; then
-      if has_approved_context "$line" || has_approved_context "$prev"; then
+      # Same-line register_artifact / annotation always allowed.
+      # Previous-line annotation (the explicit `# lint-artifact-cleanup:allow`
+      # form) is also allowed — but a bare register_artifact on the previous
+      # line is NOT, since it may register a different artifact.
+      if has_approved_context "$line" || has_prev_line_annotation "$prev"; then
         prev="$line"
         continue
       fi
@@ -260,7 +284,12 @@ scan_staged_diff() {
           [ "$in_hunk" -eq 1 ] || continue
           local content="${dline#+}"
           if ! is_comment_line "$content" && match_offender "$content"; then
-            if ! has_approved_context "$content" && ! has_approved_context "$prev_added"; then
+            # Same as scan_whole_file: same-line register_artifact OR
+            # previous-line `# lint-artifact-cleanup:allow next-line`
+            # annotation are the only carve-outs. A bare register_artifact
+            # on the previous added line is no longer a carve-out (false
+            # negative for unrelated artifacts).
+            if ! has_approved_context "$content" && ! has_prev_line_annotation "$prev_added"; then
               emit_error "E_ARTIFACT_CLEANUP_UNREGISTERED:$f:$new_line:$MATCH_DETAIL | route through scripts/lib-artifact-cleanup.sh \`register_artifact\` or an approved janitor (studio-ios-artifact-janitor / node-janitor / fleet-cleanup / sweep-janitor); per CLAUDE.md §Where workflow rules live"
             fi
           fi

--- a/tests/lint/lib-artifact-cleanup-fixture.sh
+++ b/tests/lint/lib-artifact-cleanup-fixture.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# lib-artifact-cleanup-fixture.sh — behavioral fixture for
+# scripts/lib-artifact-cleanup.sh. Exits non-zero on any miss.
+#
+# Scenarios:
+#   (a) clean on success exit
+#   (b) clean on failure (non-zero exit)
+#   (c) --keep-on-handoff transfers ownership without deletion
+#   (d) STUDIO_KEEP_ARTIFACTS=1 retains everything + emits stderr audit
+#
+# Each scenario runs in its own subshell with HOME pointed at a unique
+# tmpdir and ACHILLES_PROJECT pinned to a synthetic slug, so the
+# resolver layer never touches the user's real durable-state root.
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+LIB="$REPO_ROOT/scripts/lib-artifact-cleanup.sh"
+
+if [ ! -f "$LIB" ]; then
+  printf 'fixture: missing %s\n' "$LIB" >&2
+  exit 2
+fi
+
+FAIL=0
+fail() { printf 'FAIL[%s]: %s\n' "$1" "$2" >&2; FAIL=$((FAIL + 1)); }
+pass() { printf 'pass[%s]: %s\n' "$1" "$2"; }
+
+# Build a sandboxed HOME for one scenario. Returns the path on stdout.
+make_sandbox() {
+  local d
+  d=$(mktemp -d -t lac-fixture-XXXXXX)
+  printf '%s\n' "$d"
+}
+
+# Scenario (a): clean on success exit
+run_a() {
+  local home; home=$(make_sandbox)
+  local artifact="$home/scratch-a"
+  mkdir -p "$artifact"
+  (
+    export HOME="$home"
+    export ACHILLES_PROJECT="lac-fixture"
+    # shellcheck source=/dev/null
+    . "$LIB"
+    register_artifact tmpdir "$artifact"
+    exit 0
+  )
+  if [ -e "$artifact" ]; then
+    fail a "artifact still present after success exit: $artifact"
+  else
+    pass a "artifact removed on success exit"
+  fi
+  rm -rf "$home"
+}
+
+# Scenario (b): clean on failure (non-zero exit)
+run_b() {
+  local home; home=$(make_sandbox)
+  local artifact="$home/scratch-b"
+  mkdir -p "$artifact"
+  (
+    export HOME="$home"
+    export ACHILLES_PROJECT="lac-fixture"
+    # shellcheck source=/dev/null
+    . "$LIB"
+    register_artifact tmpdir "$artifact"
+    exit 17
+  )
+  local rc=$?
+  if [ "$rc" -ne 17 ]; then
+    fail b "exit code not propagated (got $rc, want 17)"
+  fi
+  if [ -e "$artifact" ]; then
+    fail b "artifact still present after failure exit: $artifact"
+  else
+    pass b "artifact removed on failure exit"
+  fi
+  rm -rf "$home"
+}
+
+# Scenario (c): --keep-on-handoff transfers ownership without deletion
+run_c() {
+  local home; home=$(make_sandbox)
+  local artifact="$home/scratch-c"
+  mkdir -p "$artifact"
+  (
+    export HOME="$home"
+    export ACHILLES_PROJECT="lac-fixture"
+    # shellcheck source=/dev/null
+    . "$LIB"
+    register_artifact xcresult "$artifact" --keep-on-handoff
+    exit 0
+  )
+  if [ ! -e "$artifact" ]; then
+    fail c "artifact deleted despite --keep-on-handoff: $artifact"
+  fi
+  local handoff_dir="$home/.dev-studio/lac-fixture/.runtime/state/artifact-cleanup/handoff"
+  if [ ! -d "$handoff_dir" ]; then
+    fail c "handoff dir not created: $handoff_dir"
+  else
+    local count
+    count=$(find "$handoff_dir" -type f -name '*.tsv' | wc -l | tr -d ' ')
+    if [ "$count" -lt 1 ]; then
+      fail c "no handoff record written under $handoff_dir"
+    else
+      # Verify the record names the artifact path.
+      if ! grep -Fq "$artifact" "$handoff_dir"/*.tsv 2>/dev/null; then
+        fail c "handoff record does not reference artifact path"
+      else
+        pass c "handoff record written and artifact retained"
+      fi
+    fi
+  fi
+  rm -rf "$home"
+}
+
+# Scenario (d): STUDIO_KEEP_ARTIFACTS=1 retains everything + emits stderr audit
+run_d() {
+  local home; home=$(make_sandbox)
+  local artifact="$home/scratch-d"
+  mkdir -p "$artifact"
+  local stderr_log="$home/stderr.log"
+  (
+    export HOME="$home"
+    export ACHILLES_PROJECT="lac-fixture"
+    export STUDIO_KEEP_ARTIFACTS=1
+    # shellcheck source=/dev/null
+    . "$LIB"
+    register_artifact tmpdir "$artifact"
+    exit 0
+  ) 2>"$stderr_log"
+  if [ ! -e "$artifact" ]; then
+    fail d "artifact deleted despite STUDIO_KEEP_ARTIFACTS=1: $artifact"
+  fi
+  if ! grep -q 'STUDIO_KEEP_ARTIFACTS=1' "$stderr_log"; then
+    fail d "no stderr audit line emitted (log: $stderr_log)"
+  else
+    pass d "retained artifact and emitted audit line"
+  fi
+  rm -rf "$home"
+}
+
+run_a
+run_b
+run_c
+run_d
+
+if [ "$FAIL" -gt 0 ]; then
+  printf 'lib-artifact-cleanup-fixture: %d failure(s)\n' "$FAIL" >&2
+  exit 1
+fi
+printf 'lib-artifact-cleanup-fixture: all 4 scenarios passed\n'
+exit 0

--- a/tests/lint/lint-artifact-cleanup-fixture.sh
+++ b/tests/lint/lint-artifact-cleanup-fixture.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# lint-artifact-cleanup-fixture.sh — behavioral fixture for
+# scripts/lint-artifact-cleanup.sh (#849, T-R004).
+#
+# Sister to tests/lint/lib-artifact-cleanup-fixture.sh (which exercises the
+# library primitive itself); this fixture exercises the lint gate that
+# blocks new unregistered artifact-producing call sites from accreting on
+# top of the T-R001 baseline.
+#
+# Scenarios:
+#   (a) deliberate offender (mktemp -d, xcodebuild, -derivedDataPath,
+#       git worktree add) is blocked on a whole-file scan
+#   (b) line that registers the artifact via `register_artifact` passes
+#   (c) STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1 exits 0 + emits stderr audit
+#   (d) per-line annotation `# lint-artifact-cleanup:allow next-line` passes
+#   (e) scripts/lib-artifact-cleanup.sh itself passes (resolver/primitive
+#       exempt by rule even when it uses mktemp -d for its registry)
+#   (f) staged-diff mode flags only newly-added lines (pre-existing
+#       offenders in allowlisted files stay invisible)
+
+set -u
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+LINT="$REPO_ROOT/scripts/lint-artifact-cleanup.sh"
+
+if [ ! -x "$LINT" ]; then
+  printf 'fixture: missing or not executable: %s\n' "$LINT" >&2
+  exit 2
+fi
+
+TMP=$(mktemp -d -t lint-artifact-cleanup-fixture.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+FAIL=0
+fail() { printf 'FAIL[%s]: %s\n' "$1" "$2" >&2; FAIL=$((FAIL + 1)); }
+pass() { printf 'pass[%s]: %s\n' "$1" "$2"; }
+
+# -----------------------------------------------------------------------
+# Scenario (a) — deliberate offenders flagged
+# -----------------------------------------------------------------------
+mkdir -p "$TMP/a/scripts"
+cat > "$TMP/a/scripts/offender.sh" <<'SH'
+#!/usr/bin/env bash
+tmp=$(mktemp -d)
+xcodebuild build -scheme Foo
+xcodebuild test -derivedDataPath /tmp/dd -scheme Foo
+git worktree add /tmp/wt origin/main
+SH
+if "$LINT" "$TMP/a/scripts/offender.sh" >"$TMP/a.out" 2>"$TMP/a.err"; then
+  fail a "lint accepted deliberate offender"
+else
+  # Each banned pattern should produce at least one error line.
+  for needle in '`mktemp -d`' '`xcodebuild`' '`-derivedDataPath`' '`git worktree add`'; do
+    if ! grep -Fq "$needle" "$TMP/a.out"; then
+      fail a "missing detail for $needle in lint output"
+    fi
+  done
+  [ "$FAIL" -eq 0 ] && pass a "deliberate offender flagged for all four patterns"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario (b) — register_artifact carve-out passes
+# -----------------------------------------------------------------------
+mkdir -p "$TMP/b/scripts"
+cat > "$TMP/b/scripts/registered.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/lib-artifact-cleanup.sh"
+tmp=$(mktemp -d); register_artifact tmpdir "$tmp"
+# previous-line annotation form also accepted (register_artifact below)
+register_artifact tmpdir "$tmp"
+scratch=$(mktemp -d -t scratch.XXXXXX)
+SH
+if ! "$LINT" "$TMP/b/scripts/registered.sh" >"$TMP/b.out" 2>"$TMP/b.err"; then
+  fail b "lint rejected register_artifact carve-outs"
+  cat "$TMP/b.out" "$TMP/b.err" >&2
+else
+  pass b "register_artifact same-line and previous-line carve-outs accepted"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario (c) — bypass env var exits 0 + emits stderr audit
+# -----------------------------------------------------------------------
+if ! STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1 "$LINT" "$TMP/a/scripts/offender.sh" >"$TMP/c.out" 2>"$TMP/c.err"; then
+  fail c "bypass did not exit 0"
+  cat "$TMP/c.out" "$TMP/c.err" >&2
+elif ! grep -q 'STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1' "$TMP/c.err"; then
+  fail c "bypass did not emit audit line on stderr"
+  cat "$TMP/c.err" >&2
+else
+  pass c "bypass honored with stderr audit line"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario (d) — per-line allow annotation accepted
+# -----------------------------------------------------------------------
+mkdir -p "$TMP/d/scripts"
+cat > "$TMP/d/scripts/annotated.sh" <<'SH'
+#!/usr/bin/env bash
+# lint-artifact-cleanup:allow next-line — one-shot bootstrap scratch dir, removed inline below
+tmp=$(mktemp -d)
+rm -rf "$tmp"
+SH
+if ! "$LINT" "$TMP/d/scripts/annotated.sh" >"$TMP/d.out" 2>"$TMP/d.err"; then
+  fail d "annotated line was flagged"
+  cat "$TMP/d.out" "$TMP/d.err" >&2
+else
+  pass d "per-line annotation accepted"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario (e) — scripts/lib-artifact-cleanup.sh exempt by rule
+# -----------------------------------------------------------------------
+# The real primitive lives at scripts/lib-artifact-cleanup.sh inside the
+# real repo. Sanity check whole-tree scan: --strict against the real repo
+# must not flag the primitive (it may legitimately use mktemp -d for its
+# own registry scratch space).
+if ! "$LINT" --strict >"$TMP/e.out" 2>"$TMP/e.err"; then
+  if grep -q 'scripts/lib-artifact-cleanup\.sh' "$TMP/e.out"; then
+    fail e "primitive scripts/lib-artifact-cleanup.sh was flagged by --strict"
+    grep 'scripts/lib-artifact-cleanup\.sh' "$TMP/e.out" >&2
+  else
+    fail e "--strict failed on the seeded tree (unexpected offender)"
+    cat "$TMP/e.out" "$TMP/e.err" >&2
+  fi
+else
+  pass e "--strict clean on seeded tree; primitive exempt by rule"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario (f) — staged-diff mode flags only newly-added lines
+# -----------------------------------------------------------------------
+REPO="$TMP/f"
+git init -q "$REPO"
+(
+  cd "$REPO"
+  git config user.email "fixture@local"
+  git config user.name  "fixture"
+  mkdir -p scripts
+  # Pre-existing offender — must NOT be flagged once committed.
+  cat > scripts/preexisting.sh <<'SH'
+#!/usr/bin/env bash
+tmp=$(mktemp -d)
+SH
+  git add scripts/preexisting.sh
+  git commit -q -m "seed"
+
+  # Stage 1: edit unrelated line — staged diff should be clean.
+  cat > scripts/preexisting.sh <<'SH'
+#!/usr/bin/env bash
+tmp=$(mktemp -d)
+echo "unrelated edit"
+SH
+  git add scripts/preexisting.sh
+  export LINT_ARTIFACT_CLEANUP_REPO_ROOT="$REPO"
+  if ! "$LINT" --staged >"$TMP/f1.out" 2>"$TMP/f1.err"; then
+    printf 'FAIL[f1]: staged-diff flagged pre-existing mktemp on unrelated edit\n' >&2
+    cat "$TMP/f1.out" "$TMP/f1.err" >&2
+    exit 1
+  fi
+
+  # Stage 2: add a new offender line — staged diff must flag exactly it.
+  cat > scripts/preexisting.sh <<'SH'
+#!/usr/bin/env bash
+tmp=$(mktemp -d)
+echo "unrelated edit"
+xcodebuild build -scheme New
+SH
+  git add scripts/preexisting.sh
+  if "$LINT" --staged >"$TMP/f2.out" 2>"$TMP/f2.err"; then
+    printf 'FAIL[f2]: staged-diff did not flag newly-added xcodebuild\n' >&2
+    cat "$TMP/f2.out" "$TMP/f2.err" >&2
+    exit 1
+  fi
+  grep -q 'E_ARTIFACT_CLEANUP_UNREGISTERED:scripts/preexisting.sh:' "$TMP/f2.out" \
+    || { printf 'FAIL[f2]: did not surface the added line\n' >&2; cat "$TMP/f2.out" >&2; exit 1; }
+  # Pre-existing mktemp on line 2 must NOT be flagged retroactively.
+  if grep -qE 'preexisting.sh:2:' "$TMP/f2.out"; then
+    printf 'FAIL[f2]: pre-existing mktemp was flagged retroactively\n' >&2
+    cat "$TMP/f2.out" >&2
+    exit 1
+  fi
+
+  # Stage 3: add a registered call — staged diff must NOT flag it.
+  cat > scripts/preexisting.sh <<'SH'
+#!/usr/bin/env bash
+tmp=$(mktemp -d)
+echo "unrelated edit"
+scratch=$(mktemp -d); register_artifact tmpdir "$scratch"
+SH
+  git add scripts/preexisting.sh
+  if ! "$LINT" --staged >"$TMP/f3.out" 2>"$TMP/f3.err"; then
+    printf 'FAIL[f3]: staged-diff flagged a newly-added register_artifact carve-out\n' >&2
+    cat "$TMP/f3.out" "$TMP/f3.err" >&2
+    exit 1
+  fi
+) || FAIL=$((FAIL + 1))
+[ "$FAIL" -eq 0 ] && pass f "staged-diff mode honors prior-commit baseline and flags new offenders"
+
+if [ "$FAIL" -gt 0 ]; then
+  printf 'lint-artifact-cleanup-fixture: %d failure(s)\n' "$FAIL" >&2
+  exit 1
+fi
+printf 'lint-artifact-cleanup-fixture: all 6 scenarios passed\n'
+exit 0

--- a/tests/lint/lint-artifact-cleanup-fixture.sh
+++ b/tests/lint/lint-artifact-cleanup-fixture.sh
@@ -61,22 +61,41 @@ else
 fi
 
 # -----------------------------------------------------------------------
-# Scenario (b) — register_artifact carve-out passes
+# Scenario (b) — same-line register_artifact carve-out passes
 # -----------------------------------------------------------------------
 mkdir -p "$TMP/b/scripts"
 cat > "$TMP/b/scripts/registered.sh" <<'SH'
 #!/usr/bin/env bash
 . "$(dirname "$0")/lib-artifact-cleanup.sh"
 tmp=$(mktemp -d); register_artifact tmpdir "$tmp"
-# previous-line annotation form also accepted (register_artifact below)
-register_artifact tmpdir "$tmp"
-scratch=$(mktemp -d -t scratch.XXXXXX)
+# lint-artifact-cleanup:allow next-line — explicit annotation form
+scratch=$(mktemp -d -t scratch.XXXXXX); rm -rf "$scratch"
 SH
 if ! "$LINT" "$TMP/b/scripts/registered.sh" >"$TMP/b.out" 2>"$TMP/b.err"; then
-  fail b "lint rejected register_artifact carve-outs"
+  fail b "lint rejected same-line register_artifact and explicit annotation carve-outs"
   cat "$TMP/b.out" "$TMP/b.err" >&2
 else
-  pass b "register_artifact same-line and previous-line carve-outs accepted"
+  pass b "same-line register_artifact and explicit prev-line annotation accepted"
+fi
+
+# -----------------------------------------------------------------------
+# Scenario (b2) — bare register_artifact on previous line is NOT a carve-out
+# (the false-negative the PR #860 review caught). $scratch is unregistered;
+# lint must reject it even though the line above contains register_artifact
+# for a different artifact.
+# -----------------------------------------------------------------------
+mkdir -p "$TMP/b2/scripts"
+cat > "$TMP/b2/scripts/false-negative.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/lib-artifact-cleanup.sh"
+tmp=$(mktemp -d); register_artifact tmpdir "$tmp"
+scratch=$(mktemp -d -t scratch.XXXXXX)
+SH
+if "$LINT" "$TMP/b2/scripts/false-negative.sh" >"$TMP/b2.out" 2>"$TMP/b2.err"; then
+  fail b2 "lint allowed unregistered \$scratch when previous line had register_artifact for a different artifact"
+  cat "$TMP/b2.out" "$TMP/b2.err" >&2
+else
+  pass b2 "previous-line bare register_artifact is no longer a carve-out (false-negative fixed)"
 fi
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 1 of the studio artifact-cleanup arc. Audits stale-artifact behavior across studio shell-script workflows, ships the shared cleanup primitive + lint gate, files the umbrella + 5 per-surface Phase 2 sub-issues, and documents the new hard rule in `CLAUDE.md`.

Trigger: ~13 stale Xcode DerivedData folders for Turnip-iOS observed after a few days of work-chains. Audit confirmed the leak isn't isolated — ~47 leaks-always call sites across studio scripts, plus ~25 success-only and ~9 janitor-unscheduled.

## What's in this PR

- `e5a4e33` — audit baseline + offender taxonomy (T-R001 / #846)
- `8e3c21f` — shared cleanup primitive `scripts/lib-artifact-cleanup.sh` (T-R003 / #848)
- `d15ea51` — `scripts/lint-artifact-cleanup.sh` + pre-commit gate + allowlist seeded from audit (T-R004 / #849)
- `ed015ff` — issue-tracker registry committed in-repo at `_shared/audits/2026-05-10-artifact-cleanup-issues.md` (T-R002 deliverable; ran from parent session due to chain-runner permission boundary, see #852)
- `fd22f84` — `CLAUDE.md` "Artifact cleanup (hard rule)" section + lint-gate row in workflow rules table (T-R005 / #851)

## Issues opened by this work

- **#854** umbrella — Audit + fix: studio workflows must clean their own artifacts on terminal exit
- **#855–#859** per-surface Phase 2 sub-issues (structural, chain-runner, perf, qa+flow, release/TF)
- **#852** follow-up — `manager-plan-chain` should hydrate worker issue bodies from `task-graph.json` (caught manually here)

## Cross-host review

Plan reviewed twice by `claude-reviewer` (sibling host) before issue creation; both rounds returned `clean` after fix-ups. The chain-runner-driven outcome reviews on #846/#848/#849 also returned `clean`. Recommend cross-host PR review before merge per `CLAUDE.md` §Reviews.

## Test plan

- [ ] `scripts/lint-artifact-cleanup.sh` blocks a deliberately-offending fixture and passes a registered fixture
- [ ] `.githooks/pre-commit` runs the new lint alongside the three existing siblings on a fresh commit
- [ ] `STUDIO_BYPASS_ARTIFACT_CLEANUP_LINT=1` emits expected stderr audit line
- [ ] `lib-artifact-cleanup.sh` fixture exercises clean-on-success / clean-on-failure / keep-on-handoff / `STUDIO_KEEP_ARTIFACTS=1`
- [ ] Sibling-host PR review (`scripts/pr-headless-review.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)