### PR TITLE
Clean release TestFlight artifacts on exit

### DIFF
--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -154,7 +154,7 @@ No event emitted at the commit boundary; the next event closes the archive phase
 
 ### Step 4 — Archive
 
-Run `xcodebuild archive` against the project, scheme, and configuration declared in `turnip-project-config.md`. The archive lands at `/tmp/<SCHEME>-<NEW_BUILD_NUMBER>.xcarchive`.
+Run `xcodebuild archive` against the project, scheme, and configuration declared in `turnip-project-config.md`. The archive lands at `/tmp/<SCHEME>-<NEW_BUILD_NUMBER>.xcarchive` and is registered with the shared artifact-cleanup primitive for delete-on-exit. Operators who need postmortem retention set `STUDIO_KEEP_ARTIFACTS=1`; otherwise the path in events and context is an in-run diagnostic pointer, not a durable handoff artifact.
 
 When running in background mode, write `prepared-context.json` after Step 2 and before this archive starts. The file carries `release_tag`, `build`, `version`, `scheme`, `branch`, `archive_path`, `tf_tag`, and `prev_build`, allowing the wrapper to draft the Slack message while archive/upload continue. The wrapper must still wait for final `status.json` to reach `state=="succeeded"` before sending Slack.
 
@@ -168,7 +168,7 @@ Emit `archive_completed` with `data: { build: NEW_BUILD_NUMBER, version, scheme,
 
 ### Step 5 — Export and upload
 
-Write a transient `ExportOptions.plist` with `method=app-store-connect`, `destination=upload`, `signingStyle=automatic`. Run `xcodebuild -exportArchive` against the archive with the same repo-local keychain flag used for archive. The plist's `destination=upload` means xcodebuild posts the build directly to ASC — there is no separate upload step and no local IPA.
+Write a transient `ExportOptions.plist` with `method=app-store-connect`, `destination=upload`, `signingStyle=automatic`. Run `xcodebuild -exportArchive` against the archive with the same repo-local keychain flag used for archive. The export plist, export log, and export directory are registered with the shared artifact-cleanup primitive. The plist's `destination=upload` means xcodebuild posts the build directly to ASC — there is no separate upload step and no local IPA.
 
 Do not pipe this command through `xcpretty`. The raw output is short and load-bearing for diagnosis.
 

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-11T12:10:45Z",
+  "generated_at": "2026-05-11T12:45:11Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-11T12:10:45Z",
+  "generated_at": "2026-05-11T12:45:11Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lint-artifact-cleanup-allowlist.txt
+++ b/scripts/lint-artifact-cleanup-allowlist.txt
@@ -65,7 +65,6 @@ scripts/studio-checkpoint.sh
 scripts/studio-ios-check-failover.sh
 scripts/studio-ios-check-router.sh
 scripts/studio-pr-baseline-report.sh
-scripts/studio-tf-push.sh
 scripts/studio-weekly.sh
 scripts/swift-test-gate.sh
 scripts/sync-worker.sh

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -83,6 +83,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 . "$SCRIPT_DIR/lib-build-queue.sh"
 # shellcheck source=lib-release-config.sh
 . "$SCRIPT_DIR/lib-release-config.sh"
+# shellcheck source=lib-artifact-cleanup.sh
+. "$SCRIPT_DIR/lib-artifact-cleanup.sh"
 
 if [ "${1:-}" = "compose-message" ]; then
   shift
@@ -1008,6 +1010,7 @@ EOF
   # jump ahead of queued Achilles task builds without preempting in-flight
   # ones (#267). Priority=release → rank 0 → sorts before task (rank 1).
   local ARCHIVE_PATH="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}.xcarchive"
+  [ "$DRY_RUN_FLAG" = "1" ] || register_artifact xcarchive "$ARCHIVE_PATH"
   local TF_TAG
   TF_TAG=$(tf_tag_name "$VERSION" "$NEW_BUILD_NUMBER") || halt_failed prereq "could not derive TF tag for version=$VERSION build=$NEW_BUILD_NUMBER"
   if [ -n "${STUDIO_TF_PUSH_PREPARED_CONTEXT_PATH:-}" ]; then
@@ -1027,12 +1030,30 @@ EOF
   local archive_started_at archive_duration_s=0
   archive_started_at=$(date +%s)
 
-  local _bq_dir _bq_entry="" _bq_lock="" _bq_slots=1
+  local _bq_dir _bq_entry="" _bq_lock="" _bq_slots=1 _bq_role="xcodebuild"
+  _tf_push_finalize() {
+    bq_release_slot_lock "${_bq_lock:-}"
+    _bq_lock=""
+    bq_release "${_bq_entry:-}"
+    _bq_entry=""
+    finalize_artifacts
+  }
+  _tf_push_signal_finalize() {
+    local rc="$1"
+    trap - EXIT INT TERM
+    _tf_push_finalize
+    exit "$rc"
+  }
+  if [ "$DRY_RUN_FLAG" != "1" ]; then
+    trap _tf_push_finalize EXIT
+    trap '_tf_push_signal_finalize 130' INT
+    trap '_tf_push_signal_finalize 143' TERM
+  fi
   _bq_dir="$(resolve_runtime_global)/build-queue/$NODE"
   if [ "$DRY_RUN_FLAG" != "1" ] && [ "${STUDIO_TF_PUSH_SKIP_NODE_PICK:-0}" != "1" ]; then
     _bq_slots=$(bq_node_slots "$NODE")
     _bq_entry=$(STUDIO_BUILD_PRIORITY=release bq_enqueue "$_bq_dir" \
-      "release-${NEW_BUILD_NUMBER}" release xcodebuild asc,slack) \
+      "release-${NEW_BUILD_NUMBER}" release "$_bq_role" asc,slack) \
       || halt_failed prereq "build-queue enqueue failed"
     local _bq_depth _bq_position _bq_queue_data
     _bq_depth=$(find "$_bq_dir" -maxdepth 1 -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
@@ -1044,7 +1065,6 @@ EOF
     _bq_queue_data=$(printf '{"mode":"archive","node":"%s","position":%s,"depth":%s,"slots":%s,"priority":"release","secret_scope":"asc,slack"}' \
       "$NODE" "$_bq_position" "$_bq_depth" "$_bq_slots")
     emit_event_keyed studio release build_queue_position "$RELEASE_TAG" "$_bq_queue_data" >/dev/null 2>&1 || true
-    trap 'bq_release_slot_lock "${_bq_lock:-}"; bq_release "${_bq_entry:-}"' EXIT INT TERM
     bq_wait "$_bq_dir" "$_bq_entry" "$_bq_slots" 1800 "$RELEASE_TAG" "$NODE" studio release \
       || halt_failed prereq "build-queue wait timed out"
     _bq_lock=$(bq_acquire_slot_lock "$(resolve_runtime_global)/xcodebuild-lock/$NODE" "$_bq_slots" 1800) \
@@ -1056,9 +1076,11 @@ EOF
       "$SCHEME" "$NEW_BUILD_NUMBER" "$ARCHIVE_PATH" >&2
   else
     local archive_log="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-archive.log"
+    register_artifact log "$archive_log"
     (
       HOME="$SIGNING_HOME"
       cd "$PROJECT_ROOT" || exit 1
+      # lint-artifact-cleanup:allow next-line — xcarchive/log registered above; shared finalizer handles EXIT/INT/TERM.
       xcodebuild archive \
         -project "$PROJECT_RELPATH" \
         -scheme "$SCHEME" \
@@ -1101,6 +1123,7 @@ EOF
     printf 'studio-tf-push: [dry-run] would export + upload build %s to ASC\n' "$NEW_BUILD_NUMBER" >&2
   else
     local export_plist="/tmp/ExportOptions-${NEW_BUILD_NUMBER}.plist"
+    register_artifact plist "$export_plist"
     cat > "$export_plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1116,9 +1139,13 @@ EOF
 </plist>
 PLIST
     local export_log="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-export.log"
+    local export_dir="/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-export"
+    register_artifact log "$export_log"
+    register_artifact export-dir "$export_dir"
+    # lint-artifact-cleanup:allow next-line — export plist/log/dir and xcarchive registered above; shared finalizer handles EXIT/INT/TERM.
     if ! HOME="$SIGNING_HOME" xcodebuild -exportArchive \
         -archivePath "$ARCHIVE_PATH" \
-        -exportPath "/tmp/${SCHEME}-${NEW_BUILD_NUMBER}-export" \
+        -exportPath "$export_dir" \
         -exportOptionsPlist "$export_plist" \
         -allowProvisioningUpdates \
         -authenticationKeyPath "$ASC_KEY_PATH" \

--- a/scripts/test-fixtures/288-tf-push/run.sh
+++ b/scripts/test-fixtures/288-tf-push/run.sh
@@ -97,6 +97,23 @@ done
 echo "PASS: background handle + prepared/final context"
 
 echo
+echo "=== Test 2c: registered release artifacts finalize on process exit ==="
+cleanup_archive="$TMPHOME/cleanup-default.xcarchive"
+mkdir -p "$cleanup_archive"
+bash -c '. "$1/scripts/lib-artifact-cleanup.sh"; register_artifact xcarchive "$2"' _ "$REPO" "$cleanup_archive"
+[ ! -e "$cleanup_archive" ] || { echo "FAIL: registered archive was not deleted"; exit 1; }
+
+keep_archive="$TMPHOME/cleanup-keep.xcarchive"
+mkdir -p "$keep_archive"
+STUDIO_KEEP_ARTIFACTS=1 bash -c '. "$1/scripts/lib-artifact-cleanup.sh"; register_artifact xcarchive "$2"' _ "$REPO" "$keep_archive" \
+  2>"$TMPHOME/keep-artifacts.err"
+[ -d "$keep_archive" ] || { echo "FAIL: STUDIO_KEEP_ARTIFACTS did not retain archive"; exit 1; }
+grep -q 'STUDIO_KEEP_ARTIFACTS=1' "$TMPHOME/keep-artifacts.err" \
+  || { echo "FAIL: missing keep-artifacts audit line"; cat "$TMPHOME/keep-artifacts.err"; exit 1; }
+rm -rf "$keep_archive"
+echo "PASS: register_artifact deletes by default and honors STUDIO_KEEP_ARTIFACTS"
+
+echo
 echo "=== Test 3: emit subcommand reuses release-tag ==="
 "$REPO/scripts/studio-tf-push.sh" emit slack_drafted --release-tag "$RT" \
   --data '{"build":1,"channel":"#testing","bullet_count":0,"cc_count":0}' >/dev/null


### PR DESCRIPTION
## Summary

- registers release/TestFlight archive, export plist/log, archive log, and export dir with the shared artifact cleanup primitive
- composes build-queue release with artifact finalization on EXIT/INT/TERM
- documents that archive_path is an in-run diagnostic pointer unless STUDIO_KEEP_ARTIFACTS=1 is set
- adds synthetic fixture coverage for default deletion and STUDIO_KEEP_ARTIFACTS retention
- removes scripts/studio-tf-push.sh from the artifact-cleanup allowlist

## Verification

- phase plan review: clean, cross-host satisfied
- phase outcome review: clean, cross-host satisfied
- scripts/lint-artifact-cleanup.sh scripts/studio-tf-push.sh
- scripts/lint-artifact-cleanup.sh --strict
- scripts/lint-artifact-cleanup.sh --staged
- scripts/lint-runtime-paths.sh --staged
- scripts/lint-synthetic-home.sh --staged
- scripts/lint-gh-wrapper.sh --staged
- bash scripts/test-fixtures/288-tf-push/run.sh
- bash -n scripts/studio-tf-push.sh scripts/test-fixtures/288-tf-push/run.sh
- pre-commit hook via git commit / amend

## Notes

The pre-commit hook regenerated timestamp-only changes in docs-surface.json and _shared/schemas/capability-manifest.json.

Whole-file runtime-path and synthetic-home lints still report pre-existing lines outside this slice; staged gates are clean.

Closes #859.