### PR TITLE
studio chain: restore-claude-planner-reviewer

### DIFF
--- a/_shared/host-profiles/default.yaml
+++ b/_shared/host-profiles/default.yaml
@@ -11,6 +11,7 @@ profiles:
     github_home: "${github_home}"
     capabilities:
       - reviewer
+      - planner
     synthetic_home_behavior: login-home-runtime
     eligibility_smoke_command: "claude -p --permission-mode dontAsk 'Print STUDIO_HOST_PROFILE_SMOKE=ok'"
   codex:

--- a/tests/lib-host-profiles/test-lib-host-profiles.sh
+++ b/tests/lib-host-profiles/test-lib-host-profiles.sh
@@ -69,7 +69,7 @@ for host_id in claude codex; do
   assert_eq "$host_id host_id round trip" "$host_id" "$(jq -r '.host_id' "$profile_json")"
   case "$host_id" in
     claude)
-      assert_json_field "$host_id is review-only by default" "$profile_json" '.capabilities == ["reviewer"]'
+      assert_json_field "$host_id planner/reviewer capabilities round trip" "$profile_json" '.capabilities == ["reviewer", "planner"]'
       ;;
     codex)
       assert_json_field "$host_id implementation capabilities round trip" "$profile_json" '.capabilities == ["worker", "reviewer", "planner", "perf"]'
@@ -84,7 +84,7 @@ worker_order=$(host_profile_list_for_capability worker | paste -sd, -)
 assert_eq "default worker order" "codex" "$worker_order"
 
 planner_order=$(host_profile_list_for_capability planner | paste -sd, -)
-assert_eq "default planner order" "codex" "$planner_order"
+assert_eq "default planner order" "claude,codex" "$planner_order"
 
 perf_order=$(host_profile_list_for_capability perf | paste -sd, -)
 assert_eq "default perf order" "codex" "$perf_order"


### PR DESCRIPTION
Automated chain PR for `restore-claude-planner-reviewer`.

Run by `scripts/studio-chain-runner.sh`.

Chain run: `019e325d-018d-74b2-a21d-e97fe3585fee`
Chain-run UUID: `019e325d-35ac-7375-a3c0-992ebcc6a407`
Private report: local only; resolve by run ID on the machine that ran the chain.

Review gate: `scripts/pr-headless-review.sh <pr> --method auto`.