### PR TITLE
Add Project board issue filing flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,7 @@ The canonical actionable backlog is the GitHub Projects v2 board documented in
 (track, phase, size, sibling-review status, and table/board/roadmap views);
 GitHub issues remain the durable work items behind each row.
 
-When the user agrees on new work in chat (explicitly: "let's do X", "let's plan Y for later") — **open a GitHub issue** via `scripts/studio-gh.sh issue create` with the appropriate label (`phase-2`, `roadmap`, `enhancement`, `bug`, `polish`). No need to ask permission for items the user has explicitly discussed and agreed to.
+When the user agrees on new work in chat (explicitly: "let's do X", "let's plan Y for later") — **open a GitHub issue** via `scripts/studio-gh-issue-new.sh` with the appropriate label (`phase-2`, `roadmap`, `enhancement`, `bug`, `polish`) so it is also added to the Studio v2 Project board. Use `scripts/studio-gh.sh issue create` only for narrow recovery/debug cases where Project writes are intentionally out of scope. No need to ask permission for items the user has explicitly discussed and agreed to.
 
 When work lands on `main` that closes an issue, close the issue with a one-line note pointing at the commit/PR.
 

--- a/PM-SURFACE.md
+++ b/PM-SURFACE.md
@@ -23,6 +23,9 @@ Agents that need backlog state MUST read the Project board through:
 
 ```bash
 scripts/studio-project-state.sh [--json] [--search "<keywords>"] [--status "<Status>"]
+scripts/studio-project-state.sh --by-track
+scripts/studio-project-state.sh --by-phase
+scripts/studio-project-state.sh --needs-review
 ```
 
 This reader returns issue identity plus the Project fields that decide backlog
@@ -31,6 +34,26 @@ flow: `Status`, `Track`, `Phase`, `Size`, and `Sibling host reviewed`. Raw
 but it is not sufficient for backlog planning because it cannot see Project
 fields.
 
+## Project Writer Contract
+
+Studio issue filing should use the Project-aware helper:
+
+```bash
+scripts/studio-gh-issue-new.sh --title "..." --body-file issue.md --label enhancement
+```
+
+The helper wraps `scripts/studio-gh.sh issue create`, then calls
+`scripts/studio-project-add.sh` so the issue lands on the Studio v2 transition
+board. `scripts/studio-project-add.sh <issue-number|issue-url>` is also the
+reusable primitive for adding existing issues to the board and setting
+`Status`, `Track`, `Phase`, `Size`, and `Sibling host reviewed`.
+
+Defaults are conservative: `Status=Todo` and
+`Sibling host reviewed=Not required`. `Track` is inferred only from labels with
+an unambiguous Project mapping, such as `track:pm-surface`, `track:apollo`, and
+`track:forge-safety`; otherwise pass `--track` explicitly. Missing Project
+write permission is a hard error, not a silent fallback.
+
 Mode expectations:
 
 | Flow | Project-state use |
@@ -38,6 +61,7 @@ Mode expectations:
 | `studio/guard` | G3 duplicate/backlog hits come from `scripts/studio-project-state.sh --search`, not raw issue search. |
 | `studio/audit` | A4 verifies the current v2 parent arcs are present on the board with required Project fields populated. |
 | Chanakya triage/backlog flows | Before shaping studio backlog work, read this Project state and preserve the Project fields in any surfaced candidate list. |
+| Studio issue creation | Use `scripts/studio-gh-issue-new.sh` so agreed work lands on the board at creation time. |
 
 ## Field Contract
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ scripts/                # multi-worker fleet (BETA)
   manager-analyze.sh    # /dev-studio manager analyze: studio-checkout analysis + feedback triage
   ingest-feedback.sh    # routes studio-feedback records to analysis + GH issue create/comment/defer
   analyze-feedback-ingest.sh # studio feedback triage: consolidate into existing/new GH issues before processed/
+  studio-project-state.sh # Project board reader; supports --status, --search, --by-track, --by-phase, --needs-review
+  studio-project-add.sh # add/update an issue on the Studio v2 Project board with planning fields
+  studio-gh-issue-new.sh # create a Studio issue and add it to the Project board
   detect-edits.sh       # sweep-time blind-spot detector — brief_edited + debrief_edited
   compose-build-release-message.sh # taxonomy-aware TestFlight/App Store bullet composer
   appstore-watch.sh     # polls ASC; publishes release + promotes PR only at READY_FOR_SALE after release approval is recorded

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -230,6 +230,9 @@ scripts/manager-analyze.sh --cwd "$PWD"                 # studio repo: telemetry
 scripts/ingest-feedback.sh                              # idempotent feedback route: create/comment/defer; silent outside generic-dev-studio
 scripts/analyze-feedback-ingest.sh --apply              # studio-feedback durable routing: search/comment/create, then processed/
 scripts/feedback-retroactive-sweep.sh --project generic-dev-studio --since YYYY-MM-DD [--apply] # recover missed `(studio-feedback)` / `(studio feedback)` transcript prompts
+scripts/studio-project-state.sh --by-track              # read Studio v2 Project board grouped by Track
+scripts/studio-project-add.sh 123 --track "B PM surface" # add/update an issue on the Studio v2 Project board
+scripts/studio-gh-issue-new.sh --title "..." --body-file issue.md # create a Studio issue and add it to the Project board
 
 # Studio PR autopilot primitives (#318):
 scripts/pr-reviewer-eligibility.sh codex-reviewer       # no-prompt/no-secret reviewer preflight + real verdict-emitting smoke gate

--- a/scripts/lib-project-board.sh
+++ b/scripts/lib-project-board.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Shared helpers for Studio GitHub Projects v2 reads/writes.
+
+project_board_script_dir() {
+  cd "$(dirname "${BASH_SOURCE[0]}")" && pwd
+}
+
+PROJECT_BOARD_SCRIPT_DIR="${PROJECT_BOARD_SCRIPT_DIR:-$(project_board_script_dir)}"
+
+project_board_repo_slug_from_git() {
+  local remote
+  remote=$(git remote get-url origin 2>/dev/null || true)
+  case "$remote" in
+    git@github.com:*)
+      remote=${remote#git@github.com:}
+      remote=${remote%.git}
+      ;;
+    https://github.com/*)
+      remote=${remote#https://github.com/}
+      remote=${remote%.git}
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$remote"
+}
+
+project_board_issue_number_from_ref() {
+  local ref="$1"
+  case "$ref" in
+    *github.com/*/issues/[0-9]*)
+      ref=${ref##*/issues/}
+      ref=${ref%%[^0-9]*}
+      ;;
+    \#*)
+      ref=${ref#\#}
+      ;;
+  esac
+  case "$ref" in
+    ''|*[!0-9]*) return 1 ;;
+    *) printf '%s\n' "$ref" ;;
+  esac
+}
+
+project_board_repo_slug_from_issue_url() {
+  local ref="$1" slug
+  case "$ref" in
+    https://github.com/*/*/issues/[0-9]*)
+      slug=${ref#https://github.com/}
+      slug=${slug%/issues/*}
+      printf '%s\n' "$slug"
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+project_board_issue_url() {
+  local repo_slug="$1" issue_number="$2"
+  printf 'https://github.com/%s/issues/%s\n' "$repo_slug" "$issue_number"
+}
+
+project_board_issue_labels_json() {
+  local repo_slug="$1" issue_number="$2"
+  "$PROJECT_BOARD_SCRIPT_DIR/studio-gh.sh" issue view "$issue_number" \
+    --repo "$repo_slug" \
+    --json labels |
+    jq -c '[.labels[].name]'
+}
+
+project_board_infer_track_from_labels() {
+  jq -r '
+    def mapped:
+      if . == "track:pm-surface" then "B PM surface"
+      elif . == "track:apollo" then "v1 apollo"
+      elif . == "track:forge-safety" then "v1 forge-safety"
+      else empty
+      end;
+    [ .[] | mapped ] | unique
+    | if length == 1 then .[0] else "" end
+  '
+}
+
+project_board_field_id() {
+  local fields_file="$1" field_name="$2"
+  jq -r --arg field "$field_name" '
+    (.fields // .)[]?
+    | select(.name == $field)
+    | .id
+  ' "$fields_file" | head -1
+}
+
+project_board_field_option_id() {
+  local fields_file="$1" field_name="$2" value="$3"
+  jq -r --arg field "$field_name" --arg value "$value" '
+    (.fields // .)[]?
+    | select(.name == $field)
+    | (.options // [])[]?
+    | select(.name == $value)
+    | .id
+  ' "$fields_file" | head -1
+}
+
+project_board_existing_item_id() {
+  local repo_slug="$1" issue_number="$2" project_owner="$3" project_number="$4"
+  local repo_owner repo_name
+  repo_owner=${repo_slug%%/*}
+  repo_name=${repo_slug#*/}
+
+  "$PROJECT_BOARD_SCRIPT_DIR/studio-gh.sh" api graphql \
+    -f query='
+      query($owner:String!,$repo:String!,$number:Int!){
+        repository(owner:$owner,name:$repo){
+          issue(number:$number){
+            projectItems(first:50){
+              nodes {
+                id
+                project {
+                  number
+                  owner {
+                    ... on User { login }
+                    ... on Organization { login }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }' \
+    -f owner="$repo_owner" \
+    -f repo="$repo_name" \
+    -F number="$issue_number" |
+    jq -r --arg owner "$project_owner" --argjson project_number "$project_number" '
+      .data.repository.issue.projectItems.nodes[]?
+      | select((.project.number == $project_number) and (.project.owner.login == $owner))
+      | .id
+    ' | head -1
+}
+
+project_board_set_single_select() {
+  local project_id="$1" item_id="$2" fields_file="$3" field_name="$4" value="$5"
+  local field_id option_id
+  [ -n "$value" ] || return 0
+  field_id=$(project_board_field_id "$fields_file" "$field_name")
+  option_id=$(project_board_field_option_id "$fields_file" "$field_name" "$value")
+  [ -n "$field_id" ] || {
+    printf 'project-board: Project field not found: %s\n' "$field_name" >&2
+    return 1
+  }
+  [ -n "$option_id" ] || {
+    printf 'project-board: Project field %s has no option %s\n' "$field_name" "$value" >&2
+    return 1
+  }
+  "$PROJECT_BOARD_SCRIPT_DIR/studio-gh.sh" project item-edit \
+    --id "$item_id" \
+    --project-id "$project_id" \
+    --field-id "$field_id" \
+    --single-select-option-id "$option_id" \
+    --format json >/dev/null
+}

--- a/scripts/studio-gh-issue-new.sh
+++ b/scripts/studio-gh-issue-new.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Create a studio issue and add it to the Studio v2 Project board.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=scripts/lib-project-board.sh
+. "$SCRIPT_DIR/lib-project-board.sh"
+# shellcheck source=scripts/lib-artifact-cleanup.sh
+. "$SCRIPT_DIR/lib-artifact-cleanup.sh"
+
+PROJECT_ARGS=()
+ISSUE_ARGS=()
+MODE=human
+PROJECT_OWNER="${STUDIO_PROJECT_OWNER:-v-i-s-h-a-l}"
+PROJECT_NUMBER="${STUDIO_PROJECT_NUMBER:-1}"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/studio-gh-issue-new.sh [gh issue create options] [Project field options]
+
+Project field options:
+  --project-status VALUE
+  --project-track VALUE
+  --project-phase VALUE
+  --project-size VALUE
+  --project-review-state VALUE
+  --project-owner VALUE
+  --project-number N
+  --json
+
+All other options are passed to `scripts/studio-gh.sh issue create`.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --project-status) PROJECT_ARGS+=(--status "${2:?--project-status requires value}"); shift 2 ;;
+    --project-track) PROJECT_ARGS+=(--track "${2:?--project-track requires value}"); shift 2 ;;
+    --project-phase) PROJECT_ARGS+=(--phase "${2:?--project-phase requires value}"); shift 2 ;;
+    --project-size) PROJECT_ARGS+=(--size "${2:?--project-size requires value}"); shift 2 ;;
+    --project-review-state) PROJECT_ARGS+=(--review-state "${2:?--project-review-state requires value}"); shift 2 ;;
+    --project-owner) PROJECT_OWNER="${2:?--project-owner requires value}"; PROJECT_ARGS+=(--owner "$PROJECT_OWNER"); shift 2 ;;
+    --project-number) PROJECT_NUMBER="${2:?--project-number requires value}"; PROJECT_ARGS+=(--project-number "$PROJECT_NUMBER"); shift 2 ;;
+    --json) MODE=json; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      ISSUE_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+[ "${#ISSUE_ARGS[@]}" -gt 0 ] || { usage; exit 2; }
+command -v jq >/dev/null 2>&1 || { printf 'studio-gh-issue-new: jq required\n' >&2; exit 127; }
+
+tmpdir=$(mktemp -d -t studio-gh-issue-new.XXXXXX); register_artifact tmpdir "$tmpdir"
+
+"$SCRIPT_DIR/studio-gh.sh" project view "$PROJECT_NUMBER" \
+  --owner "$PROJECT_OWNER" \
+  --format json > "$tmpdir/project.json" || {
+    printf 'studio-gh-issue-new: Project %s/%s is not readable; not creating issue\n' "$PROJECT_OWNER" "$PROJECT_NUMBER" >&2
+    exit 1
+  }
+"$SCRIPT_DIR/studio-gh.sh" project field-list "$PROJECT_NUMBER" \
+  --owner "$PROJECT_OWNER" \
+  --limit 100 \
+  --format json > "$tmpdir/fields.json" || {
+    printf 'studio-gh-issue-new: Project %s/%s fields are not readable; not creating issue\n' "$PROJECT_OWNER" "$PROJECT_NUMBER" >&2
+    exit 1
+  }
+
+issue_output=$("$SCRIPT_DIR/studio-gh.sh" issue create "${ISSUE_ARGS[@]}")
+issue_url=$(printf '%s\n' "$issue_output" | awk '/^https:\/\/github.com\// { print; exit }')
+[ -n "$issue_url" ] || {
+  printf 'studio-gh-issue-new: could not parse issue URL from issue create output\n' >&2
+  printf '%s\n' "$issue_output" >&2
+  exit 1
+}
+
+if ! project_json=$("$SCRIPT_DIR/studio-project-add.sh" "$issue_url" --json "${PROJECT_ARGS[@]}"); then
+  issue_number=$(project_board_issue_number_from_ref "$issue_url" || true)
+  issue_repo=$(project_board_repo_slug_from_issue_url "$issue_url" || true)
+  if [ -n "$issue_number" ] && [ -n "$issue_repo" ]; then
+    if "$SCRIPT_DIR/studio-gh.sh" issue close "$issue_number" \
+      --repo "$issue_repo" \
+      --comment "Closing because Project board insertion failed during scripts/studio-gh-issue-new.sh; retry after fixing Project access." >/dev/null; then
+      printf 'studio-gh-issue-new: closed %s after Project add failure\n' "$issue_url" >&2
+    else
+      printf 'studio-gh-issue-new: Project add failed and rollback close failed for %s\n' "$issue_url" >&2
+    fi
+  fi
+  exit 1
+fi
+
+if [ "$MODE" = json ]; then
+  jq -n \
+    --arg issue_url "$issue_url" \
+    --argjson project "$project_json" \
+    '{issue_url: $issue_url, project: $project}'
+else
+  printf '%s\n' "$issue_url"
+  printf 'Project: %s %s\n' \
+    "$(printf '%s\n' "$project_json" | jq -r '.disposition')" \
+    "$(printf '%s\n' "$project_json" | jq -r '.project_item_id')"
+fi

--- a/scripts/studio-project-add.sh
+++ b/scripts/studio-project-add.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Add a GitHub issue to the Studio v2 Project board and set planning fields.
+
+set -euo pipefail
+umask 022
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+# shellcheck source=scripts/lib-project-board.sh
+. "$SCRIPT_DIR/lib-project-board.sh"
+# shellcheck source=scripts/lib-artifact-cleanup.sh
+. "$SCRIPT_DIR/lib-artifact-cleanup.sh"
+
+OWNER="${STUDIO_PROJECT_OWNER:-v-i-s-h-a-l}"
+PROJECT_NUMBER="${STUDIO_PROJECT_NUMBER:-1}"
+REPO_SLUG="${STUDIO_PROJECT_REPO:-}"
+STATUS_FIELD=""
+TRACK_FIELD=""
+PHASE_FIELD=""
+SIZE_FIELD=""
+REVIEW_FIELD=""
+MODE=human
+ISSUE_REF=""
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/studio-project-add.sh <issue-number|issue-url> [field options]
+
+Options:
+  --repo owner/repo
+  --owner user-or-org
+  --project-number N
+  --status "Todo|In Progress|Done"
+  --track "B PM surface|..."
+  --phase "B2|..."
+  --size "XS|S|M|L|XL"
+  --review-state "Not required|Plan clean|Outcome clean|Needs review"
+  --json
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo) REPO_SLUG="${2:?--repo requires owner/repo}"; shift 2 ;;
+    --owner) OWNER="${2:?--owner requires user or org}"; shift 2 ;;
+    --project-number) PROJECT_NUMBER="${2:?--project-number requires number}"; shift 2 ;;
+    --status) STATUS_FIELD="${2:?--status requires value}"; shift 2 ;;
+    --track) TRACK_FIELD="${2:?--track requires value}"; shift 2 ;;
+    --phase) PHASE_FIELD="${2:?--phase requires value}"; shift 2 ;;
+    --size) SIZE_FIELD="${2:?--size requires value}"; shift 2 ;;
+    --review-state) REVIEW_FIELD="${2:?--review-state requires value}"; shift 2 ;;
+    --json) MODE=json; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*)
+      printf 'studio-project-add: unknown arg: %s\n' "$1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      if [ -n "$ISSUE_REF" ]; then
+        printf 'studio-project-add: only one issue ref is supported\n' >&2
+        exit 2
+      fi
+      ISSUE_REF="$1"
+      shift
+      ;;
+  esac
+done
+
+[ -n "$ISSUE_REF" ] || { usage; exit 2; }
+command -v jq >/dev/null 2>&1 || { printf 'studio-project-add: jq required\n' >&2; exit 127; }
+
+if [ -z "$REPO_SLUG" ]; then
+  REPO_SLUG=$(project_board_repo_slug_from_issue_url "$ISSUE_REF" || true)
+fi
+
+if [ -z "$REPO_SLUG" ]; then
+  REPO_SLUG=$(project_board_repo_slug_from_git) || {
+    printf 'studio-project-add: could not resolve repo; pass --repo owner/repo\n' >&2
+    exit 2
+  }
+fi
+
+ISSUE_NUMBER=$(project_board_issue_number_from_ref "$ISSUE_REF") || {
+  printf 'studio-project-add: unsupported issue ref: %s\n' "$ISSUE_REF" >&2
+  exit 2
+}
+ISSUE_URL=$(project_board_issue_url "$REPO_SLUG" "$ISSUE_NUMBER")
+
+tmpdir=$(mktemp -d -t studio-project-add.XXXXXX); register_artifact tmpdir "$tmpdir"
+
+"$SCRIPT_DIR/studio-gh.sh" project view "$PROJECT_NUMBER" \
+  --owner "$OWNER" \
+  --format json > "$tmpdir/project.json" || {
+    printf 'studio-project-add: failed to read Project %s/%s; Project write scope is required\n' "$OWNER" "$PROJECT_NUMBER" >&2
+    exit 1
+  }
+PROJECT_ID=$(jq -r '.id // empty' "$tmpdir/project.json")
+[ -n "$PROJECT_ID" ] || {
+  printf 'studio-project-add: Project %s/%s did not expose an id\n' "$OWNER" "$PROJECT_NUMBER" >&2
+  exit 1
+}
+
+"$SCRIPT_DIR/studio-gh.sh" project field-list "$PROJECT_NUMBER" \
+  --owner "$OWNER" \
+  --limit 100 \
+  --format json > "$tmpdir/fields.json" || {
+    printf 'studio-project-add: failed to read Project fields for %s/%s\n' "$OWNER" "$PROJECT_NUMBER" >&2
+    exit 1
+  }
+
+ITEM_ID=$(project_board_existing_item_id "$REPO_SLUG" "$ISSUE_NUMBER" "$OWNER" "$PROJECT_NUMBER")
+DISPOSITION=existing
+if [ -z "$ITEM_ID" ]; then
+  item_json=$("$SCRIPT_DIR/studio-gh.sh" project item-add "$PROJECT_NUMBER" \
+    --owner "$OWNER" \
+    --url "$ISSUE_URL" \
+    --format json) || {
+      printf 'studio-project-add: failed to add %s to Project %s/%s\n' "$ISSUE_URL" "$OWNER" "$PROJECT_NUMBER" >&2
+      exit 1
+    }
+  ITEM_ID=$(printf '%s\n' "$item_json" | jq -r '.id // .item.id // empty')
+  DISPOSITION=added
+fi
+
+[ -n "$ITEM_ID" ] || {
+  printf 'studio-project-add: Project item id missing for %s\n' "$ISSUE_URL" >&2
+  exit 1
+}
+
+if [ "$DISPOSITION" = added ]; then
+  [ -n "$STATUS_FIELD" ] || STATUS_FIELD="Todo"
+  [ -n "$REVIEW_FIELD" ] || REVIEW_FIELD="Not required"
+  if [ -z "$TRACK_FIELD" ]; then
+    labels_json=$(project_board_issue_labels_json "$REPO_SLUG" "$ISSUE_NUMBER")
+    TRACK_FIELD=$(printf '%s\n' "$labels_json" | project_board_infer_track_from_labels)
+  fi
+fi
+
+project_board_set_single_select "$PROJECT_ID" "$ITEM_ID" "$tmpdir/fields.json" "Status" "$STATUS_FIELD"
+project_board_set_single_select "$PROJECT_ID" "$ITEM_ID" "$tmpdir/fields.json" "Track" "$TRACK_FIELD"
+project_board_set_single_select "$PROJECT_ID" "$ITEM_ID" "$tmpdir/fields.json" "Phase" "$PHASE_FIELD"
+project_board_set_single_select "$PROJECT_ID" "$ITEM_ID" "$tmpdir/fields.json" "Size" "$SIZE_FIELD"
+project_board_set_single_select "$PROJECT_ID" "$ITEM_ID" "$tmpdir/fields.json" "Sibling host reviewed" "$REVIEW_FIELD"
+
+result=$(
+  jq -n \
+    --arg issue_url "$ISSUE_URL" \
+    --argjson issue_number "$ISSUE_NUMBER" \
+    --arg item_id "$ITEM_ID" \
+    --arg disposition "$DISPOSITION" \
+    --arg status "$STATUS_FIELD" \
+    --arg track "$TRACK_FIELD" \
+    --arg phase "$PHASE_FIELD" \
+    --arg size "$SIZE_FIELD" \
+    --arg review "$REVIEW_FIELD" \
+    '{
+      issue_number: $issue_number,
+      issue_url: $issue_url,
+      project_item_id: $item_id,
+      disposition: $disposition,
+      fields: {
+        Status: $status,
+        Track: $track,
+        Phase: $phase,
+        Size: $size,
+        "Sibling host reviewed": $review
+      }
+    }'
+)
+
+if [ "$MODE" = json ]; then
+  printf '%s\n' "$result"
+else
+  printf 'studio-project-add: %s %s (%s)\n' "$DISPOSITION" "$ISSUE_URL" "$ITEM_ID"
+fi

--- a/scripts/studio-project-state.sh
+++ b/scripts/studio-project-state.sh
@@ -22,6 +22,9 @@
 #   scripts/studio-project-state.sh --status "Todo"
 #   scripts/studio-project-state.sh --project-board user:v-i-s-h-a-l:1
 #   scripts/studio-project-state.sh --owner v-i-s-h-a-l --project-number 1
+#   scripts/studio-project-state.sh --by-track
+#   scripts/studio-project-state.sh --by-phase
+#   scripts/studio-project-state.sh --needs-review
 
 set -u
 set -o pipefail
@@ -42,6 +45,7 @@ PROJECT_STATUS=""
 CLI_OWNER=""
 CLI_PROJECT_NUMBER=""
 CLI_PROJECT_BOARD=""
+REPORT=""
 
 usage() {
   sed -n '2,25p' "$0"
@@ -52,6 +56,9 @@ while [ "$#" -gt 0 ]; do
     --json) MODE=json; shift ;;
     --search) QUERY="${2:?usage: --search <keywords>}"; shift 2 ;;
     --status) PROJECT_STATUS="${2:?usage: --status <project-status>}"; shift 2 ;;
+    --by-track) REPORT=by-track; shift ;;
+    --by-phase) REPORT=by-phase; shift ;;
+    --needs-review) REPORT=needs-review; shift ;;
     --owner) CLI_OWNER="${2:?usage: --owner <owner>}"; shift 2 ;;
     --project-number) CLI_PROJECT_NUMBER="${2:?usage: --project-number <number>}"; shift 2 ;;
     --project-board) CLI_PROJECT_BOARD="${2:?usage: --project-board <owner_kind>:<owner_login>:<n>}"; shift 2 ;;
@@ -493,7 +500,11 @@ items_json=$(
 ) || exit $?
 
 if [ "$MODE" = json ]; then
-  printf '%s\n' "$items_json"
+  if [ "$REPORT" = needs-review ]; then
+    printf '%s\n' "$items_json" | jq '[.[] | select((.sibling_host_reviewed // "") == "Needs review")]'
+  else
+    printf '%s\n' "$items_json"
+  fi
   exit 0
 fi
 
@@ -506,6 +517,55 @@ if [ "$count" -eq 0 ]; then
   fi
   exit 0
 fi
+
+case "$REPORT" in
+  by-track)
+    printf '%s\n' "$items_json" | jq -r '
+      group_by(.track // "")
+      | sort_by(.[0].track // "")
+      | .[]
+      | (.[0].track // "" | if . == "" then "No Track" else . end) as $track
+      | "## \($track) (\(length))",
+        (.[] | "  #\(.issue_number // "-") [\(.status // "No Status")] \(.title) -- phase=\((.phase // "") | if . == "" then "-" else . end) review=\((.sibling_host_reviewed // "") | if . == "" then "-" else . end) \(.url)"),
+        ""
+    '
+    exit 0
+    ;;
+  by-phase)
+    printf '%s\n' "$items_json" | jq -r '
+      group_by(.phase // "")
+      | sort_by(.[0].phase // "")
+      | .[]
+      | (.[0].phase // "" | if . == "" then "No Phase" else . end) as $phase
+      | "## \($phase) (\(length))",
+        (.[] | "  #\(.issue_number // "-") [\(.status // "No Status")] \(.title) -- track=\((.track // "") | if . == "" then "-" else . end) review=\((.sibling_host_reviewed // "") | if . == "" then "-" else . end) \(.url)"),
+        ""
+    '
+    exit 0
+    ;;
+  needs-review)
+    review_json=$(printf '%s\n' "$items_json" | jq '[.[] | select((.sibling_host_reviewed // "") == "Needs review")]')
+    if [ "$(printf '%s\n' "$review_json" | jq 'length')" -eq 0 ]; then
+      printf 'studio-project-state: no Project items need sibling-host review.\n'
+      exit 0
+    fi
+    printf '%s\n' "$review_json" | jq -r '
+      .[]
+      | "#\(.issue_number // "-") [\(.status // "No Status")] \(.title)"
+        + " -- track=\((.track // "") | if . == "" then "-" else . end)"
+        + " phase=\((.phase // "") | if . == "" then "-" else . end)"
+        + " size=\((.size // "") | if . == "" then "-" else . end)"
+        + " \(.url)"
+    '
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    printf 'studio-project-state: unsupported report: %s\n' "$REPORT" >&2
+    exit 2
+    ;;
+esac
 
 printf '%s\n' "$items_json" | jq -r '
   .[]

--- a/scripts/test-fixtures/818-project-board-automation/test-project-board-automation.sh
+++ b/scripts/test-fixtures/818-project-board-automation/test-project-board-automation.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+# shellcheck source=scripts/lib-artifact-cleanup.sh
+. "$ROOT/scripts/lib-artifact-cleanup.sh"
+TMPROOT=$(mktemp -d -t project-board-automation.XXXXXX)
+register_artifact tmpdir "$TMPROOT"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+mkdir -p "$TMPROOT/bin"
+cat > "$TMPROOT/bin/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "project" ] && [ "$2" = "item-list" ]; then
+  cat <<'JSON'
+{
+  "items": [
+    {
+      "content": {"number": 1, "title": "PM item", "url": "https://github.com/example/repo/issues/1"},
+      "repository": "example/repo",
+      "type": "Issue",
+      "Status": "Todo",
+      "Track": "B PM surface",
+      "Phase": "B2",
+      "Size": "S",
+      "Sibling host reviewed": "Needs review",
+      "labels": ["track:pm-surface"],
+      "milestone": null
+    },
+    {
+      "content": {"number": 2, "title": "Substrate item", "url": "https://github.com/example/repo/issues/2"},
+      "repository": "example/repo",
+      "type": "Issue",
+      "Status": "Done",
+      "Track": "A substrate",
+      "Phase": "A1",
+      "Size": "M",
+      "Sibling host reviewed": "Outcome clean",
+      "labels": ["track:host-agnostic"],
+      "milestone": {"title": "v0.test"}
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 9
+FAKE_GH
+chmod +x "$TMPROOT/bin/gh"
+
+track=$(. "$ROOT/scripts/lib-project-board.sh"; printf '["track:pm-surface"]\n' | project_board_infer_track_from_labels)
+[ "$track" = "B PM surface" ] || fail "track:pm-surface did not infer B PM surface"
+
+ambiguous=$(. "$ROOT/scripts/lib-project-board.sh"; printf '["track:pm-surface","track:apollo"]\n' | project_board_infer_track_from_labels)
+[ -z "$ambiguous" ] || fail "ambiguous track labels should not infer a Track"
+
+repo_from_url=$(. "$ROOT/scripts/lib-project-board.sh"; project_board_repo_slug_from_issue_url "https://github.com/example/repo/issues/123")
+[ "$repo_from_url" = "example/repo" ] || fail "issue URL did not expose repo slug"
+
+PATH="$TMPROOT/bin:$PATH" \
+STUDIO_PROJECT_OWNER=example \
+STUDIO_PROJECT_REPO=example/repo \
+  "$ROOT/scripts/studio-project-state.sh" --by-track > "$TMPROOT/by-track.out"
+grep -q '## B PM surface (1)' "$TMPROOT/by-track.out" || fail "--by-track missing B PM surface group"
+grep -Fq '#1 [Todo] PM item' "$TMPROOT/by-track.out" || fail "--by-track missing PM item"
+
+PATH="$TMPROOT/bin:$PATH" \
+STUDIO_PROJECT_OWNER=example \
+STUDIO_PROJECT_REPO=example/repo \
+  "$ROOT/scripts/studio-project-state.sh" --needs-review > "$TMPROOT/needs-review.out"
+grep -Fq '#1 [Todo] PM item' "$TMPROOT/needs-review.out" || fail "--needs-review missing Needs review item"
+if grep -Fq '#2' "$TMPROOT/needs-review.out"; then
+  fail "--needs-review included item that does not need review"
+fi
+
+PATH="$TMPROOT/bin:$PATH" \
+STUDIO_PROJECT_OWNER=example \
+STUDIO_PROJECT_REPO=example/repo \
+  "$ROOT/scripts/studio-project-state.sh" --json --needs-review > "$TMPROOT/needs-review.json"
+jq -e 'length == 1 and .[0].issue_number == 1' "$TMPROOT/needs-review.json" >/dev/null \
+  || fail "--json --needs-review shape mismatch"
+
+printf 'PASS: project board automation\n'


### PR DESCRIPTION
## Summary

- add reusable Project board writer `scripts/studio-project-add.sh` and shared helpers
- add Project-aware issue creation helper `scripts/studio-gh-issue-new.sh`
- add `studio-project-state.sh` report modes for track, phase, and review planning
- update PM/docs workflow guidance and add a focused fixture

## Verification

- `bash -n scripts/lib-project-board.sh scripts/studio-project-add.sh scripts/studio-gh-issue-new.sh scripts/studio-project-state.sh scripts/test-fixtures/818-project-board-automation/test-project-board-automation.sh`
- `scripts/test-fixtures/818-project-board-automation/test-project-board-automation.sh`
- `scripts/lint-gh-wrapper.sh && scripts/lint-runtime-paths.sh && scripts/lint-synthetic-home.sh && scripts/lint-artifact-cleanup.sh`
- `scripts/pre-commit-review.sh` approved

Closes #891.
Closes #892.
Closes #893.
Closes #894.
Closes #895.
Supports #818.
