### PR TITLE
bugfix-wip: structure manager analyze lookup failures

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-17T08:52:28Z",
+  "generated_at": "2026-05-17T09:45:06Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-17T08:52:28Z",
+  "generated_at": "2026-05-17T09:45:06Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/analyze-feedback-ingest.sh
+++ b/scripts/analyze-feedback-ingest.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
 # shellcheck source=scripts/lib-paths.sh
 . "$SCRIPT_DIR/lib-paths.sh"
+# shellcheck source=scripts/lib-manager-structured-output.sh
+. "$SCRIPT_DIR/lib-manager-structured-output.sh"
 
 REPO="v-i-s-h-a-l/generic-dev-studio"
 INBOX_ROOT=""
@@ -183,14 +185,49 @@ issue_number_from_url() {
   sed -n 's#.*/issues/\([0-9][0-9]*\).*#\1#p' <<<"$1"
 }
 
+inbox_count_before=0
+if [ -d "$INBOX_ROOT" ]; then
+  inbox_count_before=$(find "$INBOX_ROOT" -mindepth 2 -maxdepth 2 -type f -name '*.md' \
+    -not -path '*/processed/*' 2>/dev/null | wc -l | tr -d ' ')
+fi
+
+emit_lookup_failure() {
+  local reason="$1" message="$2" mode_label
+  mode_label=$([ "$APPLY" -eq 1 ] && printf apply || printf dry-run)
+  manager_failure_json "manager_analyze_feedback_ingest" "$mode_label" "issue_lookup" "$reason" "$message" \
+    | jq \
+      --arg repo "$REPO" \
+      --arg inbox_root "$INBOX_ROOT" \
+      --argjson before "$inbox_count_before" \
+      '. + {
+        repo: $repo,
+        inbox_root: $inbox_root,
+        inbox_count_before: $before,
+        inbox_count_after: $before,
+        destination_count: 0,
+        destinations: [],
+        policy_holds: []
+      }'
+}
+
 if [ -n "$ISSUES_FILE" ]; then
-  cp "$ISSUES_FILE" "$ISSUES_JSON"
+  if ! cp "$ISSUES_FILE" "$ISSUES_JSON" 2>"$TMPDIR/issues.err"; then
+    emit_lookup_failure "issues_file_unreadable" "$(head -n 20 "$TMPDIR/issues.err")"
+    exit 1
+  fi
 else
+  set +e
   "$SCRIPT_DIR/studio-gh.sh" issue list \
     --repo "$REPO" \
     --state open \
     --limit 200 \
-    --json number,title,body,url,state > "$ISSUES_JSON"
+    --json number,title,body,url,state > "$ISSUES_JSON" 2>"$TMPDIR/issues.err"
+  issue_lookup_rc=$?
+  set -e
+  if [ "$issue_lookup_rc" -ne 0 ]; then
+    emit_lookup_failure "github_issue_lookup_failed" "$(head -n 20 "$TMPDIR/issues.err")"
+    exit "$issue_lookup_rc"
+  fi
 fi
 
 issues_tsv() {
@@ -422,12 +459,6 @@ remember_cluster_destination() {
   local key="$1" number="$2" url="$3"
   printf '%s\t%s\t%s\n' "$key" "$number" "$url" >> "$CLUSTERS_TSV"
 }
-
-inbox_count_before=0
-if [ -d "$INBOX_ROOT" ]; then
-  inbox_count_before=$(find "$INBOX_ROOT" -mindepth 2 -maxdepth 2 -type f -name '*.md' \
-    -not -path '*/processed/*' 2>/dev/null | wc -l | tr -d ' ')
-fi
 
 if [ -d "$INBOX_ROOT" ]; then
   while IFS= read -r file; do

--- a/scripts/lib-manager-structured-output.sh
+++ b/scripts/lib-manager-structured-output.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared typed output helpers for manager front doors.
+
+manager_failure_json() {
+  local kind="${1:?usage: manager_failure_json <kind> <mode> <stage> <reason> <message>}" \
+    mode="${2:-}" \
+    stage="${3:?stage required}" \
+    reason="${4:?reason required}" \
+    message="${5:-}"
+
+  jq -n \
+    --arg kind "$kind" \
+    --arg mode "$mode" \
+    --arg stage "$stage" \
+    --arg reason "$reason" \
+    --arg message "$message" \
+    '{
+      schema_version: 1,
+      kind: $kind,
+      status: "failed",
+      failure: {
+        stage: $stage,
+        reason: $reason,
+        message: $message
+      }
+    }
+    | if $mode == "" then . else .mode = $mode end'
+}

--- a/scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
+++ b/scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
@@ -81,6 +81,7 @@ MD
 OUT="$TMPROOT/out.json"
 ACTIONS="$TMPROOT/actions.jsonl"
 DRY_OUT="$TMPROOT/dry-run.json"
+LOOKUP_FAIL_OUT="$TMPROOT/lookup-failure.json"
 
 "$RUN" \
   --inbox-root "$HOME/.dev-studio/generic-dev-studio/feedback-inbox" \
@@ -95,6 +96,25 @@ jq -e '
 ' "$DRY_OUT" >/dev/null
 
 [ ! -d "$INBOX/processed" ] || fail "dry-run should not move feedback records"
+
+if "$RUN" \
+  --inbox-root "$HOME/.dev-studio/generic-dev-studio/feedback-inbox" \
+  --issues-file "$TMPROOT/missing-issues.json" > "$LOOKUP_FAIL_OUT"; then
+  fail "missing issues fixture should fail"
+fi
+
+jq -e '
+  .kind == "manager_analyze_feedback_ingest"
+  and .status == "failed"
+  and .mode == "dry-run"
+  and .failure.stage == "issue_lookup"
+  and .failure.reason == "issues_file_unreadable"
+  and .inbox_count_before == 5
+  and .inbox_count_after == 5
+  and .destination_count == 0
+  and (.destinations | length) == 0
+  and (.policy_holds | length) == 0
+' "$LOOKUP_FAIL_OUT" >/dev/null
 
 "$RUN" \
   --apply \


### PR DESCRIPTION
## Summary
- add a shared manager failure JSON envelope helper
- make manager analyze feedback ingest return structured failure output when issue lookup cannot start
- cover lookup failure in the feedback analyze fixture

## Verification
- bash -n scripts/analyze-feedback-ingest.sh scripts/lib-manager-structured-output.sh scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
- shellcheck -x scripts/analyze-feedback-ingest.sh scripts/lib-manager-structured-output.sh scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
- zsh -c 'source scripts/lib-manager-structured-output.sh && manager_failure_json demo dry-run stage reason message >/dev/null'
- scripts/test-fixtures/608-feedback-analyze-ingest/test-feedback-analyze-ingest.sh
- scripts/test-fixtures/610-manager-analyze-routing/test-manager-analyze-routing.sh
- scripts/manager-analyze.sh --cwd /tmp/studio-analyze-structured-output --dry-run
- git diff --check
- scripts/lint-runtime-paths.sh
- scripts/lint-gh-wrapper.sh
- scripts/lint-synthetic-home.sh
- scripts/lint-artifact-cleanup.sh