### PR TITLE
feature: seed isolated codex-reviewer auth home (closes #866)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ Add to `~/.claude/settings.json` under `permissions.allow`:
 
 Optional node monitoring installs `~/Library/LaunchAgents/dev.studio.node-monitor.plist` via `scripts/monitor-install.sh install`. Optional chain monitor background sync installs `~/Library/LaunchAgents/dev.studio.chain-monitor-sync.<project>.plist` via `scripts/schedule-chain-monitor.sh --install`. Those paths are outside `~/.dev-studio/**` by design because launchd only loads user agents from `~/Library/LaunchAgents`.
 
+Optional isolated codex-reviewer auth lives at `~/.codex-reviewer/`. It is created by `scripts/studio-codex-reviewer-bootstrap.sh` (closes #866) and populated by a one-time `CODEX_HOME=~/.codex-reviewer codex login`. Lives outside `~/.dev-studio/**` because the codex CLI resolves auth via `$CODEX_HOME` (and `lib-studio-context.sh` mirrors that lookup at `$HOME/.codex-reviewer`); routing it under `~/.dev-studio` would diverge from the codex convention without buying isolation. When present, `phase-review.sh` and `pr-reviewer-eligibility.sh` switch codex-reviewer to the full-isolation branch (HOME=tmpdir, CODEX_HOME=~/.codex-reviewer); when absent, they fall back to PR #829's no-isolation behavior.
+
 ### Codex Permissions
 
 Codex needs the same runtime root in its workspace-write sandbox. Launch with an explicit writable root:

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ scripts/                # multi-worker fleet (BETA)
   studio-staleness-triage.sh # scheduled GitHub issue staleness labels + escalation comments for the PM surface
   host-preflight.sh    # pre-task host parity gate: gh auth, git ls-remote credential access, and ShellCheck availability
   studio-gh.sh          # GitHub CLI wrapper for assistant/interactive calls; uses context github_home for auth
+  studio-codex-reviewer-bootstrap.sh # seed ~/.codex-reviewer/ for full HOME-isolated codex-reviewer (closes #866); --verify, --force
   manager-feature-config.sh # /dev-studio manager config: project-scoped feature enable/disable/set/list/doctor
   manager-release-branch.sh # /dev-studio manager branch: release branch status/prepare/sync/PR preflight
   dev-studio-ingest-resolve.sh # resolves /dev-studio manager ingest destination as JSON

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-11T12:07:29Z",
+  "generated_at": "2026-05-11T12:10:45Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-11T12:01:52Z",
+  "generated_at": "2026-05-11T12:07:29Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-10T19:59:59Z",
+  "generated_at": "2026-05-11T12:01:52Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T19:59:59Z",
+  "generated_at": "2026-05-11T12:01:52Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-11T12:01:52Z",
+  "generated_at": "2026-05-11T12:07:29Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-11T12:07:29Z",
+  "generated_at": "2026-05-11T12:10:45Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -219,6 +219,7 @@ scripts/feedback-retroactive-sweep.sh --project generic-dev-studio --since YYYY-
 
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer preflight + real verdict-emitting smoke gate
+scripts/studio-codex-reviewer-bootstrap.sh              # one-time seed of ~/.codex-reviewer/ for full HOME-isolation in codex-reviewer (closes #866); --verify, --force
 scripts/pr-reviewer-eligibility.sh claude-reviewer      # same reviewer floor for Claude Code; uses CLAUDE_REVIEWER_HOME + CLAUDE_REVIEWER_CONFIG_DIR
 scripts/phase-review.sh --review-host claude-reviewer --input phase-plan.md --output review.md   # sibling-host phase gate; tries alternate cross-host reviewers, then degraded same-host continuity when needed
 scripts/pre-commit-review.sh                            # manual reviewer gate for risky staged diffs; accepts approved/approved_with_fixes only

--- a/scripts/studio-codex-reviewer-bootstrap.sh
+++ b/scripts/studio-codex-reviewer-bootstrap.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# studio-codex-reviewer-bootstrap.sh — seed an isolated codex auth home for
+# the codex-reviewer profile.
+#
+# Background: PR #829 traded reviewer isolation for working cross-host review
+# under codex ChatGPT-OAuth (which 401s when HOME or CODEX_HOME is overridden
+# against an un-seeded `.codex/`). When `~/.codex-reviewer/` exists with its
+# own auth state, `scripts/lib-studio-context.sh` resolves codex-reviewer's
+# auth_home to it and the eligibility/phase-review wrappers take the
+# full-isolation branch (HOME=tmpdir, CODEX_HOME=~/.codex-reviewer). This
+# script creates that directory and walks the user through a one-time
+# `codex login` to populate it.
+#
+# Why this needs a human step: codex 0.130+ ChatGPT-OAuth state is not
+# file-copyable from `~/.codex/` — see issue #866 for the experimental
+# findings. The only known path to seeded reviewer auth is a fresh
+# `codex login` performed under the isolated CODEX_HOME.
+#
+# Usage:
+#   scripts/studio-codex-reviewer-bootstrap.sh           # interactive
+#   scripts/studio-codex-reviewer-bootstrap.sh --verify  # only re-run the smoke
+#   scripts/studio-codex-reviewer-bootstrap.sh --force   # re-seed even if dir exists
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib-studio-context.sh
+. "$SCRIPT_DIR/lib-studio-context.sh"
+
+mode="bootstrap"
+force=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --verify) mode="verify" ;;
+    --force) force=1 ;;
+    -h|--help)
+      sed -n '2,25p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+login_home="$(_studio_context_login_home)" || {
+  echo "fatal: could not resolve login HOME" >&2
+  exit 1
+}
+reviewer_home="$login_home/.codex-reviewer"
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "fatal: codex CLI not on PATH; install from https://github.com/openai/codex" >&2
+  exit 1
+fi
+
+run_smoke() {
+  echo "→ Running reviewer eligibility smoke (codex-reviewer)..."
+  if "$SCRIPT_DIR/pr-reviewer-eligibility.sh" codex-reviewer; then
+    echo "✓ codex-reviewer eligible — isolation working."
+    return 0
+  fi
+  echo "✗ smoke failed. The isolated CODEX_HOME exists but auth did not survive." >&2
+  echo "  Common causes:" >&2
+  echo "    - codex login completed but stored credentials in the user keychain" >&2
+  echo "      rather than under \$CODEX_HOME. This is the failure mode documented" >&2
+  echo "      in issue #866; remediation requires a separate OpenAI account in a" >&2
+  echo "      fresh browser session." >&2
+  echo "    - You ran 'codex login' without CODEX_HOME pointing at $reviewer_home." >&2
+  return 1
+}
+
+if [ "$mode" = "verify" ]; then
+  [ -d "$reviewer_home" ] || { echo "no $reviewer_home; run without --verify first" >&2; exit 1; }
+  run_smoke
+  exit $?
+fi
+
+if [ -d "$reviewer_home" ] && [ "$force" -eq 0 ]; then
+  echo "→ $reviewer_home already exists. Verifying instead of re-seeding."
+  echo "  (use --force to wipe and re-seed)"
+  run_smoke
+  exit $?
+fi
+
+if [ "$force" -eq 1 ] && [ -d "$reviewer_home" ]; then
+  echo "→ --force: removing existing $reviewer_home"
+  rm -rf "$reviewer_home"
+fi
+
+mkdir -p "$reviewer_home"
+chmod 700 "$reviewer_home"
+echo "✓ Created $reviewer_home (mode 700)"
+echo
+echo "Next: log in to codex under the isolated CODEX_HOME."
+echo
+echo "  In a NEW terminal (or after exiting this one), run:"
+echo
+echo "    CODEX_HOME=$reviewer_home codex login"
+echo
+echo "  Follow the browser prompt. For real isolation from your primary codex"
+echo "  identity, sign in with a SEPARATE OpenAI account (fresh browser profile"
+echo "  or private window). Same-account concurrent sessions may or may not be"
+echo "  permitted by codex — try same-account first; if the smoke 401s, retry"
+echo "  with a separate account."
+echo
+echo "When 'codex login' completes, re-run:"
+echo
+echo "    $0 --verify"
+echo

--- a/scripts/studio-codex-reviewer-bootstrap.sh
+++ b/scripts/studio-codex-reviewer-bootstrap.sh
@@ -24,7 +24,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck source=lib-studio-context.sh
 . "$SCRIPT_DIR/lib-studio-context.sh"


### PR DESCRIPTION
## Summary

- Adds `scripts/studio-codex-reviewer-bootstrap.sh` to seed `~/.codex-reviewer/` and walk the user through a one-time `codex login` under that isolated `CODEX_HOME`.
- Restores the original full-isolation design for codex-reviewer (`HOME=tmpdir`, `CODEX_HOME=~/.codex-reviewer`) that PR #829 had to disable to keep cross-host review working.
- Closes #866 — the wrapper code in `phase-review.sh` / `pr-reviewer-eligibility.sh` / `lib-studio-context.sh` was already ready; the missing piece was seeding the isolated home, since #866 proved file-copying `~/.codex/` doesn't work.

## Verified

Same OpenAI account, concurrent session on this machine:

```
$ scripts/studio-codex-reviewer-bootstrap.sh --verify
→ Running reviewer eligibility smoke (codex-reviewer)...
PR_REVIEWER_ELIGIBLE=1
SMOKE=passed
✓ codex-reviewer eligible — isolation working.
```

## Test plan

- [x] Bootstrap creates `~/.codex-reviewer/` with mode 700
- [x] User can `codex login` under `CODEX_HOME=~/.codex-reviewer`
- [x] `pr-reviewer-eligibility.sh codex-reviewer` returns `SMOKE=passed` with full isolation
- [ ] Next cross-host `phase-review.sh --review-host codex-reviewer` round-trips clean

Closes #866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)