### PR TITLE
Use Sonnet 4.6 high for Claude planning

### DIFF
--- a/_shared/contracts/events.md
+++ b/_shared/contracts/events.md
@@ -325,7 +325,7 @@ Transport stays JSONL. These are attribute names, not a protocol change.
 |---|---|
 | `gen_ai.agent.id` | Task ID or round ID for the current operation. |
 | `gen_ai.conversation.id` | Same as task ID — the logical conversation thread. |
-| `gen_ai.request.model` | Model identifier (e.g. `claude-sonnet-4-20250514`). |
+| `gen_ai.request.model` | Model identifier (e.g. `claude-sonnet-4-6`). |
 | `gen_ai.usage.input_tokens` | Integer. Omit when not available (e.g. most mid-session events). |
 | `gen_ai.usage.output_tokens` | Integer. Omit when not available. |
 

--- a/_shared/rules/model-policy.yaml
+++ b/_shared/rules/model-policy.yaml
@@ -72,7 +72,7 @@ roles:
   reviewer.reasoning_effort:
     default: medium
     routine_after_telemetry: medium
-    rule: "Use Sonnet for Claude review/planner defaults. Opus is a last-resort tier only when explicitly justified as extreme need; do not use unverified Opus snapshots such as Opus 4.7 by default."
+    rule: "Use Sonnet 4.6 with high effort for Claude review/planner defaults. Opus is a last-resort tier only when explicitly justified as extreme need; do not use unverified Opus snapshots such as Opus 4.7 by default."
 reviewer_selection:
   default_role: reviewer.heavyweight
   fallback_role: reviewer.fallback

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-16T20:25:21Z",
+  "generated_at": "2026-05-16T20:38:14Z",
   "agents": [
 
   ]

--- a/_shared/schemas/debrief.md
+++ b/_shared/schemas/debrief.md
@@ -25,7 +25,7 @@ mode: task                                       # task | direct-debrief
 state: emitted                                   # emitted | ingested | superseded
 completed_at: 2026-04-22T12:40:51Z
 executed_with:                                   # 2.1.0; multi-model accountability — populated from scripts/emit-agent-boot.sh data
-  model_id: "claude-sonnet-4-20250514"           # canonical model id (e.g. "claude-sonnet-4-20250514", "gpt-5-codex")
+  model_id: "claude-sonnet-4-6"                  # canonical model id (e.g. "claude-sonnet-4-6", "gpt-5-codex")
   host: claude-code                              # claude-code | codex | <future-host>
   session_id: "session-42"                       # producer session id (matches agent-boot event)
   duration_s: 8246                               # integer seconds — wall-clock duration of the implementing session

--- a/_shared/schemas/model-catalog.yaml
+++ b/_shared/schemas/model-catalog.yaml
@@ -24,6 +24,9 @@ official_sources:
   anthropic_models:
     url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
     last_verified_at: 2026-05-02T00:00:00Z
+  aws_bedrock_claude_sonnet_4_6:
+    url: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html
+    last_verified_at: 2026-05-17T00:00:00Z
 provider_families:
   openai:
     display_name: OpenAI
@@ -91,8 +94,8 @@ models:
       url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
       last_verified_at: 2026-05-02T00:00:00Z
   sonnet:
-    id: claude-sonnet-4-20250514
-    display_name: Claude Sonnet 4
+    id: claude-sonnet-4-6
+    display_name: Claude Sonnet 4.6
     provider_family: anthropic
     adapter_profiles:
       - claude-code
@@ -108,23 +111,23 @@ models:
       - editor
       - triage
     stable_aliases:
-      - claude-sonnet-4-0
+      - claude-sonnet-4-6
     snapshot_ids:
-      - claude-sonnet-4-20250514
+      - claude-sonnet-4-6
     reasoning_effort:
       supported: true
       levels:
         - medium
         - high
-      default: medium
+      default: high
       provider_name: extended_thinking
-    released_at: 2025-05-14
-    variant_1m: false
+    released_at: 2026-02-17
+    variant_1m: true
     supports_fast: true
     knowledge_cutoff: null
     source:
-      url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
-      last_verified_at: 2026-05-02T00:00:00Z
+      url: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html
+      last_verified_at: 2026-05-17T00:00:00Z
   haiku:
     id: claude-3-5-haiku-20241022
     display_name: Claude Haiku 3.5

--- a/_shared/schemas/model-rates.json
+++ b/_shared/schemas/model-rates.json
@@ -7,19 +7,19 @@
   },
   "comment": "Deprecated 2026-04-22. Originally held per-million USD token rates to derive cost_usd on agent_session_completed events. The user is on the Claude Max plan (flat subscription, no per-token billing), so $-denominated telemetry was misleading — dropped in Phase 2.6 (see _shared/patterns/consumption-telemetry.md). Kept one cycle for any out-of-tree reader; remove at Phase 2.7 cutover. The rate values below are frozen and no longer read by budget-report.sh.",
   "rates": {
-    "claude-opus-4-7": {
+    "claude-opus-4-6": {
       "input": 15.00,
       "output": 75.00,
       "cache_read": 1.50,
       "cache_write": 18.75
     },
-    "claude-sonnet-4-7": {
+    "claude-sonnet-4-6": {
       "input": 3.00,
       "output": 15.00,
       "cache_read": 0.30,
       "cache_write": 3.75
     },
-    "claude-haiku-4-7": {
+    "claude-haiku-4-6": {
       "input": 0.80,
       "output": 4.00,
       "cache_read": 0.08,

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-16T20:25:21Z",
+  "generated_at": "2026-05-16T20:38:13Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/322-model-policy/test-model-policy.sh
+++ b/scripts/test-fixtures/322-model-policy/test-model-policy.sh
@@ -40,8 +40,8 @@ bash "$ROOT/scripts/resolve-reviewer-model.sh" \
 claude_rc=$?
 assert "claude reviewer resolves for openai implementation" "[ '$claude_rc' -eq 0 ]"
 assert "claude reviewer uses anthropic family" "grep -q '^REVIEWER_MODEL_PROVIDER_FAMILY=anthropic$' '$claude_out'"
-assert "claude reviewer uses sonnet" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-20250514$' '$claude_out'"
-assert "claude reviewer uses medium reasoning" "grep -q '^REVIEWER_MODEL_REASONING_EFFORT=medium$' '$claude_out'"
+assert "claude reviewer uses sonnet 4.6" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-6$' '$claude_out'"
+assert "claude reviewer uses high reasoning" "grep -q '^REVIEWER_MODEL_REASONING_EFFORT=high$' '$claude_out'"
 
 planner_out="$TMPROOT/planner.out"
 bash "$ROOT/scripts/resolve-reviewer-model.sh" \
@@ -50,7 +50,8 @@ bash "$ROOT/scripts/resolve-reviewer-model.sh" \
   --role planner.heavyweight >"$planner_out" 2>"$planner_out.err"
 planner_rc=$?
 assert "claude planner resolves for openai implementation" "[ '$planner_rc' -eq 0 ]"
-assert "claude planner uses sonnet" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-20250514$' '$planner_out'"
+assert "claude planner uses sonnet 4.6" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-6$' '$planner_out'"
+assert "claude planner uses high reasoning" "grep -q '^REVIEWER_MODEL_REASONING_EFFORT=high$' '$planner_out'"
 
 same_out="$TMPROOT/same.out"
 if bash "$ROOT/scripts/resolve-reviewer-model.sh" \

--- a/scripts/test-fixtures/454-phase-review/test-phase-review.sh
+++ b/scripts/test-fixtures/454-phase-review/test-phase-review.sh
@@ -143,8 +143,8 @@ fi
 grep -q 'PHASE_REVIEW_HOST=claude-reviewer' "$out"
 grep -q 'PHASE_REVIEW_OUTPUT=' "$out"
 grep -q 'PHASE_REVIEW_VERDICT=clean' "$out"
-grep -q 'PHASE_REVIEW_MODEL_ID=claude-sonnet-4-20250514' "$out"
-grep -q 'PHASE_REVIEW_REASONING_EFFORT=medium' "$out"
+grep -q 'PHASE_REVIEW_MODEL_ID=claude-sonnet-4-6' "$out"
+grep -q 'PHASE_REVIEW_REASONING_EFFORT=high' "$out"
 grep -q 'nothing fatal' "$output"
 [ ! -s "$output.err" ]
 


### PR DESCRIPTION
## Summary
- update the Anthropic Sonnet catalog default to claude-sonnet-4-6
- set Sonnet 4.6 reasoning default to high for Claude reviewer/planner resolution
- refresh model policy examples, deprecated rate labels, and fixtures

## Verification
- scripts/test-fixtures/322-model-policy/test-model-policy.sh
- scripts/check-model-catalog.sh
- scripts/test-fixtures/454-phase-review/test-phase-review.sh
- shellcheck -x -P scripts scripts/test-fixtures/322-model-policy/test-model-policy.sh scripts/test-fixtures/454-phase-review/test-phase-review.sh
- git diff --check