### PR TITLE
Prefer Sonnet for Claude review and planning

### DIFF
--- a/_shared/contracts/events.md
+++ b/_shared/contracts/events.md
@@ -325,7 +325,7 @@ Transport stays JSONL. These are attribute names, not a protocol change.
 |---|---|
 | `gen_ai.agent.id` | Task ID or round ID for the current operation. |
 | `gen_ai.conversation.id` | Same as task ID — the logical conversation thread. |
-| `gen_ai.request.model` | Model identifier (e.g. `claude-opus-4-7`). |
+| `gen_ai.request.model` | Model identifier (e.g. `claude-sonnet-4-20250514`). |
 | `gen_ai.usage.input_tokens` | Integer. Omit when not available (e.g. most mid-session events). |
 | `gen_ai.usage.output_tokens` | Integer. Omit when not available. |
 

--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -108,7 +108,7 @@ Bump build number to <NEW_BUILD_NUMBER>
 
 Preparing TestFlight build <NEW_BUILD_NUMBER> (v<VERSION>) from branch <BRANCH>.
 
-Co-Authored-By: Claude Opus 4.X (1M context) <noreply@anthropic.com>
+Studio-Host: release-manager
 ```
 
 Create an annotated TF anchor tag at the bump commit:

--- a/_shared/rules/model-policy.yaml
+++ b/_shared/rules/model-policy.yaml
@@ -35,30 +35,44 @@ roles:
   reviewer.heavyweight:
     purpose: Argus-style PR review, safety-floor review, cross-file regression review
     role_suitability: reviewer
-    reasoning_effort: high
+    reasoning_effort: medium
     independent_provider_family_required: true
     model_preferences:
-      - opus
+      - sonnet
       - openai_gpt_5_5
       - openai_gpt_5_3_codex
       - openai_gpt_5_2
       - openai_gpt_5
+      - opus
     downgrade_requires_telemetry: true
   reviewer.fallback:
     purpose: user-approved same-family fallback when no independent eligible reviewer can run
     role_suitability: reviewer
-    reasoning_effort: high
+    reasoning_effort: medium
     user_approved_bypass_required: true
     model_preferences:
-      - opus
+      - sonnet
       - openai_gpt_5_5
       - openai_gpt_5_3_codex
       - openai_gpt_5_2
       - openai_gpt_5
+      - opus
+  planner.heavyweight:
+    purpose: Claude planner/architect planning, decomposition, and plan review preparation
+    role_suitability: planner
+    reasoning_effort: medium
+    model_preferences:
+      - sonnet
+      - openai_gpt_5_5
+      - openai_gpt_5_3_codex
+      - openai_gpt_5_2
+      - openai_gpt_5
+      - opus
+    opus_requires_explicit_extreme_need: true
   reviewer.reasoning_effort:
-    default: high
+    default: medium
     routine_after_telemetry: medium
-    rule: "Do not silently downgrade Argus-style review or non-trivial implementation to cheaper/faster models."
+    rule: "Use Sonnet for Claude review/planner defaults. Opus is a last-resort tier only when explicitly justified as extreme need; do not use unverified Opus snapshots such as Opus 4.7 by default."
 reviewer_selection:
   default_role: reviewer.heavyweight
   fallback_role: reviewer.fallback

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-15T15:21:25Z",
+  "generated_at": "2026-05-16T20:25:21Z",
   "agents": [
 
   ]

--- a/_shared/schemas/debrief.md
+++ b/_shared/schemas/debrief.md
@@ -25,7 +25,7 @@ mode: task                                       # task | direct-debrief
 state: emitted                                   # emitted | ingested | superseded
 completed_at: 2026-04-22T12:40:51Z
 executed_with:                                   # 2.1.0; multi-model accountability — populated from scripts/emit-agent-boot.sh data
-  model_id: "claude-opus-4-7"                    # canonical model id (e.g. "claude-opus-4-7", "claude-sonnet-4-6", "gpt-5-codex")
+  model_id: "claude-sonnet-4-20250514"           # canonical model id (e.g. "claude-sonnet-4-20250514", "gpt-5-codex")
   host: claude-code                              # claude-code | codex | <future-host>
   session_id: "session-42"                       # producer session id (matches agent-boot event)
   duration_s: 8246                               # integer seconds — wall-clock duration of the implementing session

--- a/_shared/schemas/model-catalog.yaml
+++ b/_shared/schemas/model-catalog.yaml
@@ -72,7 +72,6 @@ models:
     capability_tier: heavyweight
     role_suitability:
       - implementer
-      - reviewer
       - architect
     stable_aliases: []
     snapshot_ids:
@@ -104,6 +103,8 @@ models:
     role_suitability:
       - implementer
       - reviewer
+      - planner
+      - architect
       - editor
       - triage
     stable_aliases:

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-15T15:21:24Z",
+  "generated_at": "2026-05-16T20:25:21Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/budget-report.sh
+++ b/scripts/budget-report.sh
@@ -36,7 +36,7 @@ while [ $# -gt 0 ]; do
 done
 
 # Context-window baseline for ctx_util_pct. Standard Claude context is 200K;
-# override via env for 1M-context sessions (e.g. Opus 4.7).
+# override via env for explicitly approved larger-context sessions.
 CTX_WINDOW_TOKENS=${CTX_WINDOW_TOKENS:-200000}
 
 BUDGETS="$REPO_ROOT/_shared/schemas/token-budgets.json"

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -29,7 +29,6 @@ set -u
 umask 022
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
-REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 # shellcheck source=scripts/lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
@@ -258,6 +257,16 @@ fi
 spawn_command=$(printf '%s\n' "$eligibility" | sed -n 's/^SPAWN_COMMAND=//p' | head -1)
 [ -n "$spawn_command" ] || fail "missing spawn command for $review_host"
 
+parent_host_for_model=$(resolve_current_studio_host unknown)
+resolver_args=(--review-host "$review_host" --implementation-host "$parent_host_for_model" --role reviewer.heavyweight)
+if ! review_host_is_cross_family "$parent_host_for_model" "$review_host"; then
+  resolver_args+=(--allow-same-family)
+fi
+model_resolution=$("$SCRIPT_DIR/resolve-reviewer-model.sh" "${resolver_args[@]}" 2>&1) \
+  || fail "failed to resolve reviewer model for $review_host: $model_resolution"
+# resolve-reviewer-model.sh is repo-owned and emits only %q-quoted shell assignments.
+eval "$model_resolution"
+
 tmpdir=$(mktemp -d -t phase-review.XXXXXX) || fail "mktemp failed"
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -266,6 +275,14 @@ mkdir -p "$reviewer_home"
 
 # shellcheck disable=SC2206
 spawn_argv=( $spawn_command )
+case "$review_host" in
+  codex*|*codex*)
+    spawn_argv+=(-m "$REVIEWER_MODEL_ID" -c "model_reasoning_effort=$REVIEWER_MODEL_REASONING_EFFORT")
+    ;;
+  claude*|*claude*)
+    spawn_argv+=(--model "$REVIEWER_MODEL_ID")
+    ;;
+esac
 
 input_content=$(cat "$input")
 input_bytes=$(wc -c < "$input" 2>/dev/null | tr -d ' ' || printf '0')
@@ -316,7 +333,12 @@ review_argv=("${spawn_argv[@]}")
 case "$review_host" in
   claude*|*claude*) review_argv+=("--add-dir=$input_dir") ;;
 esac
-review_cmd=(review_host_run_command "$review_host" "$reviewer_home" --env REVIEW_PAYLOAD "$input" -- "${review_argv[@]}" "$prompt")
+review_cmd=(review_host_run_command "$review_host" "$reviewer_home" \
+  --env REVIEW_PAYLOAD "$input" \
+  --env STUDIO_REVIEW_MODEL_ID "$REVIEWER_MODEL_ID" \
+  --env STUDIO_REVIEW_REASONING_EFFORT "$REVIEWER_MODEL_REASONING_EFFORT" \
+  --env STUDIO_REVIEW_PROVIDER_FAMILY "$REVIEWER_MODEL_PROVIDER_FAMILY" \
+  -- "${review_argv[@]}" "$prompt")
 
 if ! "${review_cmd[@]}" > "$output" 2>"$err_output"; then
   detail=$(failure_detail "$err_output")
@@ -348,6 +370,8 @@ printf 'PHASE_REVIEW_OUTPUT=%s\n' "$output"
 printf 'PHASE_REVIEW_ERR=%s\n' "$err_output"
 printf 'PHASE_REVIEW_VERDICT=%s\n' "$verdict"
 printf 'PHASE_REVIEW_CONTEXT_TOKENS=%s\n' "$input_estimated_tokens"
+printf 'PHASE_REVIEW_MODEL_ID=%s\n' "$REVIEWER_MODEL_ID"
+printf 'PHASE_REVIEW_REASONING_EFFORT=%s\n' "$REVIEWER_MODEL_REASONING_EFFORT"
 if review_host_is_cross_family "$parent_host_for_meta" "$review_host"; then
   printf 'PHASE_REVIEW_CROSS_HOST_SATISFIED=true\n'
 else

--- a/scripts/resolve-reviewer-model.sh
+++ b/scripts/resolve-reviewer-model.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   scripts/resolve-reviewer-model.sh --review-host <host> [--implementation-host <host>]
-#       [--role reviewer.heavyweight] [--allow-same-family]
+#       [--role reviewer.heavyweight|planner.heavyweight] [--allow-same-family]
 
 set -u
 umask 022
@@ -49,6 +49,7 @@ shell_assign() {
 
 adapter_family() {
   local host="$1" family
+  # shellcheck disable=SC2016 # yq uses strenv(HOST_NAME), not shell expansion.
   family=$(HOST_NAME="$host" yq -r '
     (.adapter_profiles[strenv(HOST_NAME)].provider_family // "") as $direct
     | if $direct != "" then $direct
@@ -85,10 +86,11 @@ fi
 selected_key=""
 while IFS= read -r key; do
   [ -n "$key" ] && [ "$key" != "null" ] || continue
-  if MODEL_KEY="$key" REVIEW_FAMILY="$review_family" REVIEW_HOST_NAME="$REVIEW_HOST" yq -e '
+  # shellcheck disable=SC2016 # yq uses strenv(...) values supplied for this invocation.
+  if MODEL_KEY="$key" REVIEW_FAMILY="$review_family" REVIEW_HOST_NAME="$REVIEW_HOST" ROLE_NAME="$ROLE" yq -e '
       .models[strenv(MODEL_KEY)] != null
       and .models[strenv(MODEL_KEY)].provider_family == strenv(REVIEW_FAMILY)
-      and ((.models[strenv(MODEL_KEY)].role_suitability // []) | contains(["reviewer"]))
+      and ((.models[strenv(MODEL_KEY)].role_suitability // []) | contains([(strenv(ROLE_NAME) | split(".")[0])]))
       and ((.models[strenv(MODEL_KEY)].adapter_profiles // []) | contains([strenv(REVIEW_HOST_NAME)]))
     ' "$CATALOG" >/dev/null 2>&1; then
     selected_key="$key"

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -980,7 +980,7 @@ Bump build number to ${NEW_BUILD_NUMBER}
 
 Preparing TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) from branch ${BRANCH}.
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Studio-Host: release-manager
 EOF
 )"; then
       cd "$oldpwd" || true

--- a/scripts/test-fixtures/322-model-policy/test-model-policy.sh
+++ b/scripts/test-fixtures/322-model-policy/test-model-policy.sh
@@ -40,7 +40,17 @@ bash "$ROOT/scripts/resolve-reviewer-model.sh" \
 claude_rc=$?
 assert "claude reviewer resolves for openai implementation" "[ '$claude_rc' -eq 0 ]"
 assert "claude reviewer uses anthropic family" "grep -q '^REVIEWER_MODEL_PROVIDER_FAMILY=anthropic$' '$claude_out'"
-assert "claude reviewer uses opus" "grep -q '^REVIEWER_MODEL_ID=claude-opus-4-1-20250805$' '$claude_out'"
+assert "claude reviewer uses sonnet" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-20250514$' '$claude_out'"
+assert "claude reviewer uses medium reasoning" "grep -q '^REVIEWER_MODEL_REASONING_EFFORT=medium$' '$claude_out'"
+
+planner_out="$TMPROOT/planner.out"
+bash "$ROOT/scripts/resolve-reviewer-model.sh" \
+  --review-host claude-reviewer \
+  --implementation-host codex \
+  --role planner.heavyweight >"$planner_out" 2>"$planner_out.err"
+planner_rc=$?
+assert "claude planner resolves for openai implementation" "[ '$planner_rc' -eq 0 ]"
+assert "claude planner uses sonnet" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-20250514$' '$planner_out'"
 
 same_out="$TMPROOT/same.out"
 if bash "$ROOT/scripts/resolve-reviewer-model.sh" \

--- a/scripts/test-fixtures/454-phase-review/test-phase-review.sh
+++ b/scripts/test-fixtures/454-phase-review/test-phase-review.sh
@@ -143,6 +143,8 @@ fi
 grep -q 'PHASE_REVIEW_HOST=claude-reviewer' "$out"
 grep -q 'PHASE_REVIEW_OUTPUT=' "$out"
 grep -q 'PHASE_REVIEW_VERDICT=clean' "$out"
+grep -q 'PHASE_REVIEW_MODEL_ID=claude-sonnet-4-20250514' "$out"
+grep -q 'PHASE_REVIEW_REASONING_EFFORT=medium' "$out"
 grep -q 'nothing fatal' "$output"
 [ ! -s "$output.err" ]
 


### PR DESCRIPTION
## Summary
- make Claude reviewer/planner model policy prefer Sonnet with medium reasoning
- pass resolved reviewer models through phase-review instead of relying on Claude CLI defaults
- remove active Opus 4.7 release commit trailer text and refresh model examples

## Verification
- scripts/test-fixtures/322-model-policy/test-model-policy.sh
- scripts/check-model-catalog.sh
- scripts/test-fixtures/454-phase-review/test-phase-review.sh
- scripts/test-fixtures/321-claude-reviewer/test-claude-reviewer.sh
- shellcheck -x -P scripts scripts/resolve-reviewer-model.sh scripts/phase-review.sh scripts/budget-report.sh scripts/test-fixtures/322-model-policy/test-model-policy.sh scripts/test-fixtures/454-phase-review/test-phase-review.sh
- shellcheck -x -P scripts --exclude=SC2034,SC2054,SC2094,SC2004,SC2015,SC2155 scripts/studio-tf-push.sh