### PR TITLE
Seed studio Project board config

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-14T11:46:55Z",
+  "generated_at": "2026-05-14T20:05:59Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-14T11:46:55Z",
+  "generated_at": "2026-05-14T20:05:59Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/profiles/generic-dev-studio/profile.yaml
+++ b/profiles/generic-dev-studio/profile.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+kind: studio-v2-project-profile
+profile: generic-dev-studio
+display_name: Generic Dev Studio
+stack: shell
+project_detection:
+  required_any:
+    - PM-SURFACE.md
+    - core/v2/skills/dev-studio/SKILL.md
+  optional:
+    - scripts/studio-project-state.sh
+# The studio repo's own profile is PM/config metadata today; executable
+# operations still live in the global dev-studio router and scripts.
+operations: {}
+rules: []
+plugin_escape_hatches: []

--- a/profiles/generic-dev-studio/project-board.yaml
+++ b/profiles/generic-dev-studio/project-board.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+owner_kind: user
+owner_login: v-i-s-h-a-l
+project_number: 1
+project_title: Studio v2 transition
+linked_repo: v-i-s-h-a-l/generic-dev-studio
+tracks:
+  - A substrate
+  - B PM surface
+  - C agent topology
+  - D chain mode
+  - v1 forge-safety
+  - v1 apollo
+  - backlog
+phases:
+  - B1
+  - B2
+  - B3
+  - B4
+  - A0
+  - A0.5
+  - A1
+  - A2
+  - A3
+  - A4
+  - A5
+  - A6
+  - A7
+  - A8
+  - A9
+  - A10
+  - A11
+  - C
+  - D
+  - v1


### PR DESCRIPTION
## Summary

- Adds the durable `profiles/generic-dev-studio/project-board.yaml` for the Studio v2 transition Project board.
- Adds the minimal `profiles/generic-dev-studio/profile.yaml` required by v2 profile-boundary enforcement.
- Records pass-1 slice-1 triage privately; no issues were closed because Project fields remain unavailable.

## Triage slice

Reviewed #43, #44, #45, #46, #47, #48, #49, #54, #55, and #56 oldest-to-newest. The only fix-now item was the missing board config uncovered while trying to use the canonical Project reader. Everything else stayed open as chain/defer/blocked because none had shipped-with-pointer closure evidence while Project fields were unavailable.

## Review notes

- Plan review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-15-issue-triage-pass1-plan-review.md` returned clean.
- Outcome review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-15-issue-triage-pass1-slice1-outcome-review.md` returned clean.
- `_shared/schemas/capability-manifest.json` and `docs-surface.json` are hook-generated timestamp refreshes from the commit hook; I treated them as mechanical hook-owned churn rather than a substantive `_shared` change.

## Verification

- `bash scripts/test-fixtures/897-project-board-portability/test-project-board-portability.sh`
- `scripts/lint-v2-enforcement.sh --staged`
- Commit pre-commit gates passed (`lint-architecture`, `lint-comms-boundary`, `lint-debrief-writers`, `lint-v2-bootstrap`, `lint-v2-enforcement`, `lint-chain-workflow-docs`, `lint-html-theme`).

## Residual blocker

`script/studio-project-state.sh --status Todo` now gets past local config resolution from this branch, but GitHub GraphQL still returns an execution error. If that persists at the start of slice 2, it should become its own bug issue instead of being carried as a triage footnote.