### PR TITLE
Fix Project state reader fallback

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-14T20:05:59Z",
+  "generated_at": "2026-05-14T20:29:03Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-14T20:05:59Z",
+  "generated_at": "2026-05-14T20:29:02Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-project-state.sh
+++ b/scripts/studio-project-state.sh
@@ -113,6 +113,7 @@ resolve_project_board
 
 OWNER=$(printf '%s\n' "$STUDIO_CONTEXT_PROJECT_BOARD" | awk -F: '{print $2}')
 PROJECT_NUMBER=$(printf '%s\n' "$STUDIO_CONTEXT_PROJECT_BOARD" | awk -F: '{print $3}')
+OWNER_KIND=$(printf '%s\n' "$STUDIO_CONTEXT_PROJECT_BOARD" | awk -F: '{print $1}')
 
 if [ -z "$OWNER" ] || [ -z "$PROJECT_NUMBER" ]; then
   printf 'studio-project-state: failed to parse resolved project_board token: %s\n' \
@@ -245,6 +246,143 @@ graphql_project_item_for_issue() {
     '
 }
 
+graphql_project_items() {
+  local limit="$1"
+  local batch_size remaining after page_json
+  local tmp_items tmp_page
+  local query
+  tmp_items=$(mktemp -t studio-project-items.XXXXXX)
+  tmp_page=$(mktemp -t studio-project-page.XXXXXX)
+  : > "$tmp_items"
+
+  remaining=$limit
+  after=""
+  while [ "$remaining" -gt 0 ]; do
+    if [ "$remaining" -gt 100 ]; then
+      batch_size=100
+    else
+      batch_size=$remaining
+    fi
+
+    if [ "$OWNER_KIND" = "org" ]; then
+      query=$PROJECT_ITEMS_ORG_QUERY
+    else
+      query=$PROJECT_ITEMS_USER_QUERY
+    fi
+
+    if [ -n "$after" ]; then
+      with_login_home_for_github gh api graphql \
+        -f query="$query" \
+        -f login="$OWNER" \
+        -F number="$PROJECT_NUMBER" \
+        -F first="$batch_size" \
+        -f after="$after" > "$tmp_page" || { rm -f "$tmp_items" "$tmp_page"; return 1; }
+    else
+      with_login_home_for_github gh api graphql \
+        -f query="$query" \
+        -f login="$OWNER" \
+        -F number="$PROJECT_NUMBER" \
+        -F first="$batch_size" > "$tmp_page" || { rm -f "$tmp_items" "$tmp_page"; return 1; }
+    fi
+
+    jq -c '
+      def field_value($name):
+        [
+          .fieldValues.nodes[]
+          | select((.field.name // "") == $name)
+          | (.name // .text // (.number | tostring) // .date // empty)
+        ][0] // "";
+      (.data.user.projectV2.items.nodes // .data.organization.projectV2.items.nodes // [])
+      | .[]
+      | select(.content.number != null)
+      | {
+          content: {
+            number: .content.number,
+            title: (.content.title // ""),
+            url: (.content.url // ""),
+            type: (.type // "")
+          },
+          repository: (.content.repository.nameWithOwner // ""),
+          labels: ((.content.labels.nodes // []) | map(.name)),
+          milestone: (.content.milestone.title // null),
+          title: (.content.title // ""),
+          status: field_value("Status"),
+          track: field_value("Track"),
+          phase: field_value("Phase"),
+          size: field_value("Size"),
+          "sibling host reviewed": field_value("Sibling host reviewed")
+        }
+    ' "$tmp_page" >> "$tmp_items" || { rm -f "$tmp_items" "$tmp_page"; return 1; }
+
+    page_json=$(jq -c '.data.user.projectV2.items.pageInfo // .data.organization.projectV2.items.pageInfo // {}' "$tmp_page") \
+      || { rm -f "$tmp_items" "$tmp_page"; return 1; }
+    after=$(printf '%s\n' "$page_json" | jq -r '.endCursor // ""')
+    if [ "$(printf '%s\n' "$page_json" | jq -r '.hasNextPage // false')" != "true" ] || [ -z "$after" ]; then
+      break
+    fi
+    remaining=$((remaining - batch_size))
+  done
+
+  jq -s '{items: .}' "$tmp_items"
+  rm -f "$tmp_items" "$tmp_page"
+}
+
+PROJECT_ITEMS_FRAGMENT='
+  items(first:$first, after:$after){
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      type
+      content {
+        ... on Issue {
+          number
+          title
+          url
+          repository { nameWithOwner }
+          labels(first:50){ nodes { name } }
+          milestone { title }
+        }
+      }
+      fieldValues(first:50){
+        nodes {
+          ... on ProjectV2ItemFieldTextValue {
+            text
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldSingleSelectValue {
+            name
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldNumberValue {
+            number
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+          ... on ProjectV2ItemFieldDateValue {
+            date
+            field { ... on ProjectV2FieldCommon { name } }
+          }
+        }
+      }
+    }
+  }'
+
+PROJECT_ITEMS_USER_QUERY='
+  query($login:String!,$number:Int!,$first:Int!,$after:String){
+    user(login:$login){
+      projectV2(number:$number){
+        '"$PROJECT_ITEMS_FRAGMENT"'
+      }
+    }
+  }'
+
+PROJECT_ITEMS_ORG_QUERY='
+  query($login:String!,$number:Int!,$first:Int!,$after:String){
+    organization(login:$login){
+      projectV2(number:$number){
+        '"$PROJECT_ITEMS_FRAGMENT"'
+      }
+    }
+  }'
+
 fallback_items_for_search() {
   [ -n "$QUERY" ] || { printf '[]\n'; return 0; }
 
@@ -282,7 +420,11 @@ raw_json=$(
     --owner "$OWNER" \
     --limit "$LIMIT" \
     --format json
-) || exit $?
+) || {
+  project_error=$?
+  printf 'studio-project-state: project item-list failed; retrying with direct ProjectV2 GraphQL reader\n' >&2
+  raw_json=$(graphql_project_items "$LIMIT") || exit "$project_error"
+}
 
 items_json=$(
   printf '%s\n' "$raw_json" | jq -c --arg q "$QUERY" --arg project_status "$PROJECT_STATUS" '
@@ -300,7 +442,7 @@ items_json=$(
         size: field("Size"),
         sibling_host_reviewed: field("Sibling host reviewed"),
         labels: (.labels // []),
-        milestone: (.milestone.title // .milestone // null)
+        milestone: (if ((.milestone // null) | type) == "object" then .milestone.title else (.milestone // null) end)
       };
     def haystack:
       [

--- a/scripts/test-fixtures/503-project-state/test-studio-project-state.sh
+++ b/scripts/test-fixtures/503-project-state/test-studio-project-state.sh
@@ -18,6 +18,10 @@ printf '%s\n' "$*" >> "$log"
 
 case "$1 $2" in
   "project item-list")
+    if [ "${GH_STUB_ITEM_LIST_FAIL:-0}" = "1" ]; then
+      printf 'GraphQL: fixture item-list failure\n' >&2
+      exit 1
+    fi
     printf '%s\n' '{
       "items": [
         {
@@ -71,6 +75,61 @@ case "$1 $2" in
     ;;
   "api graphql")
     case "$*" in
+      *"projectV2"*)
+        printf '%s\n' '{
+          "data": {
+            "user": {
+              "projectV2": {
+                "items": {
+                  "pageInfo": {"hasNextPage": false, "endCursor": null},
+                  "nodes": [
+                    {
+                      "type": "ISSUE",
+                      "content": {
+                        "number": 443,
+                        "title": "Adopt GitHub as primary PM surface",
+                        "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/443",
+                        "repository": {"nameWithOwner": "v-i-s-h-a-l/generic-dev-studio"},
+                        "labels": {"nodes": [{"name": "enhancement"}, {"name": "track:pm-surface"}]},
+                        "milestone": null
+                      },
+                      "fieldValues": {
+                        "nodes": [
+                          {"name": "Todo", "field": {"name": "Status"}},
+                          {"name": "B PM surface", "field": {"name": "Track"}},
+                          {"name": "B1", "field": {"name": "Phase"}},
+                          {"name": "M", "field": {"name": "Size"}},
+                          {"name": "Needs review", "field": {"name": "Sibling host reviewed"}}
+                        ]
+                      }
+                    },
+                    {
+                      "type": "ISSUE",
+                      "content": {
+                        "number": 446,
+                        "title": "Chain mode enhancements",
+                        "url": "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/446",
+                        "repository": {"nameWithOwner": "v-i-s-h-a-l/generic-dev-studio"},
+                        "labels": {"nodes": [{"name": "enhancement"}, {"name": "track:workflow"}]},
+                        "milestone": null
+                      },
+                      "fieldValues": {
+                        "nodes": [
+                          {"name": "Done", "field": {"name": "Status"}},
+                          {"name": "D chain mode", "field": {"name": "Track"}},
+                          {"name": "D", "field": {"name": "Phase"}},
+                          {"name": "M", "field": {"name": "Size"}},
+                          {"name": "Outcome clean", "field": {"name": "Sibling host reviewed"}}
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }'
+        ;;
       *"number=443"*)
         printf '%s\n' '{
           "data": {
@@ -185,6 +244,12 @@ bash "$ROOT/scripts/studio-project-state.sh" --json --status Done >"$TMPROOT/sta
 status_rc=$?
 assert "json status exits zero" "[ '$status_rc' -eq 0 ]"
 assert "json is valid" "jq -e 'length == 1 and .[0].issue_number == 446 and .[0].status == \"Done\"' '$TMPROOT/status.json' >/dev/null"
+
+GH_STUB_ITEM_LIST_FAIL=1 bash "$ROOT/scripts/studio-project-state.sh" --json --status Done >"$TMPROOT/direct-fallback.json" 2>"$TMPROOT/direct-fallback.err"
+direct_fallback_rc=$?
+assert "direct graphql fallback exits zero" "[ '$direct_fallback_rc' -eq 0 ]"
+assert "direct graphql fallback prints project fields" "jq -e 'length == 1 and .[0].issue_number == 446 and .[0].status == \"Done\" and .[0].track == \"D chain mode\" and .[0].sibling_host_reviewed == \"Outcome clean\"' '$TMPROOT/direct-fallback.json' >/dev/null"
+assert "direct graphql fallback reports item-list retry" "grep -q 'retrying with direct ProjectV2 GraphQL reader' '$TMPROOT/direct-fallback.err'"
 
 if [ "$failures" -ne 0 ]; then
   printf 'FAIL: %s assertion(s)\n' "$failures" >&2


### PR DESCRIPTION
## Summary

- Adds a direct ProjectV2 GraphQL fallback when `gh project item-list` fails.
- Normalizes fallback rows to the existing `studio-project-state.sh` output contract: Status, Track, Phase, Size, Sibling host reviewed, labels, milestone, and issue identity.
- Adds fixture coverage for forced `project item-list` failure.

## Why

Oldest-to-newest issue triage depends on Project fields. The local board config is fixed, but GitHub currently returns an execution error for `gh project item-list`; narrower ProjectV2 GraphQL succeeds.

## Verification

- `bash scripts/test-fixtures/503-project-state/test-studio-project-state.sh`
- `scripts/studio-project-state.sh --status Todo`
- Staged REVIEW.md/lint checks: `lint-runtime-paths`, `lint-gh-wrapper`, `lint-synthetic-home`, `lint-artifact-cleanup`, `git diff --check`
- Commit pre-commit gates passed.

## Notes

`_shared/schemas/capability-manifest.json` and `docs-surface.json` are hook-generated timestamp refreshes.

Fixes #908