### PR TITLE
docs: add Pi adapter research packet

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T12:29:29Z",
+  "generated_at": "2026-05-15T12:29:33Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T12:29:25Z",
+  "generated_at": "2026-05-15T12:29:29Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T12:09:26Z",
+  "generated_at": "2026-05-15T12:29:10Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T11:29:22Z",
+  "generated_at": "2026-05-15T12:09:26Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T11:03:41Z",
+  "generated_at": "2026-05-15T11:11:03Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T11:19:31Z",
+  "generated_at": "2026-05-15T11:29:22Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T09:15:03Z",
+  "generated_at": "2026-05-15T11:03:41Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T11:11:03Z",
+  "generated_at": "2026-05-15T11:19:31Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T12:29:10Z",
+  "generated_at": "2026-05-15T12:29:25Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T09:15:02Z",
+  "generated_at": "2026-05-15T11:03:41Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T11:03:41Z",
+  "generated_at": "2026-05-15T11:11:03Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T11:19:31Z",
+  "generated_at": "2026-05-15T11:29:22Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T12:29:10Z",
+  "generated_at": "2026-05-15T12:29:25Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T12:09:26Z",
+  "generated_at": "2026-05-15T12:29:10Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T11:11:03Z",
+  "generated_at": "2026-05-15T11:19:31Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T12:29:25Z",
+  "generated_at": "2026-05-15T12:29:29Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T11:29:22Z",
+  "generated_at": "2026-05-15T12:09:26Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T12:29:29Z",
+  "generated_at": "2026-05-15T12:29:33Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs/research/pi-adapter/01-pi-capability-map.md
+++ b/docs/research/pi-adapter/01-pi-capability-map.md
@@ -1,0 +1,28 @@
+# Pi adapter research — 01 Pi capability and architecture map
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Pi capability and architecture map |
+| Task graph node | `T-R001` |
+| Source issue | [#924](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/924) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b47-5e8c-701a-a9d1-7a6a95173fd0` |
+| Chain | `pi-adapter-research` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/01-pi-capability-map.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact maps Pi's packages, extensions, agent/subagent stance,
+model and provider configuration, telemetry, session UX, shell execution, and
+command extension points to the Studio v2 subsystems they would have to
+integrate with under a future Pi adapter. It is research only — no Pi install,
+no adapter architecture decision.
+
+Downstream research outputs (`02-model-routing.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/02-model-routing.md
+++ b/docs/research/pi-adapter/02-model-routing.md
@@ -1,0 +1,30 @@
+# Pi adapter research — 02 Dynamic model-role execution
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Dynamic model-role execution under a Pi adapter |
+| Task graph node | `T-R002` |
+| Source issue | [#925](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/925) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b47-5e8c-701a-a9d1-7a6a95173fd0` |
+| Chain | `pi-adapter-research` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/02-model-routing.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact evaluates how Studio's model-role policy
+(`ARCHITECTURE.md` §"Model-role policy") could be executed by Pi as one
+host adapter — covering provider/model/thinking-level translation, fallback
+shapes, concurrency hazards under `~/.pi/agent/`, and three candidate
+adapter shapes — without implementing a resolver or choosing final model
+names. It is research only: no Pi install, no credentials touched, and no
+adapter architecture decision.
+
+Downstream research outputs (`03-telemetry-compatibility.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/03-telemetry-compatibility.md
+++ b/docs/research/pi-adapter/03-telemetry-compatibility.md
@@ -1,0 +1,32 @@
+# Pi adapter research — 03 Telemetry compatibility and optionalization
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Telemetry compatibility and optionalization under a Pi adapter |
+| Task graph node | `T-R003` |
+| Source issue | [#926](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/926) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b47-5e8c-701a-a9d1-7a6a95173fd0` |
+| Chain | `pi-adapter-research` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/03-telemetry-compatibility.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact inventories Studio's layered telemetry surfaces
+(chain-run private events, state projection, worker summary envelope, worker
+telemetry sidecar, shared cross-agent event log, checkpoint telemetry,
+startup diagnostics, aggregate digest, public-comment allowlist) and
+classifies each surface plus the relevant Pi-side records as `core`,
+`bridge`, `optional-under-pi`, `replaceable-after-parity`, `defer`, or
+`unknown`. It is research only: no Pi install, no credentials touched, and
+no adapter architecture decision; the only optionalizations recommended are
+Pi-side outbound pings that Studio does not consume.
+
+Downstream research outputs (`04-auth-home-env.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/04-auth-home-env.md
+++ b/docs/research/pi-adapter/04-auth-home-env.md
@@ -1,0 +1,32 @@
+# Pi adapter research — 04 Auth, HOME, and environment isolation
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Auth, HOME, and environment isolation under a Pi adapter |
+| Task graph node | `T-R004` |
+| Source issue | [#927](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/927) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b47-5e8c-701a-a9d1-7a6a95173fd0` |
+| Chain | `pi-adapter-research` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/04-auth-home-env.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact verifies how a hypothetical Pi adapter would interact
+with Studio's existing auth and isolation contracts — login-HOME
+identification, parent-home flip for GitHub, host auth home routing,
+provider credentials, reviewer-profile env-scrub, GitHub auth preflight,
+subprocess HOME, and the three repo-level lints that defend the boundary.
+Each surface is classified as verified-compatible, verified-needs-bridge,
+verified-constraint, or defer-to-T-R008. It is research only: no Pi
+install, no credentials / env files / auth homes touched, and no adapter
+architecture decision; constraints surfaced are forwarded to T-R008.
+
+Downstream research outputs (`05-cross-host-review.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/05-cross-host-review.md
+++ b/docs/research/pi-adapter/05-cross-host-review.md
@@ -1,0 +1,35 @@
+# Pi adapter research — 05 Cross-host and reviewer independence
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Cross-host coordination and reviewer-profile independence under a Pi adapter |
+| Task graph node | `T-R005` |
+| Source issue | [#928](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/928) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b47-5e8c-701a-a9d1-7a6a95173fd0` |
+| Chain | `pi-adapter-research` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/05-cross-host-review.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact inventories the reviewer-profile contract and the four
+wrapper surfaces that own cross-host review — `pr-reviewer-eligibility.sh`,
+`phase-review.sh`, `pr-headless-review.sh`, `dispatch-review.sh`, plus the
+shared launch primitive `lib-review-host.sh` — and classifies each surface
+against a hypothetical Pi adapter as verified-compatible,
+verified-needs-bridge, verified-constraint, or defer-to-T-R008. It concludes
+that Pi can coordinate independent workers and reviewers without replacing
+any wrapper, conditioned on five additive case-arm extensions and one
+adapter-boundary decision held back for T-R008. It is research only: no Pi
+install, no credentials / env files / auth homes touched, and no adapter
+architecture decision; constraints surfaced are forwarded to T-R007
+(feasibility) and T-R008 (adapter boundary).
+
+Downstream research outputs (`06-skill-package-distribution.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/06-skill-package-distribution.md
+++ b/docs/research/pi-adapter/06-skill-package-distribution.md
@@ -1,0 +1,34 @@
+# Pi adapter research — 06 Skill/package distribution
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Skill/package distribution under a Pi adapter |
+| Task graph node | `T-R006` |
+| Source issue | [#929](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/929) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b8d-09dc-7a7a-a920-d15b3b173ae8` |
+| Chain | `pi-adapter-research-codex-continuation` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/06-skill-package-distribution.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact compares Studio's canonical skill source, host-global
+symlink fanout, vendored-skill loader, recipes, and router-skill portability
+metadata with Pi's skills, settings, and package-resource model. It concludes
+that Studio skills should remain canonical in this repo, while Pi-facing skill
+and package views should be generated or symlinked after the adapter boundary is
+decided. The recommended first adapter step is Pi host-target fanout or Pi
+settings-path loading, not publishing a Pi package or replacing Studio's
+`portability.yaml`, `routing.yaml`, recipes, vendored pins, or
+`sync-host-skills.sh`. It is research only: no Pi install, no package publish,
+no skill fanout removal, no credentials or Pi state touched, and no adapter
+architecture decision.
+
+Downstream research outputs (`07-current-workflow-feasibility.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/07-current-workflow-feasibility.md
+++ b/docs/research/pi-adapter/07-current-workflow-feasibility.md
@@ -1,0 +1,30 @@
+# Pi adapter research — 07 Current Studio-on-Pi feasibility
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Current Studio-on-Pi feasibility |
+| Task graph node | `T-R007` |
+| Source issue | [#930](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/930) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b8d-09dc-7a7a-a920-d15b3b173ae8` |
+| Chain | `pi-adapter-research-codex-continuation` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/07-current-workflow-feasibility.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact defines the minimal future validation set for running
+Studio on Pi: router/status, model-route envelope, checkpoint resume, and
+`manager work-chain --dry-run`. It treats full unattended chain execution as
+feasible only after Pi proves worker sandboxing, GitHub auth parity, private
+runtime writes, worker summary generation, and telemetry-gap mapping. It is
+research only: no Pi install, no credentials or Pi state touched, and no adapter
+architecture decision.
+
+Downstream research outputs (`08-adapter-boundary-options.md` through
+`10-final-synthesis.md`) follow the same private-artifact + repo-pointer
+pattern when they ship.

--- a/docs/research/pi-adapter/08-adapter-boundary-options.md
+++ b/docs/research/pi-adapter/08-adapter-boundary-options.md
@@ -1,0 +1,28 @@
+# Pi adapter research — 08 Adapter boundary design options
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Adapter boundary design options |
+| Task graph node | `T-R008` |
+| Source issue | [#931](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/931) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b8d-09dc-7a7a-a920-d15b3b173ae8` |
+| Chain | `pi-adapter-research-codex-continuation` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/08-adapter-boundary-options.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact compares an in-tree Pi host adapter, a separate Pi
+package/repo, and a hybrid generated-package model. It recommends starting with
+an in-tree `pi` host adapter and a small Studio-owned JSON execution envelope,
+then generating a Pi package later only as a reproducible distribution view
+after conformance passes. It is research only: no Pi install, no package
+publish, no credentials or Pi state touched, and no implementation.
+
+Downstream research outputs (`09-issue-sweep.md` and `10-final-synthesis.md`)
+follow the same private-artifact + repo-pointer pattern when they ship.

--- a/docs/research/pi-adapter/09-issue-sweep.md
+++ b/docs/research/pi-adapter/09-issue-sweep.md
@@ -1,0 +1,29 @@
+# Pi adapter research — 09 GitHub issue sweep impact
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | GitHub issue sweep impact |
+| Task graph node | `T-R009` |
+| Source issue | [#932](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/932) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b8d-09dc-7a7a-a920-d15b3b173ae8` |
+| Chain | `pi-adapter-research-codex-continuation` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/09-issue-sweep.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact classifies relevant open GitHub issues as
+`superseded-by-pi-adapter`, `still-needed-core`, `adapter-follow-up`, or
+`unaffected`. It finds no issue that should be closed or relabeled solely
+because of the Pi adapter research. Existing context, cleanup, telemetry,
+planning, and skill-distribution issues mostly remain core or become adapter
+inputs. It is research only: no issue edits, no closures, no labels, no Pi
+install, and no adapter architecture decision.
+
+The final research output (`10-final-synthesis.md`) follows the same
+private-artifact + repo-pointer pattern when it ships.

--- a/docs/research/pi-adapter/10-final-synthesis.md
+++ b/docs/research/pi-adapter/10-final-synthesis.md
@@ -1,0 +1,27 @@
+# Pi adapter research — 10 Final synthesis and implementation-plan outline
+
+Repo-tracked pointer to a private Studio analysis artifact. The full research
+content lives outside this repo by design (`CLAUDE.md` §"Analysis sessions and
+privacy"); this file exists so the arc is discoverable from the working tree
+and so future readers can trace which run produced the artifact.
+
+| Field | Value |
+|---|---|
+| Title | Final synthesis and implementation-plan outline |
+| Task graph node | `T-R010` |
+| Source issue | [#933](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/933) |
+| Parent research charter | [#923](https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/923) |
+| Date (UTC) | 2026-05-15 |
+| Run UUID | `019e2b8d-09dc-7a7a-a920-d15b3b173ae8` |
+| Chain | `pi-adapter-research-codex-continuation` |
+| Private artifact path | `~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/10-final-synthesis.md` |
+| Classification | private-runtime (not committed) |
+
+The private artifact synthesizes the Pi adapter research into keep/core,
+bridge, optional-under-pi, replaceable-after-parity, defer, and unknown
+classifications. It recommends starting with an in-tree Pi host adapter and a
+Studio-owned JSON execution envelope, proving dry-run/read-only workflows first,
+then live worker conformance, then reviewer profile support, and only later a
+generated Pi package. It is research only: no Pi install, no implementation,
+no issue creation, no GitHub issue mutation, and no credential or Pi state
+changes.


### PR DESCRIPTION
## Summary
- Adds repo-tracked pointers for Pi adapter research outputs 01-10.
- Keeps the full research artifacts in private runtime under ~/.dev-studio/generic-dev-studio/analysis/pi-adapter-research/.
- Covers capability map, model routing, telemetry, auth/HOME/env isolation, reviewer independence, skill/package distribution, feasibility, adapter boundaries, issue sweep, and final synthesis.

## Verification
- git diff --check origin/main..HEAD
- pre-commit hooks ran during each pointer commit

## Notes
- No Pi install, package publish, credential mutation, issue mutation, or adapter implementation occurred.
- Claude was not invoked for the recovery path; Codex/Codex reviewer routing only.