### PR TITLE
compact commit impact record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,8 @@ The initial taxonomy values are:
 ### Commit message discipline
 
 - **Subject:** must start with `<taxonomy>: ` and then state the developer-readable what/why headline.
-- **Body:** host-authored commits must include `Affected-Areas`, `Problem`, `Solution`, `Changelog`, `Implementation notes`, and `Caveats`. `Affected-Areas` is the module/surface index for regression triage. `Changelog` is the brief TestFlight/release bullet source; keep implementation detail in `Implementation notes`.
+- **Body:** host-authored commits should use the compact impact schema: `Impact`, `Areas`, `Release-Note`, `Why`, and `Risk`. `Impact` is the one-line net behavior or workflow change; `Areas` is the regression-triage index; `Release-Note` is the brief tester/release bullet source, or `none`; `Why` records the cause, trigger, or intent; `Risk` is `none|low|medium|high` plus a short reason. Add `Details` only when larger, risky, or cross-surface changes need deeper implementation context.
+- **Transition compatibility:** legacy hosted commits with `Affected-Areas`, `Problem`, `Solution`, `Changelog`, `Implementation notes`, and `Caveats` still pass lint while existing producers migrate. New host-authored commits should prefer the compact schema.
 - **Churn rules:** Commits should be logically grouped for future regression triage. Prefer smaller commits, but the hard requirement is no unrelated behavior, docs, test, or workflow changes in the same commit unless the body explains the shared problem/solution.
 - **Branch shape:** feature branches should not contain merge commits. Existing chain integration already enforces this via rebase + fast-forward-only merge paths in `scripts/lib-chain-git.sh`; do not treat this as greenfield.
 - **Dependencies:** dependent branches should rebase or retarget rather than feature-to-feature merge.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -30,6 +30,8 @@ Capture file for ideas that surface in conversation. `/capture` appends here ret
 
 - 2026-04-28 08:37 — Host-agnostic capture wrapper: existing `/capture` is useful but Claude-shaped through transcript paths and the Agent tool. Future work should preserve the behavior (dedupe session ideas into `IDEAS.md`, remind when pickable) behind a Forge wrapper that can read host-specific transcript/session state through adapters. [theme/host-agnostic]
 
+- 2026-05-17 10:21 — Build-to-build commit impact digest: after the compact commit record migration settles, add a scoped digest that compares two build or release boundaries and groups commits by `Areas`, `Impact`, `Release-Note`, and `Risk`. Keep it advisory at first: consume existing commit-body fields, collapse `Release-Note: none` out of tester-facing output, preserve uncategorized areas instead of enforcing a strict taxonomy, and emit a short operator/release summary plus a regression-triage index. Defer full regression-engine behavior, required area normalization, and automated risk scoring until real compact-record data shows the useful shape. [theme/release] [theme/triage]
+
 ---
 
 ## In design

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -342,19 +342,21 @@ Commit discipline is part of review quality for host-routed changes:
 - **Block (hard gate):**
   - Commit messages are missing an explicit taxonomy label (`feature`, `bugfix-shipped`, `bugfix-wip`, `regression-fix`, `refactor`, `docs`, `test`, `chore`, `release`) in the subject or body.
   - Host-authored commit subjects do not start with `<taxonomy>: `.
-  - Host-authored commits omit any required structured field: `Affected-Areas`, `Problem`, `Solution`, `Changelog`, `Implementation notes`, or `Caveats`.
+  - Host-authored commits omit both a complete compact field set (`Impact`, `Areas`, `Release-Note`, `Why`, `Risk`) and a complete legacy field set (`Affected-Areas`, `Problem`, `Solution`, `Changelog`, `Implementation notes`, `Caveats`).
+  - Host-authored compact commits use `Risk` without a `none|low|medium|high` value plus a short reason.
   - Feature-branch history includes merge commits before the PR merge/rebase path.
 
 - **Ask (investigate before merge):**
   - Subject does not explain *why* the change was made.
-  - `Changelog` is too implementation-heavy to become a TestFlight/release bullet.
-  - `Affected-Areas` is too broad to help regression triage, or lists unrelated areas without a shared problem/solution.
+  - `Release-Note` or legacy `Changelog` is too implementation-heavy to become a TestFlight/release bullet.
+  - `Areas` or legacy `Affected-Areas` is too broad to help regression triage, or lists unrelated areas without a shared problem/solution.
   - A commit combines unrelated logical changes that should be separate for retrospective debugging.
-  - Non-trivial human-authored change lacks `Problem`, `Solution`, or `Implementation notes` sections in the commit body.
+  - Non-trivial human-authored change lacks enough compact (`Impact`/`Why`/`Details`) or legacy (`Problem`/`Solution`/`Implementation notes`) context to explain the change.
   - Subject/body does not distinguish `bugfix-shipped` vs `bugfix-wip` for a bugfix change.
 
 - **Warn (note but proceed unless risk increases):**
-  - Missing or shallow `Caveats` for behavior-risky changes.
+  - Missing or shallow `Details` for larger, risky, or cross-surface compact commits.
+  - Missing or shallow legacy `Caveats` for behavior-risky changes.
   - Host identity is only inferred from `Co-authored-by:` text while machine-readable host metadata exists in `.studio/chain-task-start.json` / `.studio/chain-worker-summary.json`.
   - Codex-authored commits omit `Co-authored-by: Codex <noreply@openai.com>` or use an invented Codex email address.
 
@@ -362,8 +364,9 @@ Commit discipline is part of review quality for host-routed changes:
 - Prefer machine-readable host identity from `.studio/chain-task-start.json` / `.studio/chain-worker-summary.json` (`host`, `model`, `model_version`) over parsing `Co-authored-by:` in commit footers.
 - For Codex-hosted commits, keep `Studio-Host: codex` and add the GitHub-visible Codex co-author trailer `Co-authored-by: Codex <noreply@openai.com>`.
 - Verify the commit subject is imperative and change-oriented; use `git log`/`git show` on staged commits or PR payload to validate body structure.
-- Verify `Changelog` is a brief tester/release-facing overview and `Implementation notes` carries the detailed automation/reviewer context.
-- Verify `Affected-Areas` names the modules, product surfaces, commands, scripts, or workflows most likely to explain a future regression.
+- Verify `Release-Note` is the preferred tester/release-facing source; legacy `Changelog` remains accepted during producer migration.
+- Verify `Areas` names the modules, product surfaces, commands, scripts, or workflows most likely to explain a future regression.
+- Verify `Impact` and `Why` are one-line behavior/intent records, and `Details` carries deeper implementation context only when needed.
 - Verify taxonomy labels stay within the canonical set above.
 - Block-and-ask findings should be explicit in review output; hard blocks must state the minimum fix.
 

--- a/_shared/contracts/build-message-format.md
+++ b/_shared/contracts/build-message-format.md
@@ -19,21 +19,28 @@ changed without reading prose.
 
 When drafting from commits, prefer explicit trailers over subject guessing:
 `Change-Type: feature|bugfix-shipped|bugfix-wip|regression-fix|refactor|docs|test|chore|release`,
-plus `Problem:`, `Solution:`, `Caveat:`, or `Changelog:`. `feature` maps to
-`*New*`, shipped bug fixes map to `*Fixed*`, and internal work maps to
-`*Technical notes*` for TestFlight only. `bugfix-wip` is visible in TestFlight
-as a work-in-progress testing note and is omitted from App Store copy so the
-release does not overstate an unshipped fix. Missing trailers must fall back to
-the subject/body without leaking raw trailer names into Slack or App Store
-bullets.
+plus compact `Release-Note:`, `Impact:`, `Areas:`, `Why:`, and `Risk:` fields
+or legacy `Changelog:`, `Problem:`, `Solution:`, and `Caveat:` fields. The
+tester-facing bullet source falls back in this order: `Release-Note:`,
+`Changelog:`, `Impact:`, `Problem:`/`Solution:`, then subject. A literal
+`Release-Note: none` means the compact field does not contribute copy; the
+composer continues through the remaining fallbacks for TestFlight technical
+notes or legacy compatibility. `feature` maps to `*New*`, shipped bug fixes
+map to `*Fixed*`, and internal work maps to `*Technical notes*` for TestFlight
+only. `bugfix-wip` is visible in TestFlight as a work-in-progress testing note
+and is omitted from App Store copy so the release does not overstate an
+unshipped fix. Missing trailers must fall back to the subject/body without
+leaking raw trailer names into Slack or App Store bullets.
 
 Host-authored commits use the stricter canonical shape: subject
-`<Change-Type>: <developer what/why headline>`, then `Affected-Areas:`,
-`Problem:`, `Solution:`, `Changelog:`, `Implementation notes:`, `Caveats:`,
-`Change-Type:`, and `Studio-Host:`. `Affected-Areas:` is the module/surface
-index for future regression triage. The composer treats `Changelog:` as the
-preferred tester/release-facing bullet, while `Implementation notes:` remains
-detailed context for agents and reviewers.
+`<Change-Type>: <developer what/why headline>`, then compact `Impact:`,
+`Areas:`, `Release-Note:`, `Why:`, and `Risk:` fields, with `Details:` when
+deeper implementation context is needed. Legacy host commits with
+`Affected-Areas:`, `Problem:`, `Solution:`, `Changelog:`, `Implementation
+notes:`, and `Caveats:` remain valid inputs. `Areas:` / `Affected-Areas:` are
+the module/surface indexes for future regression triage. The composer treats
+`Release-Note:` as the preferred tester/release-facing bullet and keeps
+implementation detail out of the rendered Slack/App Store copy.
 
 ## Headline
 

--- a/_shared/contracts/release-tf-push.md
+++ b/_shared/contracts/release-tf-push.md
@@ -237,8 +237,11 @@ they affect testing or product expectations.
 If the draft starts from git commits, use
 `scripts/studio-tf-push.sh compose-message --channel testflight` against
 git-log-style commit blocks to apply the commit taxonomy before hand-editing.
-For App Store copy, run the same input through `--channel appstore`; TF-only
-work-in-progress and internal buckets are intentionally omitted there.
+The composer prefers compact `Release-Note:` copy, then legacy `Changelog:`,
+then compact `Impact:`, then legacy `Problem:`/`Solution:`, then the commit
+subject; rendered Slack/App Store copy must never include those raw field
+labels. For App Store copy, run the same input through `--channel appstore`;
+TF-only work-in-progress and internal buckets are intentionally omitted there.
 
 Headline: `[iOS] build <NEW_BUILD_NUMBER> is available on TestFlight`. Prefix
 `<!here>` only when `STUDIO_TF_SLACK_NOTIFY_HERE=1`; the configured default is

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -278,7 +278,7 @@ scripts/recommend-model.sh --size s --kind impl --cross-file-count 3 --novelty-s
 scripts/detect-edits.sh --quiet                         # emits brief_edited + debrief_edited
 
 # App Store submission watcher (auto-invoked by every sweep):
-scripts/studio-tf-push.sh compose-message --channel testflight < commits.txt # taxonomy-aware release/TestFlight bullet composer
+scripts/studio-tf-push.sh compose-message --channel testflight < commits.txt # taxonomy-aware release/TestFlight bullet composer; prefers Release-Note, then legacy fallbacks
 scripts/appstore-watch.sh                               # idempotent; publishes release + promotes PR only at READY_FOR_SALE after release approval is recorded
 ```
 

--- a/scripts/compose-build-release-message.sh
+++ b/scripts/compose-build-release-message.sh
@@ -41,6 +41,11 @@ def sentence(value: str) -> str:
     return value
 
 
+def note_sentence(value: str) -> str:
+    value = sentence(value)
+    return "" if value.lower() == "none" else value
+
+
 def crash_link(text: str) -> str:
     for link in URL_RE.findall(text or ""):
         if "crash" in link.lower() or "firebase" in link.lower():
@@ -86,8 +91,11 @@ def parse_block(block: str) -> dict[str, object]:
         "body": body,
         "trailers": trailers,
         "change_type": trailers.get("change-type", "").lower(),
-        "affected_areas": trailers.get("affected-areas", ""),
+        "affected_areas": trailers.get("areas", "") or trailers.get("affected-areas", ""),
+        "impact": trailers.get("impact", ""),
         "problem": trailers.get("problem", ""),
+        "release_note": trailers.get("release-note", ""),
+        "risk": trailers.get("risk", ""),
         "solution": trailers.get("solution", ""),
         "caveat": trailers.get("caveat", "") or trailers.get("caveats", ""),
         "changelog": trailers.get("changelog", ""),
@@ -121,20 +129,26 @@ def inferred_metadata(commit: dict[str, object]) -> dict[str, object]:
 
 
 def plain_bullet(commit: dict[str, object]) -> str:
+    release_note = note_sentence(str(commit.get("release_note") or ""))
+    changelog = note_sentence(str(commit.get("changelog") or ""))
+    impact = note_sentence(str(commit.get("impact") or ""))
     problem = sentence(str(commit.get("problem") or ""))
     solution = sentence(str(commit.get("solution") or ""))
-    changelog = sentence(str(commit.get("changelog") or ""))
     subject = sentence(str(commit.get("subject") or ""))
     caveat = sentence(str(commit.get("caveat") or ""))
 
-    if changelog:
+    if release_note:
+        bullet = release_note
+    elif changelog:
         bullet = changelog
+    elif impact:
+        bullet = impact
     elif problem and solution and solution.lower() not in problem.lower():
         bullet = f"{problem} - {solution}"
     else:
         bullet = problem or solution or subject
     if caveat:
-        bullet = f"{bullet} (caveat: {caveat})"
+        bullet = f"{bullet} (note: {caveat})"
     return trim(bullet, 260)
 
 

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -228,7 +228,7 @@ chain_git_parent_finalize_issue_commit() {
   local issue="${2:?issue number required}"
   local summary_file="${3:?summary file required}"
   local host="${4:-}"
-  local issue_title subject change_type affected_areas problem solution changelog implementation_notes caveats
+  local issue_title subject change_type impact areas release_note why risk details legacy_caveats
 
   chain_git_parent_finalize_summary_eligible "$summary_file" || return 1
   chain_git_parent_finalize_has_public_diff "$issue_worktree" || return 1
@@ -245,14 +245,18 @@ chain_git_parent_finalize_issue_commit() {
     printf 'chain-git: parent finalize refusing commit without known worker host\n' >&2
     return 1
   fi
-  affected_areas=$(jq -r '.affected_areas // .commit_affected_areas // .commit_metadata.affected_areas // empty' "$summary_file" 2>/dev/null || true)
-  problem=$(jq -r '.problem // .commit_problem // .commit_metadata.problem // empty' "$summary_file" 2>/dev/null || true)
-  solution=$(jq -r '.solution // .commit_solution // .commit_metadata.solution // empty' "$summary_file" 2>/dev/null || true)
-  changelog=$(jq -r '.changelog // .commit_changelog // .commit_metadata.changelog // empty' "$summary_file" 2>/dev/null || true)
-  implementation_notes=$(jq -r '.implementation_notes // .commit_implementation_notes // .commit_metadata.implementation_notes // empty' "$summary_file" 2>/dev/null || true)
-  caveats=$(jq -r '.caveats // .commit_caveats // .commit_metadata.caveats // empty' "$summary_file" 2>/dev/null || true)
-  if [ -z "$affected_areas" ] || [ -z "$problem" ] || [ -z "$solution" ] || [ -z "$changelog" ] || [ -z "$implementation_notes" ] || [ -z "$caveats" ]; then
-    printf 'chain-git: parent finalize refusing commit without complete structured commit summary fields\n' >&2
+  impact=$(jq -r '.impact // .commit_impact // .commit_metadata.impact // .solution // .commit_solution // .commit_metadata.solution // empty' "$summary_file" 2>/dev/null || true)
+  areas=$(jq -r '.areas // .commit_areas // .commit_metadata.areas // .affected_areas // .commit_affected_areas // .commit_metadata.affected_areas // empty' "$summary_file" 2>/dev/null || true)
+  release_note=$(jq -r '.release_note // .release_note_source // .commit_release_note // .commit_metadata.release_note // .changelog // .commit_changelog // .commit_metadata.changelog // empty' "$summary_file" 2>/dev/null || true)
+  why=$(jq -r '.why // .commit_why // .commit_metadata.why // .problem // .commit_problem // .commit_metadata.problem // empty' "$summary_file" 2>/dev/null || true)
+  risk=$(jq -r '.risk // .commit_risk // .commit_metadata.risk // empty' "$summary_file" 2>/dev/null || true)
+  if [ -z "$risk" ]; then
+    legacy_caveats=$(jq -r '.caveats // .commit_caveats // .commit_metadata.caveats // empty' "$summary_file" 2>/dev/null || true)
+    [ -z "$legacy_caveats" ] || risk="low; $legacy_caveats"
+  fi
+  details=$(jq -r '.details // .commit_details // .commit_metadata.details // .implementation_notes // .commit_implementation_notes // .commit_metadata.implementation_notes // empty' "$summary_file" 2>/dev/null || true)
+  if [ -z "$impact" ] || [ -z "$areas" ] || [ -z "$release_note" ] || [ -z "$why" ] || [ -z "$risk" ]; then
+    printf 'chain-git: parent finalize refusing commit without complete compact commit summary fields\n' >&2
     return 1
   fi
 
@@ -280,31 +284,58 @@ chain_git_parent_finalize_issue_commit() {
   fi
   case "$host" in
     codex|codex-*|*codex*)
-      STUDIO_HOST="$host" git -C "$issue_worktree" commit \
-        -m "$subject" \
-        -m "Affected-Areas: $affected_areas" \
-        -m "Problem: $problem" \
-        -m "Solution: $solution" \
-        -m "Changelog: $changelog" \
-        -m "Implementation notes: $implementation_notes" \
-        -m "Caveats: $caveats" \
-        -m "Closes #$issue" \
-        -m "Change-Type: $change_type" \
-        -m "Studio-Host: $host" \
-        -m "Co-authored-by: Codex <noreply@openai.com>"
+      if [ -n "$details" ]; then
+        STUDIO_HOST="$host" git -C "$issue_worktree" commit \
+          -m "$subject" \
+          -m "Impact: $impact" \
+          -m "Areas: $areas" \
+          -m "Release-Note: $release_note" \
+          -m "Why: $why" \
+          -m "Risk: $risk" \
+          -m "Details: $details" \
+          -m "Closes #$issue" \
+          -m "Change-Type: $change_type" \
+          -m "Studio-Host: $host" \
+          -m "Co-authored-by: Codex <noreply@openai.com>"
+      else
+        STUDIO_HOST="$host" git -C "$issue_worktree" commit \
+          -m "$subject" \
+          -m "Impact: $impact" \
+          -m "Areas: $areas" \
+          -m "Release-Note: $release_note" \
+          -m "Why: $why" \
+          -m "Risk: $risk" \
+          -m "Closes #$issue" \
+          -m "Change-Type: $change_type" \
+          -m "Studio-Host: $host" \
+          -m "Co-authored-by: Codex <noreply@openai.com>"
+      fi
       ;;
     *)
-      STUDIO_HOST="$host" git -C "$issue_worktree" commit \
-        -m "$subject" \
-        -m "Affected-Areas: $affected_areas" \
-        -m "Problem: $problem" \
-        -m "Solution: $solution" \
-        -m "Changelog: $changelog" \
-        -m "Implementation notes: $implementation_notes" \
-        -m "Caveats: $caveats" \
-        -m "Closes #$issue" \
-        -m "Change-Type: $change_type" \
-        -m "Studio-Host: $host"
+      if [ -n "$details" ]; then
+        STUDIO_HOST="$host" git -C "$issue_worktree" commit \
+          -m "$subject" \
+          -m "Impact: $impact" \
+          -m "Areas: $areas" \
+          -m "Release-Note: $release_note" \
+          -m "Why: $why" \
+          -m "Risk: $risk" \
+          -m "Details: $details" \
+          -m "Closes #$issue" \
+          -m "Change-Type: $change_type" \
+          -m "Studio-Host: $host"
+      else
+        STUDIO_HOST="$host" git -C "$issue_worktree" commit \
+          -m "$subject" \
+          -m "Impact: $impact" \
+          -m "Areas: $areas" \
+          -m "Release-Note: $release_note" \
+          -m "Why: $why" \
+          -m "Risk: $risk" \
+          -m "Closes #$issue" \
+          -m "Change-Type: $change_type" \
+          -m "Studio-Host: $host"
+      fi
       ;;
   esac
 }

--- a/scripts/lint-commit-message.sh
+++ b/scripts/lint-commit-message.sh
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
 # lint-commit-message.sh - validate commit trailers for studio-managed commits.
 #
-# Supported fields:
+# Supported compact fields:
 #   <change-type>: <developer headline>
+#   Impact: <net behavior/workflow change>
+#   Areas: <module/surface list>
+#   Release-Note: <tester/release-facing bullet source, or none>
+#   Why: <cause, trigger, or intent>
+#   Risk: <none|low|medium|high> <short reason>
+#   Details: <optional deeper implementation notes>
+#   Change-Type: <change-type>
+#   Studio-Host: <host-id>
+#   Co-authored-by: Codex <noreply@openai.com>
+#
+# Legacy verbose fields remain accepted during the producer migration:
 #   Affected-Areas: <module/surface list>
 #   Problem: <why this was needed>
 #   Solution: <what changed>
 #   Changelog: <tester/release-facing bullet source>
 #   Implementation notes: <automation/reviewer details>
 #   Caveats: <risks, limits, skipped verification, or None>
-#   Change-Type: <change-type>
-#   Studio-Host: <host-id>
-#   Co-authored-by: Codex <noreply@openai.com>
 #
 # Exit 0 on pass (or warnings with explicit env bypass), 1 on hard failures.
 
@@ -63,6 +71,11 @@ fail() { errs=$((errs + 1)); printf 'lint-commit-message: ERROR: %s\n' "$1" >&2;
 
 change_type=""
 studio_host=""
+impact=""
+areas=""
+release_note=""
+why=""
+risk=""
 affected_areas=""
 problem=""
 solution=""
@@ -74,6 +87,11 @@ codex_coauthor_seen=0
 bad_codex_coauthor=""
 while IFS= read -r line || [ -n "$line" ]; do
   case "$line" in
+    Impact:*) impact=$(trim "${line#Impact:}") ;;
+    Areas:*) areas=$(trim "${line#Areas:}") ;;
+    Release-Note:*) release_note=$(trim "${line#Release-Note:}") ;;
+    Why:*) why=$(trim "${line#Why:}") ;;
+    Risk:*) risk=$(trim "${line#Risk:}") ;;
     Problem:*) problem=$(trim "${line#Problem:}") ;;
     Affected-Areas:*) affected_areas=$(trim "${line#Affected-Areas:}") ;;
     Solution:*) solution=$(trim "${line#Solution:}") ;;
@@ -92,6 +110,27 @@ while IFS= read -r line || [ -n "$line" ]; do
       ;;
   esac
 done < "$COMMIT_FILE"
+
+compact_missing_labels() {
+  local labels=""
+  [ -n "$impact" ] || labels="${labels} Impact"
+  [ -n "$areas" ] || labels="${labels} Areas"
+  [ -n "$release_note" ] || labels="${labels} Release-Note"
+  [ -n "$why" ] || labels="${labels} Why"
+  [ -n "$risk" ] || labels="${labels} Risk"
+  printf '%s' "${labels# }"
+}
+
+verbose_missing_labels() {
+  local labels=""
+  [ -n "$affected_areas" ] || labels="${labels} Affected-Areas"
+  [ -n "$problem" ] || labels="${labels} Problem"
+  [ -n "$solution" ] || labels="${labels} Solution"
+  [ -n "$changelog" ] || labels="${labels} Changelog"
+  [ -n "$implementation_notes" ] || labels="${labels} Implementation notes"
+  [ -n "$caveats" ] || labels="${labels} Caveats"
+  printf '%s' "${labels# }"
+}
 
 valid_change_type() {
   case "$1" in
@@ -141,24 +180,43 @@ if [ -n "$change_type" ] && valid_change_type "$change_type"; then
   esac
 fi
 
-require_field() {
-  local label="$1" value="$2" purpose="$3"
-  if [ -n "$value" ]; then
-    return 0
+risk_value=""
+if [ -n "$risk" ]; then
+  risk_value="${risk%%[[:space:]:,-]*}"
+  risk_prefix_valid=0
+  case "$risk_value" in
+    none|low|medium|high) risk_prefix_valid=1 ;;
+    *)
+      if [ "$strict_for_hosted" -eq 1 ]; then
+        fail "invalid Risk field: expected none|low|medium|high plus a short reason"
+      else
+        warn "invalid Risk field: expected none|low|medium|high plus a short reason"
+      fi
+      ;;
+  esac
+  risk_reason="${risk#"$risk_value"}"
+  risk_reason="${risk_reason#"${risk_reason%%[![:space:]:,-]*}"}"
+  risk_reason=$(trim "$risk_reason")
+  if [ "$risk_prefix_valid" -eq 1 ] && [ -z "$risk_reason" ]; then
+    if [ "$strict_for_hosted" -eq 1 ]; then
+      fail "invalid Risk field: expected none|low|medium|high plus a short reason"
+    else
+      warn "invalid Risk field: expected none|low|medium|high plus a short reason"
+    fi
   fi
-  if [ "$strict_for_hosted" -eq 1 ]; then
-    fail "missing required ${label}: ${purpose}"
-  else
-    warn "missing recommended ${label}: ${purpose}"
-  fi
-}
+fi
 
-require_field "Affected-Areas" "$affected_areas" "module/surface list for regression triage"
-require_field "Problem" "$problem" "why the change was needed"
-require_field "Solution" "$solution" "what changed"
-require_field "Changelog" "$changelog" "brief TestFlight/release bullet source"
-require_field "Implementation notes" "$implementation_notes" "details agents and reviewers can use"
-require_field "Caveats" "$caveats" "risks, limits, skipped work, or None"
+compact_missing=$(compact_missing_labels)
+verbose_missing=$(verbose_missing_labels)
+if [ -z "$compact_missing" ] || [ -z "$verbose_missing" ]; then
+  :
+else
+  if [ "$strict_for_hosted" -eq 1 ]; then
+    fail "missing required commit metadata: provide compact fields (Impact, Areas, Release-Note, Why, Risk) or legacy fields (Affected-Areas, Problem, Solution, Changelog, Implementation notes, Caveats). Missing compact: ${compact_missing}; missing legacy: ${verbose_missing}"
+  else
+    warn "missing recommended commit metadata: provide compact fields (Impact, Areas, Release-Note, Why, Risk) or legacy fields (Affected-Areas, Problem, Solution, Changelog, Implementation notes, Caveats). Missing compact: ${compact_missing}; missing legacy: ${verbose_missing}"
+  fi
+fi
 
 if [ -z "$studio_host" ]; then
   if [ "$strict_for_hosted" -eq 1 ]; then

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -7373,9 +7373,13 @@ Rules:
 - Keep changes scoped to this issue.
 - Commit the result on the current branch.
 - Use commit subject "<change-type>: <developer-readable why/what headline>".
-- Include commit body fields "Affected-Areas:", "Problem:", "Solution:", "Changelog:", "Implementation notes:", and "Caveats:".
-- Use "Affected-Areas:" for comma-separated modules, surfaces, commands, or workflows likely to be relevant in regression triage.
-- Use "Changelog:" for a brief tester/release-facing bullet; keep implementation detail out of it.
+- Include compact commit body fields "Impact:", "Areas:", "Release-Note:", "Why:", and "Risk:".
+- Use "Impact:" for the one-line net behavior or workflow change.
+- Use "Areas:" for comma-separated modules, surfaces, commands, or workflows likely to be relevant in regression triage.
+- Use "Release-Note:" for a brief tester/release-facing bullet, or "none"; keep implementation detail out of it.
+- Use "Why:" for the one-line cause, trigger, or intent.
+- Use "Risk:" as "none|low|medium|high" plus a short reason.
+- Include optional "Details:" only when larger, risky, or cross-surface changes need deeper implementation context.
 - Include "Closes #$issue" in the commit message.
 - Include "Change-Type: <type>" and "Studio-Host: $host" trailers.
 - If $host is codex, include exactly one "Co-authored-by: Codex <noreply@openai.com>" trailer.
@@ -7400,7 +7404,8 @@ Summary JSON fields:
 - issue_title: "$issue_title"
 - host: "$host"
 - change_type: feature|bugfix-shipped|bugfix-wip|regression-fix|refactor|docs|test|chore|release
-- affected_areas, problem, solution, changelog, implementation_notes, caveats matching the commit body fields
+- impact, areas, release_note, why, risk matching the compact commit body fields
+- details when the commit includes a Details field, otherwise null or omitted
 - model/model_version/effort when known, otherwise null
 - started_at/ended_at/duration_s
 - exit_code

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -978,17 +978,17 @@ cmd_push() {
     elif ! git commit -m "$(cat <<EOF
 release: bump build number to ${NEW_BUILD_NUMBER}
 
-Affected-Areas: release-manager, TestFlight build metadata, Xcode project versioning
+Impact: TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) has a committed project-version bump before archive and upload.
 
-Problem: TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) needs a committed project-version bump before archive and upload.
+Areas: release-manager, TestFlight build metadata, Xcode project versioning
 
-Solution: Update the Xcode project build and marketing version for branch ${BRANCH}.
+Release-Note: Preparing TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) from branch ${BRANCH}.
 
-Changelog: Preparing TestFlight build ${NEW_BUILD_NUMBER} (v${VERSION}) from branch ${BRANCH}.
+Why: TestFlight upload requires the Xcode project build and marketing version to match the release branch metadata.
 
-Implementation notes: The release-manager workflow updated zaps-app/Turnip.xcodeproj/project.pbxproj.
+Risk: low; only zaps-app/Turnip.xcodeproj/project.pbxproj version fields are updated before existing gated release steps.
 
-Caveats: Release upload and Slack send still depend on the later gated workflow steps.
+Details: The release-manager workflow updated zaps-app/Turnip.xcodeproj/project.pbxproj; release upload and Slack send still depend on later gated workflow steps.
 
 Change-Type: release
 Studio-Host: release-manager

--- a/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
+++ b/scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh
@@ -50,12 +50,12 @@ cat > "$REPO/.studio/chain-worker-summary.json" <<'JSON'
   "issue_title": "Parent finalize fixture",
   "host": "codex",
   "change_type": "bugfix-wip",
-  "affected_areas": "chain parent finalization, commit metadata",
-  "problem": "Worker completed the file changes but could not update primary git metadata.",
-  "solution": "Parent finalization creates the commit from the public diff.",
-  "changelog": "Parent finalization now preserves structured commit metadata.",
-  "implementation_notes": "The parent commit path reads structured fields from the worker summary.",
-  "caveats": "Only applies when parent finalization is eligible.",
+  "impact": "Parent finalization creates the commit from the public diff.",
+  "areas": "chain parent finalization, commit metadata",
+  "release_note": "Parent finalization now preserves structured commit metadata.",
+  "why": "Worker completed the file changes but could not update primary git metadata.",
+  "risk": "low; only applies when parent finalization is eligible.",
+  "details": "The parent commit path reads compact fields from the worker summary.",
   "commit_before": "base",
   "commit_after": null,
   "blocked_reason": "Unable to stage or commit: filesystem denies writes inside .git creating .git/index.lock with Operation not permitted.",
@@ -117,16 +117,22 @@ chain_git_parent_finalize_issue_commit "$REPO" 584 "$REPO/.studio/chain-worker-s
 
 git -C "$REPO" log -1 --format=%B | grep -q 'Closes #584' \
   || fail "parent commit did not close issue"
-git -C "$REPO" log -1 --format=%B | grep -q 'Affected-Areas: chain parent finalization, commit metadata' \
-  || fail "parent commit did not include Affected-Areas field"
+git -C "$REPO" log -1 --format=%B | grep -q 'Impact: Parent finalization creates the commit from the public diff.' \
+  || fail "parent commit did not include Impact field"
+git -C "$REPO" log -1 --format=%B | grep -q 'Areas: chain parent finalization, commit metadata' \
+  || fail "parent commit did not include Areas field"
+git -C "$REPO" log -1 --format=%B | grep -q 'Release-Note: Parent finalization now preserves structured commit metadata.' \
+  || fail "parent commit did not include Release-Note field"
+git -C "$REPO" log -1 --format=%B | grep -q 'Why: Worker completed the file changes but could not update primary git metadata.' \
+  || fail "parent commit did not include Why field"
+git -C "$REPO" log -1 --format=%B | grep -q 'Risk: low; only applies when parent finalization is eligible.' \
+  || fail "parent commit did not include Risk field"
 git -C "$REPO" log -1 --format=%B | grep -q 'Change-Type: bugfix-wip' \
   || fail "parent commit did not include Change-Type trailer"
 git -C "$REPO" log -1 --format=%B | grep -q 'Studio-Host: codex' \
   || fail "parent commit did not include Studio-Host trailer"
 git -C "$REPO" log -1 --format=%B | grep -q 'Co-authored-by: Codex <noreply@openai.com>' \
   || fail "parent commit did not include Codex coauthor trailer"
-git -C "$REPO" log -1 --format=%B | grep -q 'Changelog: Parent finalization now preserves structured commit metadata.' \
-  || fail "parent commit did not include Changelog field"
 git -C "$REPO" log -1 --format=%s | grep -qx 'bugfix-wip: Parent finalize fixture (#584)' \
   || fail "parent commit subject did not use issue title"
 git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -qx 'README.md' \
@@ -141,6 +147,41 @@ fi
 if git -C "$REPO" diff-tree --no-commit-id --name-only -r HEAD | grep -Eq '^\.git(2|-protected)/'; then
   fail "private git metadata dir was committed"
 fi
+
+LEGACY_REPO="$TMPROOT/legacy-repo"
+mkdir -p "$LEGACY_REPO/.studio"
+git -C "$LEGACY_REPO" init -q
+git -C "$LEGACY_REPO" config user.email studio@example.invalid
+git -C "$LEGACY_REPO" config user.name "Studio Test"
+printf 'base\n' > "$LEGACY_REPO/README.md"
+git -C "$LEGACY_REPO" add README.md
+git -C "$LEGACY_REPO" commit -q -m "base"
+printf 'base\nlegacy\n' > "$LEGACY_REPO/README.md"
+cat > "$LEGACY_REPO/.studio/chain-worker-summary.json" <<'JSON'
+{
+  "schema_version": 1,
+  "kind": "completion",
+  "status": "blocked",
+  "issue_number": 584,
+  "issue_title": "Legacy summary fixture",
+  "host": "codex",
+  "change_type": "bugfix-wip",
+  "affected_areas": "chain parent finalization, commit metadata",
+  "problem": "Worker completed the file changes but could not update primary git metadata.",
+  "solution": "Parent finalization creates the commit from the public diff.",
+  "changelog": "Parent finalization now preserves structured commit metadata.",
+  "implementation_notes": "The parent commit path reads structured fields from the worker summary.",
+  "caveats": "Only applies when parent finalization is eligible.",
+  "commit_before": "base",
+  "commit_after": null,
+  "blocked_reason": "Unable to stage or commit: filesystem denies writes inside .git creating .git/index.lock with Operation not permitted.",
+  "tests": [{"command": "fixture", "outcome": "passed"}]
+}
+JSON
+chain_git_parent_finalize_issue_commit "$LEGACY_REPO" 584 "$LEGACY_REPO/.studio/chain-worker-summary.json" codex \
+  || fail "parent finalize did not derive compact commit fields from legacy summary"
+git -C "$LEGACY_REPO" log -1 --format=%B | grep -q 'Risk: low; Only applies when parent finalization is eligible.' \
+  || fail "legacy caveats were not converted to a valid compact Risk field"
 
 PAYLOAD=$(chain_git_parent_finalize_event_payload "$REPO/.studio/chain-worker-summary.json" base "$(git -C "$REPO" rev-parse HEAD)" codex)
 printf '%s\n' "$PAYLOAD" | jq -e '

--- a/scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
+++ b/scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh
@@ -29,7 +29,7 @@ run_case() {
   local out="$TMPROOT/$case_name.out"
   printf '%s\n' "$message" > "$msg_file"
 
-  if (cd "$root" && STUDIO_COMMIT_MSG_LINT_REPO_ROOT="$root" STUDIO_BYPASS_COMMIT_TRAILER_LINT="$bypass" "$LINT_SCRIPT" --file "$msg_file" >"$out" 2>&1); then
+  if (cd "$root" && unset STUDIO_HOST && STUDIO_COMMIT_MSG_LINT_REPO_ROOT="$root" STUDIO_BYPASS_COMMIT_TRAILER_LINT="$bypass" "$LINT_SCRIPT" --file "$msg_file" >"$out" 2>&1); then
     rc=0
   else
     rc=$?
@@ -60,6 +60,24 @@ Changelog: Commit messages now carry a release-ready summary.
 Implementation notes: The commit-msg lint checks the canonical field labels.
 
 Caveats: None.
+
+Change-Type: feature
+Studio-Host: codex
+Co-authored-by: Codex <noreply@openai.com>"
+
+compact_valid_message="feature: enforce compact commit metadata
+
+Impact: Hosted commit lint now accepts the compact impact schema.
+
+Areas: commit hooks, release messages
+
+Release-Note: Commit messages now carry compact release-note metadata.
+
+Why: Compact fields keep commit bodies shorter while preserving triage metadata.
+
+Risk: low - accept-either transition preserves legacy commit producers.
+
+Details: The lint keeps legacy verbose fields valid until producer migration completes.
 
 Change-Type: feature
 Studio-Host: codex
@@ -148,6 +166,49 @@ Caveats: None.
 Change-Type: feature
 Studio-Host: codex"
 
+compact_missing_risk_message="feature: enforce compact commit metadata
+
+Impact: Hosted commit lint now accepts the compact impact schema.
+
+Areas: commit hooks, release messages
+
+Release-Note: Commit messages now carry compact release-note metadata.
+
+Why: Compact fields keep commit bodies shorter while preserving triage metadata.
+
+Change-Type: feature
+Studio-Host: codex"
+
+compact_invalid_risk_message="feature: enforce compact commit metadata
+
+Impact: Hosted commit lint now accepts the compact impact schema.
+
+Areas: commit hooks, release messages
+
+Release-Note: Commit messages now carry compact release-note metadata.
+
+Why: Compact fields keep commit bodies shorter while preserving triage metadata.
+
+Risk: urgent - no taxonomy value.
+
+Change-Type: feature
+Studio-Host: codex"
+
+compact_risk_without_reason_message="feature: enforce compact commit metadata
+
+Impact: Hosted commit lint now accepts the compact impact schema.
+
+Areas: commit hooks, release messages
+
+Release-Note: Commit messages now carry compact release-note metadata.
+
+Why: Compact fields keep commit bodies shorter while preserving triage metadata.
+
+Risk: low
+
+Change-Type: feature
+Studio-Host: codex"
+
 bad_subject_message="Structured metadata without taxonomy prefix
 
 Affected-Areas: commit hooks, release messages
@@ -179,13 +240,18 @@ human_repo="$TMPROOT/human"
 mkdir -p "$human_repo"
 
 run_case "valid_automation" 0 "$automation_repo" "$valid_message" ""
+run_case "compact_valid_automation" 0 "$automation_repo" "$compact_valid_message" ""
 run_case "codex_missing_coauthor_warns" 0 "$automation_repo" "$codex_missing_coauthor_message" "Codex-hosted commits should include GitHub-visible credit"
 run_case "codex_bad_coauthor_warns" 0 "$automation_repo" "$codex_bad_coauthor_message" "Codex co-author trailer should be exactly"
 run_case "invalid_change_type_fails" 1 "$automation_repo" "$invalid_type_message" "invalid Change-Type trailer: unknown"
 run_case "missing_host_fails_in_automation" 1 "$automation_repo" "$missing_host_message" "missing trailer Studio-Host"
-run_case "missing_changelog_fails_in_automation" 1 "$automation_repo" "$missing_changelog_message" "missing required Changelog"
+run_case "missing_changelog_fails_in_automation" 1 "$automation_repo" "$missing_changelog_message" "missing required commit metadata"
+run_case "compact_missing_risk_fails_in_automation" 1 "$automation_repo" "$compact_missing_risk_message" "Missing compact: Risk"
+run_case "compact_invalid_risk_fails_in_automation" 1 "$automation_repo" "$compact_invalid_risk_message" "invalid Risk field"
+run_case "compact_risk_without_reason_fails_in_automation" 1 "$automation_repo" "$compact_risk_without_reason_message" "plus a short reason"
 run_case "bad_subject_fails_in_automation" 1 "$automation_repo" "$bad_subject_message" "commit subject must start with 'feature: '"
 run_case "missing_host_warns_for_human" 0 "$human_repo" "$missing_host_message" "passed with"
+run_case "compact_missing_risk_warns_for_human" 0 "$human_repo" "$compact_missing_risk_message" "passed with"
 run_case "bypass_allows_hard_failure_case" 0 "$automation_repo" "$missing_host_message" "commit trailer lint bypassed via STUDIO_BYPASS_COMMIT_TRAILER_LINT=1" 1
 
 printf 'PASS: commit-message lint fixture suite\n'

--- a/scripts/test-fixtures/692-commit-taxonomy-release-message/test-commit-taxonomy-release-message.sh
+++ b/scripts/test-fixtures/692-commit-taxonomy-release-message/test-commit-taxonomy-release-message.sh
@@ -13,17 +13,22 @@ JSON_OUT="$TMP_DIR/testflight.json"
 cat >"$COMMITS" <<'EOF'
 aaa111 | Add smarter release composer
 Change-Type: feature
-Problem: Release writers had to classify every commit by hand.
-Solution: The composer now groups taxonomy metadata into release sections.
+Impact: Release writers can draft TestFlight and App Store notes from compact metadata.
+Areas: release composer, TestFlight, App Store
+Release-Note: Release writers now get cleaner build notes from compact commit metadata.
+Why: Release writers had to classify every commit by hand.
+Risk: low; parser fallback remains compatible.
 ---
 bbb222 | Fix shipped editor upload retry
 Change-Type: bugfix-shipped
+Changelog: Editor upload retry now recovers after the first failed request.
 Problem: Upload retry sometimes stopped after the first failed request.
 Solution: Retry state now survives the transient failure.
+Caveat: Retry requires network connectivity to return.
 ---
 ccc333 | Draft fix for flaky tester invite sync
 Change-Type: bugfix-wip
-Problem: Tester invite sync is still being verified.
+Impact: Tester invite sync has a narrower temporary failure mode while verification continues.
 Solution: A partial guard narrows the failure while testing continues.
 ---
 ddd444 | Repair regression in release marker finalization
@@ -33,11 +38,14 @@ Solution: Finalization now records every completed step.
 ---
 eee555 | Update release docs
 Change-Type: docs
-Problem: Internal release docs were stale.
-Solution: The examples now match the current scripts.
+Release-Note: none
+Impact: Internal release docs explain the compact metadata fallback order.
 ---
 fff666 | Handle missing taxonomy trailers from old commits
 Old commit body without structured metadata.
+---
+ggg777 | Subject fallback remains safe
+Change-Type: bugfix-shipped
 ---
 999aaa | Crash fix from Crashlytics
 Change-Type: bugfix-shipped
@@ -70,22 +78,38 @@ assert_not_contains() {
 }
 
 assert_contains "$TF_OUT" "*New*"
-assert_contains "$TF_OUT" "Release writers had to classify every commit by hand"
+assert_contains "$TF_OUT" "Release writers now get cleaner build notes from compact commit metadata"
 assert_contains "$TF_OUT" "*Fixed*"
-assert_contains "$TF_OUT" "Upload retry sometimes stopped after the first failed request"
-assert_contains "$TF_OUT" "Work-in-progress fix: Tester invite sync is still being verified"
+assert_contains "$TF_OUT" "Editor upload retry now recovers after the first failed request"
+assert_contains "$TF_OUT" "Editor upload retry now recovers after the first failed request (note: Retry requires network connectivity to return)"
+assert_contains "$TF_OUT" "Work-in-progress fix: Tester invite sync has a narrower temporary failure mode while verification continues"
 assert_contains "$TF_OUT" "regression bug fix: Release finalization could skip marker cleanup"
 assert_contains "$TF_OUT" "Handle missing taxonomy trailers from old commits"
+assert_contains "$TF_OUT" "Subject fallback remains safe"
+assert_contains "$TF_OUT" "technical: Internal release docs explain the compact metadata fallback order"
 assert_contains "$TF_OUT" "https://console.firebase.google.com/project/demo/crashlytics/app/ios:demo/issues/123"
 
 assert_contains "$APP_OUT" "*New*"
-assert_contains "$APP_OUT" "Upload retry sometimes stopped after the first failed request"
+assert_contains "$APP_OUT" "Editor upload retry now recovers after the first failed request"
 assert_contains "$APP_OUT" "Fixed crash https://console.firebase.google.com/project/demo/crashlytics/app/ios:demo/issues/123"
+assert_contains "$APP_OUT" "Subject fallback remains safe"
 assert_not_contains "$APP_OUT" "Work-in-progress fix"
-assert_not_contains "$APP_OUT" "Internal release docs were stale"
+assert_not_contains "$APP_OUT" "Internal release docs explain the compact metadata fallback order"
 
 assert_not_contains "$TF_OUT" "Change-Type:"
+assert_not_contains "$TF_OUT" "Release-Note:"
+assert_not_contains "$TF_OUT" "Impact:"
+assert_not_contains "$TF_OUT" "Areas:"
+assert_not_contains "$TF_OUT" "Risk:"
+assert_not_contains "$TF_OUT" "Caveat:"
+assert_not_contains "$TF_OUT" "caveat:"
 assert_not_contains "$APP_OUT" "Change-Type:"
+assert_not_contains "$APP_OUT" "Release-Note:"
+assert_not_contains "$APP_OUT" "Impact:"
+assert_not_contains "$APP_OUT" "Areas:"
+assert_not_contains "$APP_OUT" "Risk:"
+assert_not_contains "$APP_OUT" "Caveat:"
+assert_not_contains "$APP_OUT" "caveat:"
 
 jq -e '
   .channel == "testflight"


### PR DESCRIPTION
## Summary

- Accept compact hosted commit metadata: `Impact`, `Areas`, `Release-Note`, `Why`, and `Risk`, while keeping the legacy verbose fields valid during migration.
- Migrate automated chain and TestFlight commit producers to emit compact impact records.
- Prefer compact `Release-Note` values in release/TestFlight/App Store message composition while retaining legacy fallbacks.
- Capture the future build-to-build impact digest idea in `IDEAS.md` without implementing the digest engine in this chain.

## Compatibility Notes

- Commit lint intentionally accepts either compact metadata or legacy verbose metadata. This PR should preserve that accept-either invariant.
- `Release-Note: none` is intentionally treated as empty and falls through to the next usable release-message source.
- Full shellcheck without severity filtering still reports pre-existing informational/style findings; the post-rebase verification used `shellcheck -S error` for touched shell surfaces.

## Verification

- `bash scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh`
- `bash scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh`
- `bash scripts/test-fixtures/692-commit-taxonomy-release-message/test-commit-taxonomy-release-message.sh`
- `bash -n scripts/lint-commit-message.sh scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/studio-tf-push.sh`
- `shellcheck -S error scripts/lint-commit-message.sh scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/studio-tf-push.sh scripts/test-fixtures/584-parent-finalize/test-chain-parent-finalize.sh scripts/test-fixtures/691-commit-message-lint/test-commit-message-lint.sh scripts/test-fixtures/692-commit-taxonomy-release-message/test-commit-taxonomy-release-message.sh`
- `git diff --check origin/main...HEAD`

## Follow-ups

- Promote the captured build-to-build commit impact digest idea into a scoped issue after compact commit metadata has real usage data.
- Consider updating `_shared/contracts/definition-of-done.md` in a later issue so `Release-Note:` is reflected as the preferred tester-facing trailer.
- Track the pre-existing non-error shellcheck findings as debt in one cleanup issue.

Chain run report: `/Users/vishalsingh/.dev-studio/generic-dev-studio/chain-runs/019e3550-0bde-78fe-a4e8-c6955896d6e3/report.md`