### PR TITLE
Halt on non-200 /relationships/build probe (#824 outcome review)

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T19:35:12Z",
+  "generated_at": "2026-05-10T19:42:21Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T19:35:12Z",
+  "generated_at": "2026-05-10T19:42:20Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -1364,20 +1364,42 @@ cmd_appstore() {
   # Build-mismatch guard: confirm the version's *current* build relationship
   # still points at the build we intend to submit. Catches resume-from-partial
   # cases where another flow swapped the build under us.
-  local cur_build_resp cur_build_id
+  #
+  # #824 outcome review item: an opaque non-2xx on /relationships/build means
+  # we can't *prove* the version is still bound to our build. Treating that
+  # as "no current binding" (cur_build_id empty → skip the != check) would
+  # silently allow a mismatched build to be submitted. Halt instead so the
+  # operator sees the relationship probe itself failed.
+  local cur_build_resp cur_build_status cur_build_id
   cur_build_resp=$(asc_api GET "/v1/appStoreVersions/${version_id}/relationships/build")
+  cur_build_status=$(asc_status "$cur_build_resp")
+  if [ "$cur_build_status" != "200" ]; then
+    halt_failed prereq "ASC: GET /v1/appStoreVersions/${version_id}/relationships/build returned HTTP ${cur_build_status:-unknown}; refusing to submit without a verifiable build binding"
+  fi
   cur_build_id=$(asc_body "$cur_build_resp" | jq -r '.data.id // empty')
   if [ -n "$cur_build_id" ] && [ "$cur_build_id" != "$build_id" ]; then
     halt_failed prereq "ASC: appStoreVersion ${version_id} is bound to build ${cur_build_id}, not ${build_id} (build $BUILD); refusing to submit a mismatched build"
   fi
 
   # Idempotent pre-check: does an appStoreVersionSubmission already exist?
+  # Non-2xx on this GET is informative but not fatal — Apple sometimes
+  # returns 4xx for "no submission relationship" (a legitimate "not found")
+  # and the POST below treats absence-or-error symmetrically by attempting
+  # to create. Just log unexpected statuses for postmortem.
   local sub_pre_resp sub_pre_status sub_id=""
   sub_pre_resp=$(asc_api GET "/v1/appStoreVersions/${version_id}/relationships/appStoreVersionSubmission")
   sub_pre_status=$(asc_status "$sub_pre_resp")
-  if [ "$sub_pre_status" = "200" ]; then
-    sub_id=$(asc_body "$sub_pre_resp" | jq -r '.data.id // empty')
-  fi
+  case "$sub_pre_status" in
+    200)
+      sub_id=$(asc_body "$sub_pre_resp" | jq -r '.data.id // empty')
+      ;;
+    404)
+      : # No submission yet — expected state for a fresh version.
+      ;;
+    *)
+      printf 'studio-tf-push: warning: GET /relationships/appStoreVersionSubmission returned HTTP %s (continuing — POST will create)\n' "$sub_pre_status" >&2
+      ;;
+  esac
 
   if [ -n "$sub_id" ]; then
     printf 'studio-tf-push: ASC submission already exists for version %s: %s — reusing\n' "$VERSION" "$sub_id" >&2

--- a/scripts/test-fixtures/824-appstore-submission/test-appstore-submission.sh
+++ b/scripts/test-fixtures/824-appstore-submission/test-appstore-submission.sh
@@ -92,6 +92,16 @@ asc_api() {
       printf '201\n{"data":{"id":"SHOULD-NOT-REACH"}}\n'
       ;;
 
+    # Build-probe failure: the /relationships/build GET itself returns
+    # non-200. We can't prove the version is bound to our build, so the
+    # submission must halt rather than blindly proceed.
+    probefail::GET::*/relationships/build) printf '503\n{"errors":[{"status":"503","detail":"upstream timeout"}]}\n' ;;
+    probefail::GET::*/relationships/appStoreVersionSubmission) printf '404\n{}\n' ;;
+    probefail::POST::/v1/appStoreVersionSubmissions)
+      touch "$TMPROOT/probefail_post_was_called"
+      printf '201\n{"data":{"id":"SHOULD-NOT-REACH"}}\n'
+      ;;
+
     *) printf '500\n{"errors":[{"detail":"unstubbed scenario %s"}]}\n' "$ASC_SCENARIO::$method::$path" ;;
   esac
 }
@@ -124,8 +134,13 @@ run_submission() {
   rm -f "$TMPROOT/post_was_called" "$TMPROOT/post_attempted" "$TMPROOT/mismatch_post_was_called"
 
   local version_id="VER-1" build_id="BUILD-123"
-  local cur_build_resp cur_build_id
+  local cur_build_resp cur_build_status cur_build_id
   cur_build_resp=$(asc_api GET "/v1/appStoreVersions/${version_id}/relationships/build")
+  cur_build_status=$(asc_status "$cur_build_resp")
+  if [ "$cur_build_status" != "200" ]; then
+    halt_failed prereq "ASC: /relationships/build probe returned HTTP $cur_build_status; refusing to submit without a verifiable build binding"
+    return 1
+  fi
   cur_build_id=$(asc_body "$cur_build_resp" | jq -r '.data.id // empty')
   if [ -n "$cur_build_id" ] && [ "$cur_build_id" != "$build_id" ]; then
     halt_failed prereq "ASC: appStoreVersion ${version_id} is bound to build ${cur_build_id}, not ${build_id}"
@@ -191,6 +206,14 @@ assert "build mismatch does NOT POST" \
   '! [ -f "$TMPROOT/mismatch_post_was_called" ]'
 assert "build mismatch reason names the wrong build" \
   'printf %s "$HALT_DETAIL" | grep -q "BUILD-OTHER-999"'
+
+# Build-probe non-200: halt without submitting.
+ASC_SCENARIO=probefail run_submission && rc=0 || rc=$?
+assert "build-probe non-200 halts non-zero" '[ "$rc" -ne 0 ]'
+assert "build-probe non-200 does NOT POST" \
+  '! [ -f "$TMPROOT/probefail_post_was_called" ]'
+assert "build-probe non-200 reason names the http status" \
+  'printf %s "$HALT_DETAIL" | grep -q "503"'
 
 if [ "$fail" -gt 0 ]; then
   printf 'FAIL: %d test(s) failed\n' "$fail" >&2


### PR DESCRIPTION
## Summary

Codex outcome review on #824 noted: the build-mismatch guard ignores non-200 responses from `GET /relationships/build`. If that probe fails and the submission pre-check returns an existing submission, the flow could report success without proving the version is still bound to the intended build.

This PR captures the HTTP status from the relationship GET and halts when it's anything other than 200. The probe IS the proof; if it can't run, we refuse to submit.

The `/relationships/appStoreVersionSubmission` GET is treated more liberally: 404 is expected (no submission yet), other non-2xx is logged but not fatal (the POST below creates or fails honestly).

## Test plan

- [x] `bash scripts/test-fixtures/824-appstore-submission/test-appstore-submission.sh` → 14/14 cases pass. New `probefail` scenario (503 on relationships/build) asserts: halt non-zero, POST not called, halt reason names the HTTP status.
- [x] All four lints clean.

Refs #824