### PR TITLE
Add Codex co-author trailer policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,11 @@ Use machine-readable host metadata as the source of truth whenever it is present
 
 Do not infer host identity only from a `Co-authored-by:` footer. If host metadata is not available from tooling, assistant-authored commits should append a `Co-authored-by:` footer for the host identity.
 
+Codex-authored commits should include the official Codex co-author trailer for
+GitHub-visible credit in addition to `Studio-Host: codex`:
+`Co-authored-by: Codex <noreply@openai.com>`. Do not use invented Codex email
+addresses such as `codex@openai.com`.
+
 ### Commit-taxonomy values (initial set)
 
 The initial taxonomy values are:

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -351,9 +351,11 @@ Commit discipline is part of review quality for host-routed changes:
 - **Warn (note but proceed unless risk increases):**
   - Missing or shallow `Caveats` for behavior-risky changes.
   - Host identity is only inferred from `Co-authored-by:` text while machine-readable host metadata exists in `.studio/chain-task-start.json` / `.studio/chain-worker-summary.json`.
+  - Codex-authored commits omit `Co-authored-by: Codex <noreply@openai.com>` or use an invented Codex email address.
 
 **How to check:**
 - Prefer machine-readable host identity from `.studio/chain-task-start.json` / `.studio/chain-worker-summary.json` (`host`, `model`, `model_version`) over parsing `Co-authored-by:` in commit footers.
+- For Codex-hosted commits, keep `Studio-Host: codex` and add the GitHub-visible Codex co-author trailer `Co-authored-by: Codex <noreply@openai.com>`.
 - Verify the commit subject is imperative and change-oriented; use `git log`/`git show` on staged commits or PR payload to validate body structure.
 - Verify taxonomy labels stay within the canonical set above.
 - Block-and-ask findings should be explicit in review output; hard blocks must state the minimum fix.

--- a/scripts/lint-commit-message.sh
+++ b/scripts/lint-commit-message.sh
@@ -4,6 +4,7 @@
 # Supported trailers:
 #   Change-Type: <change-type>
 #   Studio-Host: <host-id>
+#   Co-authored-by: Codex <noreply@openai.com>
 #
 # Exit 0 on pass (or warnings with explicit env bypass), 1 on hard failures.
 
@@ -56,11 +57,20 @@ fail() { errs=$((errs + 1)); printf 'lint-commit-message: ERROR: %s\n' "$1" >&2;
 change_type=""
 studio_host=""
 coauthored_by_seen=0
+codex_coauthor_seen=0
+bad_codex_coauthor=""
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in
     Change-Type:*) change_type=$(trim "${line#Change-Type:}") ;;
     Studio-Host:*) studio_host=$(trim "${line#Studio-Host:}") ;;
-    Co-authored-by:*) coauthored_by_seen=1 ;;
+    Co-authored-by:*)
+      coauthored_by_seen=1
+      coauthor=$(trim "${line#Co-authored-by:}")
+      case "$coauthor" in
+        "Codex <noreply@openai.com>") codex_coauthor_seen=1 ;;
+        "Codex <"*) bad_codex_coauthor="$coauthor" ;;
+      esac
+      ;;
   esac
 done < "$COMMIT_FILE"
 
@@ -110,6 +120,16 @@ fi
 if [ "$coauthored_by_seen" -eq 1 ] && [ -z "$studio_host" ] && [ "$errs" -eq 0 ]; then
   warn "Co-authored-by is for human-visible credit and is not used for host attribution."
 fi
+
+case "$studio_host" in
+  codex|codex-reviewer)
+    if [ -n "$bad_codex_coauthor" ]; then
+      warn "Codex co-author trailer should be exactly: Co-authored-by: Codex <noreply@openai.com> (found: $bad_codex_coauthor)"
+    elif [ "$codex_coauthor_seen" -eq 0 ]; then
+      warn "Codex-hosted commits should include GitHub-visible credit: Co-authored-by: Codex <noreply@openai.com>"
+    fi
+    ;;
+esac
 
 if [ "$errs" -gt 0 ]; then
   printf 'commit message must include valid Change-Type and Studio-Host trailers\n' >&2

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -7059,6 +7059,8 @@ Rules:
 - Keep changes scoped to this issue.
 - Commit the result on the current branch.
 - Include "Closes #$issue" in the commit message.
+- Include "Change-Type: <type>" and "Studio-Host: $host" trailers.
+- If $host is codex, include exactly one "Co-authored-by: Codex <noreply@openai.com>" trailer.
 - Before exit, write $summary_path as valid JSON.
 - Do not add or commit $summary_path; it is a private parent-runner artifact.
 - Do not open a PR.

--- a/scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
+++ b/scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
@@ -50,7 +50,19 @@ run_case() {
 valid_message="Valid commit
 
 Change-Type: feature
+Studio-Host: codex
+Co-authored-by: Codex <noreply@openai.com>"
+
+codex_missing_coauthor_message="Missing Codex coauthor
+
+Change-Type: feature
 Studio-Host: codex"
+
+codex_bad_coauthor_message="Bad Codex coauthor
+
+Change-Type: feature
+Studio-Host: codex
+Co-authored-by: Codex <codex@openai.com>"
 
 invalid_type_message="Invalid change-type
 
@@ -75,6 +87,8 @@ human_repo="$TMPROOT/human"
 mkdir -p "$human_repo"
 
 run_case "valid_automation" 0 "$automation_repo" "$valid_message" ""
+run_case "codex_missing_coauthor_warns" 0 "$automation_repo" "$codex_missing_coauthor_message" "Codex-hosted commits should include GitHub-visible credit"
+run_case "codex_bad_coauthor_warns" 0 "$automation_repo" "$codex_bad_coauthor_message" "Codex co-author trailer should be exactly"
 run_case "invalid_change_type_fails" 1 "$automation_repo" "$invalid_type_message" "invalid Change-Type trailer: unknown"
 run_case "missing_host_fails_in_automation" 1 "$automation_repo" "$missing_host_message" "missing trailer Studio-Host"
 run_case "missing_host_warns_for_human" 0 "$human_repo" "$missing_host_message" "passed with 1 warning(s)"


### PR DESCRIPTION
## Summary
- document the official Codex co-author trailer: `Co-authored-by: Codex <noreply@openai.com>`
- keep `Studio-Host` as the machine-readable attribution source
- warn when Codex-hosted commit messages omit the trailer or use an invented Codex email
- update chain worker commit instructions to include the trailer for Codex hosts

## Verification
- bash scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
- shellcheck scripts/lint-commit-message.sh scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
- bash -n scripts/studio-chain-runner.sh scripts/lint-commit-message.sh scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
- git diff --check
