### PR TITLE
Update README for v0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ timeline
              : v0.12.0 — reviewed work chains + commit taxonomy
              : v0.13.0 — host-aware work chains
              : v0.14.0 — artifact cleanup + release safety
+             : v0.15.0 — branch discipline + chain recovery
     Coming next : Issue graph hygiene — duplicate, blocked-by, caused-by, urgent triage
     Deferred : Knowledge layer — memory-query + synthesis across debriefs
              : Lu Ban — a dedicated architect agent for design dialogue
@@ -43,6 +44,7 @@ timeline
 
 ### Story so far
 
+- **[v0.15.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.15.0)** — Studio chains now carry stronger branch and recovery state through long-running work. Branch policies give manager, chain, PR, and hook surfaces the same default base, release-branch pattern, stacked-parent rules, merge-target checks, and cleanup budgets. Attended runs can pause for human verification and resume with a closeout inventory, durable progress recaps, and fresh host overrides for unfinished chains. GitHub-backed fetch/push paths now share one auth-normalized transport helper, while planner ingestion preserves dependency edges and Swift/iOS paths instead of flattening useful project shape.
 - **[v0.14.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.14.0)** — Studio runs leave less cleanup work behind: release/TestFlight archives, export logs, temp artifacts, and rebuildable caches now have explicit cleanup rules and opt-in retention. New lints catch unsafe path, GitHub CLI, synthetic-home, JSONL merge, and artifact-producing script patterns before they land. App Store handoffs now verify the submitted build more carefully and avoid publishing tags or draft releases before ASC accepts the submission, while Codex reviewer auth and worktree/project resolution fixes make cross-host review and recovery less fragile.
 - **[v0.13.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.13.0)** — Work chains can now choose a healthy worker host instead of assuming one hardcoded CLI. Host profiles, eligibility smoke checks, and typed halt details make auto-selection explainable, while durable reviewer payloads, startup diagnostics, stale-report warnings, and doctor recommendations make long-chain recovery less dependent on the original session. The release also rounds out chain monitor, iOS execution, release handoff, and GitHub-home normalization work so cross-host chains have a clearer operational trail.
 - **[v0.12.0](https://github.com/v-i-s-h-a-l/generic-dev-studio/releases/tag/v0.12.0)** — Studio work can now move from rough planning to reviewed, dependency-aware chains with less session babysitting. The manager work-chain front door, PRD normalization, task-graph synthesis, selective rule packs, checkpoint-aware resumes, and telemetry digests make long arcs easier to launch, audit, and recover. Commit messages now carry a release-friendly taxonomy, TestFlight/App Store drafts can use that metadata directly, and feature-branch merge gates are shared across chain, worktree, and PR paths so dependent branches rebase or retarget instead of quietly accumulating merge commits.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-14T05:36:24Z",
+  "generated_at": "2026-05-14T06:44:33Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-14T05:36:24Z",
+  "generated_at": "2026-05-14T06:44:32Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary
- Add v0.15.0 to the README timeline
- Prepend the v0.15.0 Story so far summary
- Keep generated repo surface manifests in sync via the pre-commit hook

## Verification
- git diff --check origin/main..HEAD
- pre-commit hook passed during commit
