### PR TITLE
Preserve planner dependencies and resume host overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ scripts/manager-work-chain.sh ios-v2-execution --dry-run # preview the named cha
 scripts/studio-chain-runner.sh --auto workflow-measurement-improvements # unattended safe start/resume for one manifest
 scripts/studio-chain-runner.sh workflow-measurement-improvements --attended --yes # attended run with explicit confirmation bypass
 scripts/studio-chain-runner.sh workflow-measurement-improvements --unattended --yes # no routine continue prompts; typed blockers halt
-scripts/studio-chain-runner.sh --resume <run_id> --yes # resume from event-derived state; repair stale projection before scheduling
+scripts/studio-chain-runner.sh --resume <run_id> --host codex --yes # resume with a fresh host override for unfinished chains
 scripts/studio-chain-runner.sh --regenerate-report <run_id> # opt-in refresh for stale private chain-run reports
 scripts/studio-chain-runner.sh --doctor <run_id> --public-safe # inspect recovery state with local paths/details redacted
 STUDIO_CHAIN_TARGET_REPO_ROOT=/repo scripts/studio-chain-runner.sh /tmp/chain.yaml --dry-run # run a non-repo manifest against an explicit checkout

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-14T05:35:19Z",
+  "generated_at": "2026-05-14T05:36:24Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-14T01:37:20Z",
+  "generated_at": "2026-05-14T05:35:19Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-14T01:37:20Z",
+  "generated_at": "2026-05-14T05:35:19Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-14T05:35:19Z",
+  "generated_at": "2026-05-14T05:36:24Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -87,7 +87,7 @@ scripts/studio-chain-runner.sh workflow-measurement-improvements --unattended --
 scripts/studio-chain-runner.sh --explain-next workflow-measurement-improvements # show the supervisor's next action without mutating state
 scripts/prd-intake-normalize.sh prd.md                                     # normalize PRD/transcript/issue brief language into a requirement packet
 scripts/prd-task-graph-synthesize.sh packet.md                             # synthesize deterministic scheduler graph; flags missing prereqs, write races, and unbounded tasks
-scripts/studio-chain-runner.sh --resume <run_id> --yes                     # resume from state.json; reconciles completed worker summaries before scheduling dependents
+scripts/studio-chain-runner.sh --resume <run_id> --host codex --yes        # resume with a fresh host override for unfinished chains
 scripts/studio-chain-runner.sh --resume <run_id> --verified --yes          # resume after human verification and print closeout statuses
 scripts/studio-chain-runner.sh --list                                      # list persisted chain runs and report paths
 scripts/studio-chain-runner.sh --regenerate-report <run_id>                # opt-in refresh for stale private chain-run reports

--- a/scripts/manager-plan-chain.sh
+++ b/scripts/manager-plan-chain.sh
@@ -9,6 +9,7 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # shellcheck source=lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
+_lp_load_project_env 2>/dev/null || true
 
 PROJECT="${STUDIO_MANAGER_PLAN_CHAIN_PROJECT:-}"
 ISSUE_NUMBER=""
@@ -17,6 +18,8 @@ PARENT_ISSUE_NUMBER=""
 SOURCE_FILE=""
 SOURCE_TEXT=""
 FROM_PLAN=""
+FROM_PLAN_JSON=""
+FROM_PLAN_KIND=""
 TITLE=""
 CHAIN_NAME=""
 SOURCE_BRANCH="main"
@@ -694,7 +697,7 @@ expected_task_count_from_source() {
   ' "$SOURCE_MD"
 }
 
-write_planner_artifact() {
+write_generated_planner_artifact() {
   local status="$1" blocked_json="$2"
   local expected_task_count produced_task_count cardinality_findings
   expected_task_count=$(expected_task_count_from_source || true)
@@ -796,6 +799,42 @@ write_planner_artifact() {
         status: $status
       }
   ' > "$PLANNER_ARTIFACT"
+}
+
+write_planner_artifact() {
+  local status="$1" blocked_json="$2"
+  if [ "$FROM_PLAN_KIND" = "planner-output" ] && [ -n "$FROM_PLAN_JSON" ] && [ -r "$FROM_PLAN_JSON" ]; then
+    jq -S \
+      --arg status "$status" \
+      --arg source_path "$SOURCE_MD" \
+      --arg requirement_packet "$REQUIREMENT_PACKET" \
+      --arg task_graph "$TASK_GRAPH" \
+      --arg review_input "$REVIEW_INPUT" \
+      --argjson blocked "$blocked_json" \
+      '
+        .status = $status
+        | .evidence_refs = (((.evidence_refs // []) + [$source_path, $requirement_packet, $task_graph, $review_input]) | unique)
+        | .payload.self_review_findings = (
+            (.payload.self_review_findings // [])
+            + [
+                "Task graph validation status: ready for reviewed planner-output ingest.",
+                "Preserved planner-output contract-specific checks, stop conditions, non-goals, acceptance criteria, and follow-up notes."
+              ]
+            | unique
+          )
+        | .payload.self_review_fixes = (
+            (.payload.self_review_fixes // [])
+            + (if ($blocked | length) > 0
+               then ["Stopped before review, issue creation, and manifest creation because the source needs more context."]
+               else []
+               end)
+            | unique
+          )
+      ' "$FROM_PLAN_JSON" > "$PLANNER_ARTIFACT"
+    return 0
+  fi
+
+  write_generated_planner_artifact "$status" "$blocked_json"
 }
 
 write_review_input() {
@@ -965,6 +1004,42 @@ task_graph_from_planner_output() {
   local plan_json="$1"
   jq -S '
     (.payload.decomposition // []) as $items
+    | (
+        ($items | map({key: (.contract_id // ""), value: (.task_graph_node_id // "")}))
+        + ($items | map({key: (.task_graph_node_id // ""), value: (.task_graph_node_id // "")}))
+        | map(select(.key != "" and .value != ""))
+        | from_entries
+      ) as $id_map
+    | def normalized_deps($item):
+        [($item.dependencies // $item.depends_on // [])[]?
+         | select(type == "string")
+         | ($id_map[.] // .)];
+      (
+        $items
+        | to_entries
+        | map(
+            .value as $item
+            | (.value.task_graph_node_id // ("T-W" + ((.key + 1) | tostring))) as $id
+            | normalized_deps($item) as $deps
+            | {
+                id: $id,
+                kind: "task",
+                source_id: (.value.contract_id // ("worker-contract:" + ((.key + 1) | tostring))),
+                label: (.value.summary // .value.contract_id // "Worker contract"),
+                dependencies: $deps,
+                read_resources: [],
+                write_resources: (.value.allowed_paths // []),
+                status: (if ($deps | length) > 0 then "blocked" else "ready" end)
+              }
+          )
+      ) as $nodes
+    | ($nodes | map(.id)) as $node_ids
+    | (
+        [$nodes[] as $node
+         | $node.dependencies[]?
+         | select(($node_ids | index(.)) | not)
+         | {node_id: $node.id, missing_source_id: .}]
+      ) as $missing_dependencies
     | {
         schema_version: 1,
         kind: "task-graph",
@@ -974,29 +1049,16 @@ task_graph_from_planner_output() {
           fingerprint_sha256: "",
           generator: {name:"manager-plan-chain", version:1}
         },
-        nodes: (
-          $items
-          | to_entries
-          | map({
-              id: (.value.task_graph_node_id // ("T-W" + ((.key + 1) | tostring))),
-              kind: "task",
-              source_id: (.value.contract_id // ("worker-contract:" + ((.key + 1) | tostring))),
-              label: (.value.summary // .value.contract_id // "Worker contract"),
-              dependencies: [],
-              read_resources: [],
-              write_resources: (.value.allowed_paths // []),
-              status: "ready"
-            })
+        nodes: $nodes,
+        edges: (
+          [$nodes[] as $node
+           | $node.dependencies[]?
+           | {from: ., to: $node.id, reason: "planner-output dependency"}]
         ),
-        edges: [],
-        ready_node_ids: (
-          $items
-          | to_entries
-          | map(.value.task_graph_node_id // ("T-W" + ((.key + 1) | tostring)))
-        ),
+        ready_node_ids: ($nodes | map(select((.dependencies // []) | length == 0) | .id)),
         validation: {
-          status: (if ($items | length) > 0 then "valid" else "invalid" end),
-          missing_dependencies: [],
+          status: (if (($items | length) > 0 and ($missing_dependencies | length) == 0) then "valid" else "invalid" end),
+          missing_dependencies: $missing_dependencies,
           parallel_write_races: [],
           packet_conflicts: [],
           unresolved_missing_details: (if ($items | length) > 0 then [] else [{source_id:"M001", text:"Planner output has no decomposition entries."}] end)
@@ -1016,6 +1078,8 @@ prepare_task_graph() {
     from_plan_json="$ARTIFACT_ROOT/from-plan.json"
     yq -o=json '.' "$FROM_PLAN" > "$from_plan_json"
     plan_kind=$(jq -r '.kind // .artifact_kind // ""' "$from_plan_json")
+    FROM_PLAN_JSON="$from_plan_json"
+    FROM_PLAN_KIND="$plan_kind"
     case "$plan_kind" in
       task-graph)
         jq -S '.' "$from_plan_json" > "$TASK_GRAPH"

--- a/scripts/prd-task-graph-synthesize.sh
+++ b/scripts/prd-task-graph-synthesize.sh
@@ -176,10 +176,13 @@ function resource_like(value) {
   if (value ~ /[[:space:]]|--|"|>|<|\$\(|\$\{|;|&&|\|\|/) {
     return 0
   }
+  if (value == ".gitignore") {
+    return 1
+  }
   if (value ~ /^\.[A-Za-z0-9]+$/) {
     return 0
   }
-  return value ~ /(^scripts\/|^_shared\/|^core\/|^hooks\/|^commands\/|^tests\/|^README\.md$|^REVIEW\.md$|^CLAUDE\.md$|^AGENTS\.md$|^ROADMAP\.md$|^ARCHITECTURE\.md$|^hosts\/|[A-Za-z0-9_-]+\.sh$|[A-Za-z0-9_-]+\.md$|[A-Za-z0-9_-]+\.json$|[A-Za-z0-9_-]+\.ya?ml$)/
+  return value ~ /(^scripts\/|^_shared\/|^core\/|^hooks\/|^commands\/|^tests\/|^README\.md$|^REVIEW\.md$|^CLAUDE\.md$|^AGENTS\.md$|^ROADMAP\.md$|^ARCHITECTURE\.md$|^\.gitignore$|^hosts\/|^zaps-app\/|^docs\/|^Documentation\/|^Sources\/|^Tests\/|^Resources\/|^Package\.swift$|[A-Za-z0-9_-]+\.swift$|[A-Za-z0-9_-]+\.pbxproj$|[A-Za-z0-9_-]+\.xcstrings$|[A-Za-z0-9_-]+\.xcscheme$|[A-Za-z0-9_-]+\.sh$|[A-Za-z0-9_-]+\.md$|[A-Za-z0-9_-]+\.json$|[A-Za-z0-9_-]+\.ya?ml$)/
 }
 
 function resources_from_title(title,    rest, value, out) {

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -6,7 +6,7 @@
 #   scripts/studio-chain-runner.sh <manifest|chain-name|chain-id> [--only <chain>] [--host <host>] [--dry-run] [--yes] [--parallel-chains <n|auto|1>] [--checkpoint auto|off] [--attended|--unattended]
 #   scripts/studio-chain-runner.sh --auto <manifest|chain-name|chain-id> [--only <chain>] [--host <host>] [--dry-run] [--checkpoint auto|off] [--unattended]
 #   scripts/studio-chain-runner.sh --explain-next <manifest|chain-name|chain-id> [--only <chain>]
-#   scripts/studio-chain-runner.sh --resume <run_id> [--verified] [--yes]
+#   scripts/studio-chain-runner.sh --resume <run_id> [--verified] [--yes] [--host <host>]
 #   scripts/studio-chain-runner.sh --regenerate-report <run_id>
 #   scripts/studio-chain-runner.sh --doctor <run_id> [--format markdown|json] [--public-safe]
 #   scripts/studio-chain-runner.sh --list
@@ -6852,6 +6852,7 @@ explain_plan() {
 }
 
 prepare_plan() {
+  local resume_host resume_git_metadata_strategy
   if [ -n "$RESUME_ID" ]; then
     resolve_resume_state
     TARGET_REPO_ROOT=$(jq -r '.target_repo_root // empty' "$RUN_STATE_JSON" 2>/dev/null || true)
@@ -6867,6 +6868,29 @@ prepare_plan() {
     cp "$RUN_STATE_JSON" "$PLAN_JSON"
     jq --arg target_repo_root "$TARGET_REPO_ROOT" --arg issue_repo "$REPO_SLUG" '.target_repo_root = $target_repo_root | .issue_repo = $issue_repo' "$PLAN_JSON" > "$PLAN_JSON.tmp.$$"
     mv "$PLAN_JSON.tmp.$$" "$PLAN_JSON"
+    if [ -n "$HOST_OVERRIDE" ]; then
+      resume_host=$(chain_runner_host_for_profile "$HOST_OVERRIDE")
+      resume_git_metadata_strategy=$(git_metadata_strategy_for_host "$resume_host")
+      jq \
+        --arg host_override "$HOST_OVERRIDE" \
+        --arg host "$resume_host" \
+        --arg git_metadata_strategy "$resume_git_metadata_strategy" \
+        '
+          .host_override = $host_override
+          | .chains |= map(
+              if (.status // "pending") == "completed" then
+                .
+              else
+                .host = $host
+                | .git_metadata_strategy = $git_metadata_strategy
+                | .host_eligibility.resolver.requested_host = $host_override
+                | .host_eligibility.resolver.resolved_host = $host
+                | .host_eligibility.resolver.host_override = $host_override
+              end
+            )
+        ' "$PLAN_JSON" > "$PLAN_JSON.tmp.$$"
+      mv "$PLAN_JSON.tmp.$$" "$PLAN_JSON"
+    fi
   else
     if [ -z "$TARGET_REPO_ROOT" ]; then
       resolve_new_run_manifest_context

--- a/scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
+++ b/scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
@@ -76,6 +76,12 @@ across multiple wrapped lines. The reviewer surfaces the resolved host in
 - Update `hosts/ADAPTER-SPEC.md` with a forward pointer.
 - No new top-level rules in `REVIEW.md`. The block-tier rules are deferred.
 
+### 7. Swift package implementation
+
+- Create `zaps-app/PhotoEditor/Package.swift`.
+- Write `zaps-app/PhotoEditor/Sources/PhotoEditor/PhotoEditor.swift`.
+- Add tests in `zaps-app/PhotoEditor/Tests/PhotoEditorTests/PhotoEditorTests.swift`.
+
 ## Edges and prior art in the repo
 
 - `scripts/foo-consumer.sh` — read-only inventory reference.
@@ -102,6 +108,7 @@ t3=$(writes_for T-R003)
 t4=$(writes_for T-R004)
 t5=$(writes_for T-R005)
 t6=$(writes_for T-R006)
+t7=$(writes_for T-R007)
 
 # Each assertion checks one of the original 10 fatal items from #793.
 
@@ -177,6 +184,20 @@ esac
 case ",$t6," in
   *,hosts/ADAPTER-SPEC.md,*) :;;
   *) fail "T-R006 missing hosts/ADAPTER-SPEC.md (got: $t6)";;
+esac
+
+# T-R007: iOS project paths should be valid write_resources for project plans.
+case ",$t7," in
+  *,zaps-app/PhotoEditor/Package.swift,*) :;;
+  *) fail "T-R007 missing zaps-app/PhotoEditor/Package.swift (got: $t7)";;
+esac
+case ",$t7," in
+  *,zaps-app/PhotoEditor/Sources/PhotoEditor/PhotoEditor.swift,*) :;;
+  *) fail "T-R007 missing Swift source path (got: $t7)";;
+esac
+case ",$t7," in
+  *,zaps-app/PhotoEditor/Tests/PhotoEditorTests/PhotoEditorTests.swift,*) :;;
+  *) fail "T-R007 missing Swift test path (got: $t7)";;
 esac
 
 # Validation must report no parallel-write races and not leave empty

--- a/scripts/test-fixtures/884-verified-resume/test-verified-resume.sh
+++ b/scripts/test-fixtures/884-verified-resume/test-verified-resume.sh
@@ -20,6 +20,14 @@ grep -Fq 'verified_closeout_line "Worker summary ingested and validated"' "$ROOT
   || fail "closeout inventory is missing worker summary row"
 grep -Fq -- '--verified|--doctor' "$ROOT/scripts/manager-work-chain.sh" \
   || fail "manager front door does not treat --verified as an explicit runner mode"
+grep -Fq -- 'scripts/studio-chain-runner.sh --resume <run_id> [--verified] [--yes] [--host <host>]' "$ROOT/scripts/studio-chain-runner.sh" \
+  || fail "resume usage does not document host override"
+grep -Fq '.host_override = $host_override' "$ROOT/scripts/studio-chain-runner.sh" \
+  || fail "resume path does not persist host override"
+grep -Fq 'if (.status // "pending") == "completed" then' "$ROOT/scripts/studio-chain-runner.sh" \
+  || fail "resume host override rewrites completed chains"
+grep -Fq '.git_metadata_strategy = $git_metadata_strategy' "$ROOT/scripts/studio-chain-runner.sh" \
+  || fail "resume host override does not recompute git metadata strategy"
 
 if "$ROOT/scripts/studio-chain-runner.sh" --verified >/tmp/verified-resume.out 2>/tmp/verified-resume.err; then
   fail "--verified without --resume unexpectedly succeeded"


### PR DESCRIPTION
## Summary
- Preserve planner-output artifacts and dependency edges when manager-plan-chain ingests an existing planner output
- Recognize Swift package and Xcode project paths in synthesized task graphs
- Reapply --host overrides to unfinished chains when resuming a run, with docs and fixture coverage

## Verification
- bash -n scripts/manager-plan-chain.sh scripts/prd-task-graph-synthesize.sh scripts/studio-chain-runner.sh scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh scripts/test-fixtures/884-verified-resume/test-verified-resume.sh scripts/test-fixtures/885-chain-progress-recap/test-chain-progress-recap.sh
- shellcheck -S error scripts/manager-plan-chain.sh scripts/prd-task-graph-synthesize.sh scripts/studio-chain-runner.sh scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh scripts/test-fixtures/884-verified-resume/test-verified-resume.sh
- bash scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh && bash scripts/test-fixtures/884-verified-resume/test-verified-resume.sh && bash scripts/test-fixtures/885-chain-progress-recap/test-chain-progress-recap.sh
- git diff --check origin/main..HEAD
