### PR TITLE
bugfix-wip: enforce structured commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,9 @@ The initial taxonomy values are:
 
 ### Commit message discipline
 
-- **Subject:** should state why the change was made and include one taxonomy label via a subject prefix or explicit body marker.
-- **Body:** include `Problem`, `Solution`, `Implementation notes`, and `Caveats` when useful.
-- **Churn rules:** XS WIP feature tasks may be one commit; larger independent changes should be split by logical behavior/tests/docs/workflow boundaries.
+- **Subject:** must start with `<taxonomy>: ` and then state the developer-readable what/why headline.
+- **Body:** host-authored commits must include `Affected-Areas`, `Problem`, `Solution`, `Changelog`, `Implementation notes`, and `Caveats`. `Affected-Areas` is the module/surface index for regression triage. `Changelog` is the brief TestFlight/release bullet source; keep implementation detail in `Implementation notes`.
+- **Churn rules:** Commits should be logically grouped for future regression triage. Prefer smaller commits, but the hard requirement is no unrelated behavior, docs, test, or workflow changes in the same commit unless the body explains the shared problem/solution.
 - **Branch shape:** feature branches should not contain merge commits. Existing chain integration already enforces this via rebase + fast-forward-only merge paths in `scripts/lib-chain-git.sh`; do not treat this as greenfield.
 - **Dependencies:** dependent branches should rebase or retarget rather than feature-to-feature merge.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -341,11 +341,16 @@ Commit discipline is part of review quality for host-routed changes:
 
 - **Block (hard gate):**
   - Commit messages are missing an explicit taxonomy label (`feature`, `bugfix-shipped`, `bugfix-wip`, `regression-fix`, `refactor`, `docs`, `test`, `chore`, `release`) in the subject or body.
+  - Host-authored commit subjects do not start with `<taxonomy>: `.
+  - Host-authored commits omit any required structured field: `Affected-Areas`, `Problem`, `Solution`, `Changelog`, `Implementation notes`, or `Caveats`.
   - Feature-branch history includes merge commits before the PR merge/rebase path.
 
 - **Ask (investigate before merge):**
   - Subject does not explain *why* the change was made.
-  - Non-trivial change lacks `Problem`, `Solution`, or `Implementation notes` sections in the commit body.
+  - `Changelog` is too implementation-heavy to become a TestFlight/release bullet.
+  - `Affected-Areas` is too broad to help regression triage, or lists unrelated areas without a shared problem/solution.
+  - A commit combines unrelated logical changes that should be separate for retrospective debugging.
+  - Non-trivial human-authored change lacks `Problem`, `Solution`, or `Implementation notes` sections in the commit body.
   - Subject/body does not distinguish `bugfix-shipped` vs `bugfix-wip` for a bugfix change.
 
 - **Warn (note but proceed unless risk increases):**
@@ -357,6 +362,8 @@ Commit discipline is part of review quality for host-routed changes:
 - Prefer machine-readable host identity from `.studio/chain-task-start.json` / `.studio/chain-worker-summary.json` (`host`, `model`, `model_version`) over parsing `Co-authored-by:` in commit footers.
 - For Codex-hosted commits, keep `Studio-Host: codex` and add the GitHub-visible Codex co-author trailer `Co-authored-by: Codex <noreply@openai.com>`.
 - Verify the commit subject is imperative and change-oriented; use `git log`/`git show` on staged commits or PR payload to validate body structure.
+- Verify `Changelog` is a brief tester/release-facing overview and `Implementation notes` carries the detailed automation/reviewer context.
+- Verify `Affected-Areas` names the modules, product surfaces, commands, scripts, or workflows most likely to explain a future regression.
 - Verify taxonomy labels stay within the canonical set above.
 - Block-and-ask findings should be explicit in review output; hard blocks must state the minimum fix.
 

--- a/_shared/contracts/build-message-format.md
+++ b/_shared/contracts/build-message-format.md
@@ -27,6 +27,14 @@ release does not overstate an unshipped fix. Missing trailers must fall back to
 the subject/body without leaking raw trailer names into Slack or App Store
 bullets.
 
+Host-authored commits use the stricter canonical shape: subject
+`<Change-Type>: <developer what/why headline>`, then `Affected-Areas:`,
+`Problem:`, `Solution:`, `Changelog:`, `Implementation notes:`, `Caveats:`,
+`Change-Type:`, and `Studio-Host:`. `Affected-Areas:` is the module/surface
+index for future regression triage. The composer treats `Changelog:` as the
+preferred tester/release-facing bullet, while `Implementation notes:` remains
+detailed context for agents and reviewers.
+
 ## Headline
 
 - **TF:** `[iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. `<!here>` is opt-in via release config and is off by default.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-17T06:34:02Z",
+  "generated_at": "2026-05-17T08:52:28Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-17T06:34:01Z",
+  "generated_at": "2026-05-17T08:52:28Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/compose-build-release-message.sh
+++ b/scripts/compose-build-release-message.sh
@@ -86,9 +86,10 @@ def parse_block(block: str) -> dict[str, object]:
         "body": body,
         "trailers": trailers,
         "change_type": trailers.get("change-type", "").lower(),
+        "affected_areas": trailers.get("affected-areas", ""),
         "problem": trailers.get("problem", ""),
         "solution": trailers.get("solution", ""),
-        "caveat": trailers.get("caveat", ""),
+        "caveat": trailers.get("caveat", "") or trailers.get("caveats", ""),
         "changelog": trailers.get("changelog", ""),
     }
 

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -228,7 +228,7 @@ chain_git_parent_finalize_issue_commit() {
   local issue="${2:?issue number required}"
   local summary_file="${3:?summary file required}"
   local host="${4:-}"
-  local issue_title subject change_type
+  local issue_title subject change_type affected_areas problem solution changelog implementation_notes caveats
 
   chain_git_parent_finalize_summary_eligible "$summary_file" || return 1
   chain_git_parent_finalize_has_public_diff "$issue_worktree" || return 1
@@ -243,6 +243,16 @@ chain_git_parent_finalize_issue_commit() {
   fi
   if [ -z "$host" ] || [ "$host" = "unknown" ]; then
     printf 'chain-git: parent finalize refusing commit without known worker host\n' >&2
+    return 1
+  fi
+  affected_areas=$(jq -r '.affected_areas // .commit_affected_areas // .commit_metadata.affected_areas // empty' "$summary_file" 2>/dev/null || true)
+  problem=$(jq -r '.problem // .commit_problem // .commit_metadata.problem // empty' "$summary_file" 2>/dev/null || true)
+  solution=$(jq -r '.solution // .commit_solution // .commit_metadata.solution // empty' "$summary_file" 2>/dev/null || true)
+  changelog=$(jq -r '.changelog // .commit_changelog // .commit_metadata.changelog // empty' "$summary_file" 2>/dev/null || true)
+  implementation_notes=$(jq -r '.implementation_notes // .commit_implementation_notes // .commit_metadata.implementation_notes // empty' "$summary_file" 2>/dev/null || true)
+  caveats=$(jq -r '.caveats // .commit_caveats // .commit_metadata.caveats // empty' "$summary_file" 2>/dev/null || true)
+  if [ -z "$affected_areas" ] || [ -z "$problem" ] || [ -z "$solution" ] || [ -z "$changelog" ] || [ -z "$implementation_notes" ] || [ -z "$caveats" ]; then
+    printf 'chain-git: parent finalize refusing commit without complete structured commit summary fields\n' >&2
     return 1
   fi
 
@@ -264,22 +274,34 @@ chain_git_parent_finalize_issue_commit() {
   fi
 
   if [ -n "$issue_title" ]; then
-    subject="$issue_title (#$issue)"
+    subject="$change_type: $issue_title (#$issue)"
   else
-    subject="Implement #$issue"
+    subject="$change_type: implement #$issue"
   fi
   case "$host" in
     codex|codex-*|*codex*)
-      git -C "$issue_worktree" commit \
+      STUDIO_HOST="$host" git -C "$issue_worktree" commit \
         -m "$subject" \
+        -m "Affected-Areas: $affected_areas" \
+        -m "Problem: $problem" \
+        -m "Solution: $solution" \
+        -m "Changelog: $changelog" \
+        -m "Implementation notes: $implementation_notes" \
+        -m "Caveats: $caveats" \
         -m "Closes #$issue" \
         -m "Change-Type: $change_type" \
         -m "Studio-Host: $host" \
         -m "Co-authored-by: Codex <noreply@openai.com>"
       ;;
     *)
-      git -C "$issue_worktree" commit \
+      STUDIO_HOST="$host" git -C "$issue_worktree" commit \
         -m "$subject" \
+        -m "Affected-Areas: $affected_areas" \
+        -m "Problem: $problem" \
+        -m "Solution: $solution" \
+        -m "Changelog: $changelog" \
+        -m "Implementation notes: $implementation_notes" \
+        -m "Caveats: $caveats" \
         -m "Closes #$issue" \
         -m "Change-Type: $change_type" \
         -m "Studio-Host: $host"

--- a/scripts/lint-commit-message.sh
+++ b/scripts/lint-commit-message.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # lint-commit-message.sh - validate commit trailers for studio-managed commits.
 #
-# Supported trailers:
+# Supported fields:
+#   <change-type>: <developer headline>
+#   Affected-Areas: <module/surface list>
+#   Problem: <why this was needed>
+#   Solution: <what changed>
+#   Changelog: <tester/release-facing bullet source>
+#   Implementation notes: <automation/reviewer details>
+#   Caveats: <risks, limits, skipped verification, or None>
 #   Change-Type: <change-type>
 #   Studio-Host: <host-id>
 #   Co-authored-by: Codex <noreply@openai.com>
@@ -56,11 +63,23 @@ fail() { errs=$((errs + 1)); printf 'lint-commit-message: ERROR: %s\n' "$1" >&2;
 
 change_type=""
 studio_host=""
+affected_areas=""
+problem=""
+solution=""
+changelog=""
+implementation_notes=""
+caveats=""
 coauthored_by_seen=0
 codex_coauthor_seen=0
 bad_codex_coauthor=""
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in
+    Problem:*) problem=$(trim "${line#Problem:}") ;;
+    Affected-Areas:*) affected_areas=$(trim "${line#Affected-Areas:}") ;;
+    Solution:*) solution=$(trim "${line#Solution:}") ;;
+    Changelog:*) changelog=$(trim "${line#Changelog:}") ;;
+    Implementation\ notes:*) implementation_notes=$(trim "${line#Implementation notes:}") ;;
+    Caveats:*) caveats=$(trim "${line#Caveats:}") ;;
     Change-Type:*) change_type=$(trim "${line#Change-Type:}") ;;
     Studio-Host:*) studio_host=$(trim "${line#Studio-Host:}") ;;
     Co-authored-by:*)
@@ -109,6 +128,38 @@ elif ! valid_change_type "$change_type"; then
   fi
 fi
 
+if [ -n "$change_type" ] && valid_change_type "$change_type"; then
+  case "$first_line" in
+    "$change_type":\ ?*) ;;
+    *)
+      if [ "$strict_for_hosted" -eq 1 ]; then
+        fail "commit subject must start with '${change_type}: ' followed by a developer-readable why/what headline"
+      else
+        warn "commit subject should start with '${change_type}: ' followed by a developer-readable why/what headline"
+      fi
+      ;;
+  esac
+fi
+
+require_field() {
+  local label="$1" value="$2" purpose="$3"
+  if [ -n "$value" ]; then
+    return 0
+  fi
+  if [ "$strict_for_hosted" -eq 1 ]; then
+    fail "missing required ${label}: ${purpose}"
+  else
+    warn "missing recommended ${label}: ${purpose}"
+  fi
+}
+
+require_field "Affected-Areas" "$affected_areas" "module/surface list for regression triage"
+require_field "Problem" "$problem" "why the change was needed"
+require_field "Solution" "$solution" "what changed"
+require_field "Changelog" "$changelog" "brief TestFlight/release bullet source"
+require_field "Implementation notes" "$implementation_notes" "details agents and reviewers can use"
+require_field "Caveats" "$caveats" "risks, limits, skipped work, or None"
+
 if [ -z "$studio_host" ]; then
   if [ "$strict_for_hosted" -eq 1 ]; then
     fail "missing trailer Studio-Host: <host-id> (strict for host-authored automation; e.g., Studio-Host: ${known_host})"
@@ -122,7 +173,7 @@ if [ "$coauthored_by_seen" -eq 1 ] && [ -z "$studio_host" ] && [ "$errs" -eq 0 ]
 fi
 
 case "$studio_host" in
-  codex|codex-reviewer)
+  codex|codex-*|*codex*)
     if [ -n "$bad_codex_coauthor" ]; then
       warn "Codex co-author trailer should be exactly: Co-authored-by: Codex <noreply@openai.com> (found: $bad_codex_coauthor)"
     elif [ "$codex_coauthor_seen" -eq 0 ]; then
@@ -132,7 +183,7 @@ case "$studio_host" in
 esac
 
 if [ "$errs" -gt 0 ]; then
-  printf 'commit message must include valid Change-Type and Studio-Host trailers\n' >&2
+  printf 'commit message must include the structured subject, required body fields, and valid Change-Type/Studio-Host trailers\n' >&2
   printf 'To bypass only in emergency, set STUDIO_BYPASS_COMMIT_TRAILER_LINT=1\n' >&2
   exit 1
 fi

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -7323,6 +7323,10 @@ Rules:
 - Implement only issue #$issue.
 - Keep changes scoped to this issue.
 - Commit the result on the current branch.
+- Use commit subject "<change-type>: <developer-readable why/what headline>".
+- Include commit body fields "Affected-Areas:", "Problem:", "Solution:", "Changelog:", "Implementation notes:", and "Caveats:".
+- Use "Affected-Areas:" for comma-separated modules, surfaces, commands, or workflows likely to be relevant in regression triage.
+- Use "Changelog:" for a brief tester/release-facing bullet; keep implementation detail out of it.
 - Include "Closes #$issue" in the commit message.
 - Include "Change-Type: <type>" and "Studio-Host: $host" trailers.
 - If $host is codex, include exactly one "Co-authored-by: Codex <noreply@openai.com>" trailer.
@@ -7347,6 +7351,7 @@ Summary JSON fields:
 - issue_title: "$issue_title"
 - host: "$host"
 - change_type: feature|bugfix-shipped|bugfix-wip|regression-fix|refactor|docs|test|chore|release
+- affected_areas, problem, solution, changelog, implementation_notes, caveats matching the commit body fields
 - model/model_version/effort when known, otherwise null
 - started_at/ended_at/duration_s
 - exit_code
@@ -7414,6 +7419,7 @@ EOF
         STUDIO_CONTEXT_HOST_PROFILE="$worker_host_profile" \
         STUDIO_CONTEXT_AUTH_HOME="$codex_auth_home" \
         STUDIO_CONTEXT_GITHUB_HOME="$github_home" \
+        STUDIO_HOST="$host" \
         STUDIO_RUN_ID="$RUN_ID" \
         STUDIO_CHAIN_RUN_ID="$chain_run_id" \
         STUDIO_ISSUE_RUN_ID="$issue_run_id" \
@@ -7430,6 +7436,7 @@ EOF
         STUDIO_CONTEXT_HOST_PROFILE="$worker_host_profile" \
         STUDIO_CONTEXT_AUTH_HOME="$launch_home" \
         STUDIO_CONTEXT_GITHUB_HOME="$github_home" \
+        STUDIO_HOST="$host" \
         STUDIO_RUN_ID="$RUN_ID" \
         STUDIO_CHAIN_RUN_ID="$chain_run_id" \
         STUDIO_ISSUE_RUN_ID="$issue_run_id" \
@@ -7448,6 +7455,7 @@ EOF
         STUDIO_CONTEXT_HOST_PROFILE="$worker_host_profile" \
         STUDIO_CONTEXT_AUTH_HOME="$codex_auth_home" \
         STUDIO_CONTEXT_GITHUB_HOME="$github_home" \
+        STUDIO_HOST="$host" \
         STUDIO_RUN_ID="$RUN_ID" \
         STUDIO_CHAIN_RUN_ID="$chain_run_id" \
         STUDIO_ISSUE_RUN_ID="$issue_run_id" \
@@ -7464,6 +7472,7 @@ EOF
         STUDIO_CONTEXT_HOST_PROFILE="$worker_host_profile" \
         STUDIO_CONTEXT_AUTH_HOME="$launch_home" \
         STUDIO_CONTEXT_GITHUB_HOME="$github_home" \
+        STUDIO_HOST="$host" \
         STUDIO_CHAIN_RUN_ID="$chain_run_id" \
         STUDIO_ISSUE_RUN_ID="$issue_run_id" \
         STUDIO_CHAIN_ARTIFACT_ROOT="$chain_artifact_root" \

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -976,10 +976,21 @@ cmd_push() {
       printf 'studio-tf-push: pbxproj already at target build=%s version=%s; skipping bump commit\n' \
         "$NEW_BUILD_NUMBER" "$VERSION" >&2
     elif ! git commit -m "$(cat <<EOF
-Bump build number to ${NEW_BUILD_NUMBER}
+release: bump build number to ${NEW_BUILD_NUMBER}
 
-Preparing TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) from branch ${BRANCH}.
+Affected-Areas: release-manager, TestFlight build metadata, Xcode project versioning
 
+Problem: TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) needs a committed project-version bump before archive and upload.
+
+Solution: Update the Xcode project build and marketing version for branch ${BRANCH}.
+
+Changelog: Preparing TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) from branch ${BRANCH}.
+
+Implementation notes: The release-manager workflow updated zaps-app/Turnip.xcodeproj/project.pbxproj.
+
+Caveats: Release upload and Slack send still depend on the later gated workflow steps.
+
+Change-Type: release
 Studio-Host: release-manager
 EOF
 )"; then

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -50,6 +50,12 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
   "issue_title": "Parent finalize fixture",
   "host": "codex",
   "change_type": "bugfix-wip",
+  "affected_areas": "chain parent finalization, commit metadata",
+  "problem": "Worker completed the file changes but could not update primary git metadata.",
+  "solution": "Parent finalization creates the commit from the public diff.",
+  "changelog": "Parent finalization now preserves structured commit metadata.",
+  "implementation_notes": "The parent commit path reads structured fields from the worker summary.",
+  "caveats": "Only applies when parent finalization is eligible.",
   "commit_before": "base",
   "commit_after": null,
   "blocked_reason": "Unable to stage or commit: filesystem denies writes inside .git creating .git/index.lock with Operation not permitted.",
@@ -111,13 +117,17 @@ chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-s
 
 git -C "$REPO" log -1 --format=%B | grep -q 'Closes #584' \
   || fail "parent commit did not close issue"
+git -C "$REPO" log -1 --format=%B | grep -q 'Affected-Areas: chain parent finalization, commit metadata' \
+  || fail "parent commit did not include Affected-Areas field"
 git -C "$REPO" log -1 --format=%B | grep -q 'Change-Type: bugfix-wip' \
   || fail "parent commit did not include Change-Type trailer"
 git -C "$REPO" log -1 --format=%B | grep -q 'Studio-Host: codex' \
   || fail "parent commit did not include Studio-Host trailer"
 git -C "$REPO" log -1 --format=%B | grep -q 'Co-authored-by: Codex <noreply@openai.com>' \
   || fail "parent commit did not include Codex coauthor trailer"
-git -C "$REPO" log -1 --format=%s | grep -qx 'Parent finalize fixture (#584)' \
+git -C "$REPO" log -1 --format=%B | grep -q 'Changelog: Parent finalization now preserves structured commit metadata.' \
+  || fail "parent commit did not include Changelog field"
+git -C "$REPO" log -1 --format=%s | grep -qx 'bugfix-wip: Parent finalize fixture (#584)' \
   || fail "parent commit subject did not use issue title"
 git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'README.md' \
   || fail "README diff missing from parent commit"

--- a/scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
+++ b/scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
@@ -47,31 +47,123 @@ run_case() {
   printf 'PASS: %s\n' "$case_name"
 }
 
-valid_message="Valid commit
+valid_message="feature: enforce structured commit metadata
+
+Affected-Areas: commit hooks, release messages
+
+Problem: Automated commits need consistent metadata for humans, release notes, and agents.
+
+Solution: Require the structured commit sections and trailers.
+
+Changelog: Commit messages now carry a release-ready summary.
+
+Implementation notes: The commit-msg lint checks the canonical field labels.
+
+Caveats: None.
 
 Change-Type: feature
 Studio-Host: codex
 Co-authored-by: Codex <noreply@openai.com>"
 
-codex_missing_coauthor_message="Missing Codex coauthor
+codex_missing_coauthor_message="feature: enforce structured commit metadata
+
+Affected-Areas: commit hooks, release messages
+
+Problem: Automated commits need consistent metadata for humans, release notes, and agents.
+
+Solution: Require the structured commit sections and trailers.
+
+Changelog: Commit messages now carry a release-ready summary.
+
+Implementation notes: The commit-msg lint checks the canonical field labels.
+
+Caveats: None.
 
 Change-Type: feature
 Studio-Host: codex"
 
-codex_bad_coauthor_message="Bad Codex coauthor
+codex_bad_coauthor_message="feature: enforce structured commit metadata
+
+Affected-Areas: commit hooks, release messages
+
+Problem: Automated commits need consistent metadata for humans, release notes, and agents.
+
+Solution: Require the structured commit sections and trailers.
+
+Changelog: Commit messages now carry a release-ready summary.
+
+Implementation notes: The commit-msg lint checks the canonical field labels.
+
+Caveats: None.
 
 Change-Type: feature
 Studio-Host: codex
 Co-authored-by: Codex <codex@openai.com>"
 
-invalid_type_message="Invalid change-type
+invalid_type_message="unknown: enforce structured commit metadata
+
+Affected-Areas: commit hooks, release messages
+
+Problem: Automated commits need consistent metadata for humans, release notes, and agents.
+
+Solution: Require the structured commit sections and trailers.
+
+Changelog: Commit messages now carry a release-ready summary.
+
+Implementation notes: The commit-msg lint checks the canonical field labels.
+
+Caveats: None.
 
 Change-Type: unknown
 Studio-Host: codex"
 
-missing_host_message="Missing host metadata
+missing_host_message="docs: document structured commit metadata
+
+Affected-Areas: commit docs
+
+Problem: Commit metadata expectations were unclear.
+
+Solution: Document the structured shape.
+
+Changelog: Commit message docs now show the required release summary field.
+
+Implementation notes: Documentation-only fixture.
+
+Caveats: None.
 
 Change-Type: docs"
+
+missing_changelog_message="feature: enforce structured commit metadata
+
+Affected-Areas: commit hooks, release messages
+
+Problem: Automated commits need consistent metadata for humans, release notes, and agents.
+
+Solution: Require the structured commit sections and trailers.
+
+Implementation notes: The commit-msg lint checks the canonical field labels.
+
+Caveats: None.
+
+Change-Type: feature
+Studio-Host: codex"
+
+bad_subject_message="Structured metadata without taxonomy prefix
+
+Affected-Areas: commit hooks, release messages
+
+Problem: Automated commits need consistent metadata for humans, release notes, and agents.
+
+Solution: Require the structured commit sections and trailers.
+
+Changelog: Commit messages now carry a release-ready summary.
+
+Implementation notes: The commit-msg lint checks the canonical field labels.
+
+Caveats: None.
+
+Change-Type: feature
+Studio-Host: codex"
 
 automation_repo="$TMPROOT/automation"
 mkdir -p "$automation_repo/.studio"
@@ -91,7 +183,9 @@ run_case "codex_missing_coauthor_warns" 0 "$automation_repo" "$codex_missing_coa
 run_case "codex_bad_coauthor_warns" 0 "$automation_repo" "$codex_bad_coauthor_message" "Codex co-author trailer should be exactly"
 run_case "invalid_change_type_fails" 1 "$automation_repo" "$invalid_type_message" "invalid Change-Type trailer: unknown"
 run_case "missing_host_fails_in_automation" 1 "$automation_repo" "$missing_host_message" "missing trailer Studio-Host"
-run_case "missing_host_warns_for_human" 0 "$human_repo" "$missing_host_message" "passed with 1 warning(s)"
+run_case "missing_changelog_fails_in_automation" 1 "$automation_repo" "$missing_changelog_message" "missing required Changelog"
+run_case "bad_subject_fails_in_automation" 1 "$automation_repo" "$bad_subject_message" "commit subject must start with 'feature: '"
+run_case "missing_host_warns_for_human" 0 "$human_repo" "$missing_host_message" "passed with"
 run_case "bypass_allows_hard_failure_case" 0 "$automation_repo" "$missing_host_message" "commit trailer lint bypassed via STUDIO_BYPASS_COMMIT_TRAILER_LINT=1" 1
 
 printf 'PASS: commit-message lint fixture suite\n'


### PR DESCRIPTION
## Problem
Host-authored commits need one message shape that serves developers, release/TestFlight notes, regression triage, and agent recovery.

## Solution
Hard-gate the structured subject and body fields for hosted commits, add Affected-Areas as the regression-triage index, and make chain/release-manager commit producers emit the same shape.

## Commit shape
```text
<change-type>: <developer what/why headline>

Affected-Areas: <modules/surfaces/workflows>

Problem: <why this changed>

Solution: <what changed>

Changelog: <tester/release-facing bullet>

Implementation notes: <details for agents/reviewers>

Caveats: <risks, limits, or None>

Change-Type: <taxonomy>
Studio-Host: <host>
```

## Verification
- bash scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
- bash scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
- bash scripts/test-fixtures/692-commit-taxonomy-release-message/test-commit-taxonomy-release-message.sh
- bash -n scripts/lint-commit-message.sh scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/studio-tf-push.sh
- scripts/pre-commit-review.sh --review-host claude-reviewer

Change-Type: bugfix-wip
Studio-Host: codex
Co-authored-by: Codex <noreply@openai.com>