### PR TITLE
Limit Claude host profile to reviewer

### DIFF
--- a/_shared/contracts/host-profile.md
+++ b/_shared/contracts/host-profile.md
@@ -31,7 +31,10 @@ profiles:
 ```
 
 `default_order` is `claude,codex`. It is alphabetical and does not encode a
-quality preference. Runtime consumers can override ordering with
+quality preference. Runtime consumers filter that list by capability before
+selection. The shipped default keeps Claude review-only, so worker, planner,
+and perf auto-selection resolve to Codex unless a custom profile or explicit
+host override says otherwise. Runtime consumers can override ordering with
 `STUDIO_AUTO_HOST_ORDER`; this contract only defines the shipped default.
 
 ## Profile Fields
@@ -83,17 +86,16 @@ profiles:
     auth_home: "${env.CLAUDE_HOME:-${login_home}}"
     github_home: "${github_home}"
     capabilities:
-      - worker
       - reviewer
-      - planner
-      - perf
     synthetic_home_behavior: login-home-runtime
     eligibility_smoke_command: "claude -p --permission-mode dontAsk 'Print STUDIO_HOST_PROFILE_SMOKE=ok'"
 ```
 
 This resolves the host binary from `PATH`, keeps Claude auth under the real
 login home unless `CLAUDE_HOME` is set, and keeps GitHub operations out of a
-synthetic host home.
+synthetic host home. In the repo default, Claude is intentionally limited to
+reviewer capability so implementation chains do not consume Claude Code plan
+limits.
 
 ## Validation Expectations
 

--- a/_shared/host-profiles/default.yaml
+++ b/_shared/host-profiles/default.yaml
@@ -10,10 +10,7 @@ profiles:
     auth_home: "${env.CLAUDE_HOME:-${login_home}}"
     github_home: "${github_home}"
     capabilities:
-      - worker
       - reviewer
-      - planner
-      - perf
     synthetic_home_behavior: login-home-runtime
     eligibility_smoke_command: "claude -p --permission-mode dontAsk 'Print STUDIO_HOST_PROFILE_SMOKE=ok'"
   codex:

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T12:29:33Z",
+  "generated_at": "2026-05-15T15:21:25Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T12:29:33Z",
+  "generated_at": "2026-05-15T15:21:24Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lint-field-review-surfaces.sh
+++ b/scripts/lint-field-review-surfaces.sh
@@ -23,7 +23,6 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 ERRORS=0
-emit_error() { printf '%s\n' "$1"; ERRORS=$((ERRORS + 1)); }
 
 collect_targets() {
   case "${1:-}" in
@@ -33,7 +32,7 @@ collect_targets() {
             case "$f" in
               core/v2/*|chains/*|scripts/*|_shared/*|hosts/*|REVIEW.md|CLAUDE.md|AGENTS.md)
                 case "$f" in
-                  *.md|*.sh|*.yaml|*.yml|*.json|CLAUDE.md|AGENTS.md|REVIEW.md) printf '%s\n' "$f" ;;
+                  *.md|*.sh|*.yaml|*.yml|*.json) printf '%s\n' "$f" ;;
                 esac
                 ;;
             esac
@@ -105,6 +104,9 @@ scan_file() {
     function has_review_context(text) {
       return text ~ /(reviewer|review host|review setup|review this|cross-host|sibling-host|phase[ -]?gate|phase plan|plan[ -]?review|outcome[ -]?review|verdict|qa|flow|release-manager|perf|planner|architect|field-agent)/
     }
+    function is_host_eligibility_smoke(line) {
+      return line ~ /^[[:space:]]*eligibility_smoke_command:[[:space:]]*["'\''"]?(claude[[:space:]]+-p|codex[[:space:]]+exec)([[:space:]]|["'\''"]|$)/
+    }
     function documents_banned_pattern(text) {
       return text ~ /(must not|do not|forbid|forbidden|banned|retired|instead of raw|bypass|wrapper|document|testing|test fixture)/
     }
@@ -131,6 +133,7 @@ scan_file() {
             had = 1
           }
         } else if (has_raw_command(lines[i]) &&
+            !is_host_eligibility_smoke(lines[i]) &&
             !(allowed_annotation(lines[i]) || allowed_annotation(prev1)) &&
             has_review_context(window) &&
             !documents_banned_pattern(window)) {

--- a/scripts/test-fixtures/458-field-review-lint/test-field-review-lint.sh
+++ b/scripts/test-fixtures/458-field-review-lint/test-field-review-lint.sh
@@ -30,6 +30,18 @@ cat > "$TMPROOT/good/allow.md" <<'MD'
 Run claude -p "review this plan" for the synthetic bad case.
 MD
 
+cat > "$TMPROOT/good/host-profile.yaml" <<'YAML'
+profiles:
+  claude:
+    capabilities:
+      - reviewer
+    eligibility_smoke_command: "claude -p --permission-mode dontAsk 'Print STUDIO_HOST_PROFILE_SMOKE=ok'"
+  codex:
+    capabilities:
+      - worker
+    eligibility_smoke_command: "codex exec --ignore-user-config --ignore-rules --ephemeral --sandbox read-only -c approval_policy=never 'Print STUDIO_HOST_PROFILE_SMOKE=ok'"
+YAML
+
 cat > "$TMPROOT/bad/raw-claude.md" <<'MD'
 # Planner review
 

--- a/tests/lib-host-profiles/test-lib-host-profiles.sh
+++ b/tests/lib-host-profiles/test-lib-host-profiles.sh
@@ -67,21 +67,37 @@ for host_id in claude codex; do
     ] | sort)
   '
   assert_eq "$host_id host_id round trip" "$host_id" "$(jq -r '.host_id' "$profile_json")"
-  assert_json_field "$host_id capabilities round trip" "$profile_json" '.capabilities | length == 4'
+  case "$host_id" in
+    claude)
+      assert_json_field "$host_id is review-only by default" "$profile_json" '.capabilities == ["reviewer"]'
+      ;;
+    codex)
+      assert_json_field "$host_id implementation capabilities round trip" "$profile_json" '.capabilities == ["worker", "reviewer", "planner", "perf"]'
+      ;;
+  esac
   assert_json_field "$host_id auth_home round trip" "$profile_json" '.auth_home | length > 0'
   assert_json_field "$host_id github_home round trip" "$profile_json" '.github_home | length > 0'
   assert_json_field "$host_id smoke command round trip" "$profile_json" '.eligibility_smoke_command | length > 0'
 done
 
 worker_order=$(host_profile_list_for_capability worker | paste -sd, -)
-assert_eq "default worker order" "claude,codex" "$worker_order"
+assert_eq "default worker order" "codex" "$worker_order"
+
+planner_order=$(host_profile_list_for_capability planner | paste -sd, -)
+assert_eq "default planner order" "codex" "$planner_order"
+
+perf_order=$(host_profile_list_for_capability perf | paste -sd, -)
+assert_eq "default perf order" "codex" "$perf_order"
+
+reviewer_order=$(host_profile_list_for_capability reviewer | paste -sd, -)
+assert_eq "default reviewer order" "claude,codex" "$reviewer_order"
 
 HOST_PROFILE_LOADED_FILE=
 STUDIO_HOST_PROFILE_FILE="$CUSTOM_PROFILE" host_profile_load_file || fail "STUDIO_HOST_PROFILE_FILE override did not load"
 assert_eq "env override loaded file" "$CUSTOM_PROFILE" "$HOST_PROFILE_LOADED_FILE"
 
-reviewer_order=$(host_profile_list_for_capability reviewer | paste -sd, -)
-assert_eq "custom reviewer order" "alpha" "$reviewer_order"
+custom_reviewer_order=$(host_profile_list_for_capability reviewer | paste -sd, -)
+assert_eq "custom reviewer order" "alpha" "$custom_reviewer_order"
 
 export STUDIO_AUTO_HOST_ORDER="beta,alpha"
 worker_override_order=$(host_profile_list_for_capability worker | paste -sd, -)


### PR DESCRIPTION
## Summary
- make the default Claude host profile reviewer-only
- keep Codex as the default worker/planner/perf host
- update host-profile and field-review lint fixtures for the new policy

## Verification
- bash tests/lib-host-profiles/test-lib-host-profiles.sh
- bash scripts/test-fixtures/458-field-review-lint/test-field-review-lint.sh
- shellcheck scripts/lint-field-review-surfaces.sh scripts/test-fixtures/458-field-review-lint/test-field-review-lint.sh tests/lib-host-profiles/test-lib-host-profiles.sh
- bash scripts/lint-field-review-surfaces.sh --staged
