### PR TITLE
bugfix-wip: enforce trailers on parent commits

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-17T01:31:20Z",
+  "generated_at": "2026-05-17T06:34:02Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-17T01:31:20Z",
+  "generated_at": "2026-05-17T06:34:01Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -216,15 +216,35 @@ chain_git_parent_finalize_has_public_diff() {
     | grep -q .
 }
 
+chain_git_valid_change_type() {
+  case "${1:-}" in
+    feature|bugfix-shipped|bugfix-wip|regression-fix|refactor|docs|test|chore|release) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 chain_git_parent_finalize_issue_commit() {
-  local issue_worktree="${1:?usage: chain_git_parent_finalize_issue_commit <issue-worktree> <issue-number> <summary-file>}"
+  local issue_worktree="${1:?usage: chain_git_parent_finalize_issue_commit <issue-worktree> <issue-number> <summary-file> [host] }"
   local issue="${2:?issue number required}"
   local summary_file="${3:?summary file required}"
-  local issue_title subject
+  local host="${4:-}"
+  local issue_title subject change_type
 
   chain_git_parent_finalize_summary_eligible "$summary_file" || return 1
   chain_git_parent_finalize_has_public_diff "$issue_worktree" || return 1
   issue_title=$(jq -r '.issue_title // empty' "$summary_file" 2>/dev/null || true)
+  change_type=$(jq -r '.change_type // .commit_change_type // .commit_metadata.change_type // .commit_trailers.change_type // empty' "$summary_file" 2>/dev/null || true)
+  if ! chain_git_valid_change_type "$change_type"; then
+    printf 'chain-git: parent finalize refusing commit without valid summary change_type trailer value\n' >&2
+    return 1
+  fi
+  if [ -z "$host" ] || [ "$host" = "unknown" ]; then
+    host=$(jq -r '.host // .worker_host // empty' "$summary_file" 2>/dev/null || true)
+  fi
+  if [ -z "$host" ] || [ "$host" = "unknown" ]; then
+    printf 'chain-git: parent finalize refusing commit without known worker host\n' >&2
+    return 1
+  fi
 
   git -C "$issue_worktree" reset -q -- .studio '.git[0-9]*' '.git-*' 2>/dev/null || true
   rm -rf "$issue_worktree/.studio"
@@ -248,7 +268,23 @@ chain_git_parent_finalize_issue_commit() {
   else
     subject="Implement #$issue"
   fi
-  git -C "$issue_worktree" commit -m "$subject" -m "Closes #$issue"
+  case "$host" in
+    codex|codex-*|*codex*)
+      git -C "$issue_worktree" commit \
+        -m "$subject" \
+        -m "Closes #$issue" \
+        -m "Change-Type: $change_type" \
+        -m "Studio-Host: $host" \
+        -m "Co-authored-by: Codex <noreply@openai.com>"
+      ;;
+    *)
+      git -C "$issue_worktree" commit \
+        -m "$subject" \
+        -m "Closes #$issue" \
+        -m "Change-Type: $change_type" \
+        -m "Studio-Host: $host"
+      ;;
+  esac
 }
 
 chain_git_parent_finalize_event_payload() {

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -7327,6 +7327,7 @@ Rules:
 - Include "Change-Type: <type>" and "Studio-Host: $host" trailers.
 - If $host is codex, include exactly one "Co-authored-by: Codex <noreply@openai.com>" trailer.
 - Before exit, write $summary_path as valid JSON.
+- Set summary field "change_type" to the same value used in the Change-Type trailer.
 - Do not add or commit $summary_path; it is a private parent-runner artifact.
 - Do not open a PR.
 - Do not merge to the source branch ($source_branch) or main.
@@ -7345,6 +7346,7 @@ Summary JSON fields:
 - issue_number: $issue
 - issue_title: "$issue_title"
 - host: "$host"
+- change_type: feature|bugfix-shipped|bugfix-wip|regression-fix|refactor|docs|test|chore|release
 - model/model_version/effort when known, otherwise null
 - started_at/ended_at/duration_s
 - exit_code
@@ -7854,7 +7856,7 @@ run_issue_job() {
     && chain_git_parent_finalize_summary_eligible "$summary_file" \
     && chain_git_parent_finalize_has_public_diff "$issue_worktree"; then
     log "issue #$issue worker could not write git metadata; parent finalizing commit"
-    if chain_git_parent_finalize_issue_commit "$issue_worktree" "$issue" "$summary_file"; then
+    if chain_git_parent_finalize_issue_commit "$issue_worktree" "$issue" "$summary_file" "$host"; then
       after=$(git -C "$issue_worktree" rev-parse HEAD)
       refresh_summary_commit_metrics "$summary_file" "$issue_worktree" "$before" "$after" true
       parent_finalized=true

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -48,6 +48,8 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
   "status": "blocked",
   "issue_number": 584,
   "issue_title": "Parent finalize fixture",
+  "host": "codex",
+  "change_type": "bugfix-wip",
   "commit_before": "base",
   "commit_after": null,
   "blocked_reason": "Unable to stage or commit: filesystem denies writes inside .git creating .git/index.lock with Operation not permitted.",
@@ -104,11 +106,17 @@ if chain_git_parent_finalize_summary_eligible "$TMPROOT/primary-advanced-summary
 fi
 chain_git_parent_finalize_has_public_diff "$REPO" \
   || fail "public diff was not detected"
-chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-summary.json" \
+chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-summary.json" codex \
   || fail "parent finalize did not commit"
 
 git -C "$REPO" log -1 --format=%B | grep -q 'Closes #584' \
   || fail "parent commit did not close issue"
+git -C "$REPO" log -1 --format=%B | grep -q 'Change-Type: bugfix-wip' \
+  || fail "parent commit did not include Change-Type trailer"
+git -C "$REPO" log -1 --format=%B | grep -q 'Studio-Host: codex' \
+  || fail "parent commit did not include Studio-Host trailer"
+git -C "$REPO" log -1 --format=%B | grep -q 'Co-authored-by: Codex <noreply@openai.com>' \
+  || fail "parent commit did not include Codex coauthor trailer"
 git -C "$REPO" log -1 --format=%s | grep -qx 'Parent finalize fixture (#584)' \
   || fail "parent commit subject did not use issue title"
 git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'README.md' \
@@ -173,6 +181,33 @@ cat > "$TMPROOT/unknown-outcome/.studio/chain-worker-summary.json" <<'JSON'
 JSON
 if chain_git_parent_finalize_summary_eligible "$TMPROOT/unknown-outcome/.studio/chain-worker-summary.json"; then
   fail "unknown passed_* outcome was eligible"
+fi
+
+MISSING_CHANGE_REPO="$TMPROOT/missing-change-type-repo"
+mkdir -p "$MISSING_CHANGE_REPO/.studio"
+git -C "$MISSING_CHANGE_REPO" init -q
+git -C "$MISSING_CHANGE_REPO" config user.email studio@example.invalid
+git -C "$MISSING_CHANGE_REPO" config user.name "Studio Test"
+printf 'base\n' > "$MISSING_CHANGE_REPO/README.md"
+git -C "$MISSING_CHANGE_REPO" add README.md
+git -C "$MISSING_CHANGE_REPO" commit -q -m "base"
+printf 'base\nchange\n' > "$MISSING_CHANGE_REPO/README.md"
+cat > "$TMPROOT/missing-change-type-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "issue_number": 584,
+  "issue_title": "Missing change type fixture",
+  "host": "codex",
+  "commit_before": "base",
+  "commit_after": null,
+  "blocked_reason": "Unable to stage or commit: .git/index.lock Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "passed"}]
+}
+JSON
+if chain_git_parent_finalize_issue_commit "$MISSING_CHANGE_REPO" 584 "$TMPROOT/missing-change-type-summary.json" codex; then
+  fail "parent finalize committed without change_type"
 fi
 
 mkdir -p "$TMPROOT/secret/.studio"


### PR DESCRIPTION
## Problem
Parent-finalized chain commits could be created without the commit taxonomy and host trailers required by studio commit guidelines.

## Solution
Require worker summaries to include a valid change_type before parent finalization, and have the parent commit writer add Change-Type, Studio-Host, and the official Codex co-author trailer for Codex-hosted commits.

## Verification
- bash scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
- bash scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- scripts/pre-commit-review.sh --review-host codex-reviewer

Change-Type: bugfix-wip
Studio-Host: codex
Co-authored-by: Codex <noreply@openai.com>