### PR TITLE
Preserve GitHub author identity for chain commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,11 @@ GitHub-visible credit in addition to `Studio-Host: codex`:
 `Co-authored-by: Codex <noreply@openai.com>`. Do not use invented Codex email
 addresses such as `codex@openai.com`.
 
+The primary Git author/committer for studio automation must remain the
+authenticated GitHub profile used for GitHub operations. Host credit such as
+Codex belongs in `Studio-Host` and `Co-authored-by` metadata; it must not
+replace the primary GitHub author identity.
+
 ### Commit-taxonomy values (initial set)
 
 The initial taxonomy values are:

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -363,6 +363,7 @@ Commit discipline is part of review quality for host-routed changes:
 **How to check:**
 - Prefer machine-readable host identity from `.studio/chain-task-start.json` / `.studio/chain-worker-summary.json` (`host`, `model`, `model_version`) over parsing `Co-authored-by:` in commit footers.
 - For Codex-hosted commits, keep `Studio-Host: codex` and add the GitHub-visible Codex co-author trailer `Co-authored-by: Codex <noreply@openai.com>`.
+- The primary Git author/committer should be the authenticated GitHub profile used for GitHub operations; host credit is additive metadata, not a replacement for the main author identity.
 - Verify the commit subject is imperative and change-oriented; use `git log`/`git show` on staged commits or PR payload to validate body structure.
 - Verify `Release-Note` is the preferred tester/release-facing source; legacy `Changelog` remains accepted during producer migration.
 - Verify `Areas` names the modules, product surfaces, commands, scripts, or workflows most likely to explain a future regression.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-17T09:45:06Z",
+  "generated_at": "2026-05-17T11:59:09Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-17T09:45:06Z",
+  "generated_at": "2026-05-17T11:59:09Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/lib-chain-git.sh
+++ b/scripts/lib-chain-git.sh
@@ -1,6 +1,43 @@
 #!/usr/bin/env bash
 # Git workspace helpers for studio-chain-runner issue sessions.
 
+CHAIN_GIT_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+if ! command -v with_login_home_for_github >/dev/null 2>&1 && [ -f "$CHAIN_GIT_SCRIPT_DIR/lib-paths.sh" ]; then
+  # shellcheck source=lib-paths.sh
+  . "$CHAIN_GIT_SCRIPT_DIR/lib-paths.sh"
+fi
+
+chain_git_configure_github_identity() {
+  local worktree="${1:?usage: chain_git_configure_github_identity <worktree>}"
+  local user_json login id name email git_name git_email
+
+  user_json=$(with_login_home_for_github gh api user 2>/dev/null) || {
+    printf 'chain-git: cannot resolve GitHub profile for commit identity\n' >&2
+    return 1
+  }
+  login=$(printf '%s\n' "$user_json" | jq -r '.login // empty')
+  id=$(printf '%s\n' "$user_json" | jq -r '.id // empty')
+  name=$(printf '%s\n' "$user_json" | jq -r '.name // empty')
+  email=$(printf '%s\n' "$user_json" | jq -r '.email // empty')
+  if [ -z "$login" ]; then
+    printf 'chain-git: GitHub profile is missing login for commit identity\n' >&2
+    return 1
+  fi
+  git_name="${name:-$login}"
+  if [ -n "$email" ]; then
+    git_email="$email"
+  elif [ -n "$id" ]; then
+    git_email="$id+$login@users.noreply.github.com"
+  else
+    printf 'chain-git: GitHub profile is missing email and id for commit identity\n' >&2
+    return 1
+  fi
+
+  git -C "$worktree" config user.name "$git_name"
+  git -C "$worktree" config user.email "$git_email"
+  git -C "$worktree" config user.useConfigOnly true
+}
+
 chain_git_prepare_issue_workspace() {
   local repo_root="${1:?usage: chain_git_prepare_issue_workspace <repo-root> <chain-worktree> <chain-branch> <issue-worktree> <issue-branch> <strategy>}"
   local chain_worktree="${2:?chain worktree required}"

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -7923,6 +7923,8 @@ run_issue_job() {
   log "issue #$issue -> $issue_branch"
   if [ "$DRY_RUN" -eq 0 ]; then
     chain_git_prepare_issue_workspace "$TARGET_REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
+    chain_git_configure_github_identity "$issue_worktree" \
+      || abort_run_with_reason github_auth_unavailable "cannot configure GitHub commit identity for issue #$issue worktree"
     before=$(git -C "$issue_worktree" rev-parse HEAD)
   else
     printf 'DRY-RUN git metadata strategy for host %q: %s\n' "$host" "$git_metadata_strategy"
@@ -8001,6 +8003,8 @@ run_issue_job() {
     log "issue #$issue exited $worker_rc with no summary and no public diff; retrying once in a fresh issue worktree"
     mark_issue_retry_attempt "$issue_run_id" "worker_summary_missing_no_changes"
     chain_git_prepare_issue_workspace "$TARGET_REPO_ROOT" "$chain_worktree" "$branch" "$issue_worktree" "$issue_branch" "$git_metadata_strategy"
+    chain_git_configure_github_identity "$issue_worktree" \
+      || abort_run_with_reason github_auth_unavailable "cannot configure GitHub commit identity for retry issue #$issue worktree"
     before=$(git -C "$issue_worktree" rev-parse HEAD)
     mark_issue_state "$issue_run_id" running "$before"
     issue_started_at=$(now_epoch)
@@ -8750,13 +8754,19 @@ for ((idx = 0; idx < chain_count; idx++)); do
     mkdir -p "$chain_results_dir"
     if [ -n "$RESUME_ID" ] && git_checkout_exists "$chain_worktree"; then
       git -C "$chain_worktree" checkout "$branch"
+      chain_git_configure_github_identity "$chain_worktree" \
+        || abort_run_with_reason github_auth_unavailable "cannot configure GitHub commit identity for chain $name worktree"
     elif ! git_checkout_exists "$chain_worktree"; then
       git -C "$TARGET_REPO_ROOT" worktree add -B "$branch" "$chain_worktree" "origin/$base"
       git -C "$chain_worktree" checkout "$branch"
       git -C "$chain_worktree" reset --hard "origin/$base"
+      chain_git_configure_github_identity "$chain_worktree" \
+        || abort_run_with_reason github_auth_unavailable "cannot configure GitHub commit identity for chain $name worktree"
     else
       git -C "$chain_worktree" checkout "$branch"
       git -C "$chain_worktree" reset --hard "origin/$base"
+      chain_git_configure_github_identity "$chain_worktree" \
+        || abort_run_with_reason github_auth_unavailable "cannot configure GitHub commit identity for chain $name worktree"
     fi
   else
     mkdir -p "$chain_results_dir"

--- a/scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh
+++ b/scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh
@@ -60,6 +60,18 @@ cat > "$BIN/gh" <<'SH'
 #!/usr/bin/env bash
 set -eu
 
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  cat <<'JSON'
+{
+  "login": "fixture-login",
+  "name": null,
+  "email": null,
+  "id": 571
+}
+JSON
+  exit 0
+fi
+
 if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
   issue="$3"
   cat <<JSON
@@ -78,6 +90,16 @@ printf 'unexpected gh invocation: %s\n' "$*" >&2
 exit 1
 SH
 chmod +x "$BIN/gh"
+
+PATH="$BIN:$PATH" HOME="$HOME_DIR" chain_git_configure_github_identity "$CHAIN_WORKTREE"
+[ "$(git -C "$CHAIN_WORKTREE" config user.name)" = "fixture-login" ] || {
+  printf 'GitHub identity did not set user.name from profile login\n' >&2
+  exit 1
+}
+[ "$(git -C "$CHAIN_WORKTREE" config user.email)" = "571+fixture-login@users.noreply.github.com" ] || {
+  printf 'GitHub identity did not set noreply user.email from profile id/login\n' >&2
+  exit 1
+}
 
 manifest="$TMPROOT/chain.yaml"
 cat > "$manifest" <<'YAML'


### PR DESCRIPTION
## Summary

- Configure chain and issue worktrees with the authenticated GitHub profile before worker commits are created.
- Use the GitHub noreply address from `id+login@users.noreply.github.com` when the profile email is private.
- Keep `Studio-Host` and `Co-authored-by: Codex <noreply@openai.com>` as additive host credit, not the primary Git author identity.
- Record the identity rule in `CLAUDE.md` and `REVIEW.md`.

## Verification

- `bash scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh`
- `bash scripts/test-fixtures/975-runner-auth-home/test-runner-auth-home.sh`
- `bash -n scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh`
- `shellcheck -S error scripts/lib-chain-git.sh scripts/studio-chain-runner.sh scripts/test-fixtures/571-chain-git-metadata/test-chain-git-metadata.sh`
- `scripts/lint-gh-wrapper.sh`
- `scripts/lint-synthetic-home.sh`
- `scripts/lint-runtime-paths.sh`
- `scripts/lint-commit-message.sh --file <HEAD message>`
- `git diff --check HEAD^ HEAD`

## Notes

The already-merged commits in PR #1009 cannot have their primary author changed without rewriting `main`; this fixes future chain-created commits.