### PR TITLE
bugfix-shipped: preserve cross-project composite planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ scripts/manager-composite-chain.sh init --manifest composite.yaml --json # scrip
 scripts/manager-work-chain.sh ios-v2-execution # repo-side wrapper for the manager work-chain front door
 scripts/prd-intake-normalize.sh prd.md # normalize a PRD/transcript/issue brief into a planner-ready requirement packet
 scripts/prd-task-graph-synthesize.sh packet.md # turn a requirement packet or headed source into a validated scheduler graph
+scripts/bug-reopen-iteration-report.sh --repo owner/repo --cohort-size 20 # #549 bug-fix closure iteration reopen metric
 /dev-studio checkpoint           # manager-shaped checkpoint routing; stdout is the checkpoint id for resume
 /dev-studio worker checkpoint    # worker-owned compact checkpoint; does not replace worker summary
 /dev-studio worker resume-checkpoint # resume worker checkpoint via manifest.json + context.md first
@@ -239,6 +240,7 @@ scripts/                # multi-worker fleet (BETA)
   studio-tf-slack.sh # script-backed TF Slack draft/send bridge with lint + approval gate
   forge-latency-report.sh  # stage-level task latency + review-gate comparison from event logs
   field-workflow-report.sh # Field loop report: timing, token, gate, review, and improvement mining
+  bug-reopen-iteration-report.sh # #549 iteration-based bug reopen metric from issue events
   studio-pr-baseline-report.sh # PR-level timing, churn, gate, and generated-file baselines
   studio-dependency-export.sh # Mermaid graph from native GitHub blocked_by issue dependencies
   studio-weekly.sh     # weekly GitHub issue digest; scheduled workflow posts to the pinned summary issue
@@ -415,7 +417,9 @@ is `/dev-studio manager composite-chain init --manifest <file>` or
 `scripts/manager-composite-chain.sh init --manifest <file>`. Inputs must be an
 explicit `kind: composite-chain` manifest; `/dev-studio manager work-chain
 --composite-parent <issue>` and parent-issue natural-language extraction are
-future/non-MVP. Use `/dev-studio manager composite-chain status --run-id
+future/non-MVP. Cross-project manifests can declare `repo`, `project`, and
+`target_repo_root`; the normalized state then carries those values through
+child planning and resume. Use `/dev-studio manager composite-chain status --run-id
 <run_id>` for non-mutating progress inspection, then continue from a clean
 session with `/dev-studio manager composite-chain plan-active-child --run-id
 <run_id>`, `execute-active-child --run-id <run_id>`, or `resume --run-id

--- a/_shared/contracts/composite-chain-state.md
+++ b/_shared/contracts/composite-chain-state.md
@@ -56,6 +56,21 @@ children:
     issue: 124
 ```
 
+Cross-project manifests may also declare:
+
+```yaml
+repo: example-org/sample-app
+project: sample-app
+target_repo_root: /Users/example/src/sample-app
+```
+
+When present, these values are normalized into the state snapshot during
+`init`. Issue child URLs, `manager plan-chain --repo`, runtime artifact lookup,
+and child run lookup use the state snapshot on later `plan`, `status`, and
+`resume` calls, so operators do not need to preserve environment variables
+between sessions. When omitted, the supervisor falls back to the current studio
+checkout behavior.
+
 `children[].id` is the stable child identity. It is reused in state,
 idempotency keys, status output, event payloads, and resume commands. IDs are
 slugs, not issue titles, so they stay stable when issue titles change.

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-17T14:12:06Z",
+  "generated_at": "2026-05-18T00:32:25Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-17T14:12:05Z",
+  "generated_at": "2026-05-18T00:32:25Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,6 +65,7 @@ scripts/analyze-collect.sh --project turnip-ios         # stats dump for a usage
 scripts/analyze-collect.sh --project turnip-ios --since 2026-04-01
 scripts/forge-latency-report.sh --project turnip-ios --days 14   # stage-level task latency + review-gate comparison
 scripts/field-workflow-report.sh --project turnip-ios --days 14   # Field loop timing, tokens, gates, review coverage, improvement candidates
+scripts/bug-reopen-iteration-report.sh --repo owner/repo --cohort-size 20 # #549 bug-fix closure iteration reopen metric; emits markdown or --json
 scripts/studio-weekly.sh --post                                  # weekly GitHub PM digest comment on the pinned summary issue
 scripts/studio-chain-runner.sh workflow-measurement-improvements            # default plan/explain + private resumable state
 scripts/studio-chain-runner.sh workflow-measurement-improvements --dry-run  # same resolved graph, then non-mutating command trace

--- a/scripts/bug-reopen-iteration-report.sh
+++ b/scripts/bug-reopen-iteration-report.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# bug-reopen-iteration-report.sh — iteration-based bug reopen metric for #549.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)
+
+# shellcheck source=scripts/lib-artifact-cleanup.sh
+. "$SCRIPT_DIR/lib-artifact-cleanup.sh"
+
+REPO=""
+CUTOVER="2026-05-03T23:37:02Z"
+COHORT_SIZE=20
+EVENTS_JSON=""
+OUTPUT_JSON=0
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  scripts/bug-reopen-iteration-report.sh --repo owner/repo [--cutover ISO] [--cohort-size N] [--json]
+  scripts/bug-reopen-iteration-report.sh --events-json events.json [--cutover ISO] [--cohort-size N] [--json]
+
+Computes the #549 iteration-based bug-reopen metric. A closure iteration is one
+`closed` event on a bug issue. A closure is counted as reopened when the same
+issue receives a later `reopened` event before its next closure.
+EOF
+  exit 2
+}
+
+fail() {
+  printf 'bug-reopen-iteration-report: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="${2:?--repo requires owner/repo}"; shift 2 ;;
+    --repo=*) REPO="${1#--repo=}"; shift ;;
+    --cutover) CUTOVER="${2:?--cutover requires an ISO timestamp}"; shift 2 ;;
+    --cutover=*) CUTOVER="${1#--cutover=}"; shift ;;
+    --cohort-size) COHORT_SIZE="${2:?--cohort-size requires a number}"; shift 2 ;;
+    --cohort-size=*) COHORT_SIZE="${1#--cohort-size=}"; shift ;;
+    --events-json) EVENTS_JSON="${2:?--events-json requires a file}"; shift 2 ;;
+    --events-json=*) EVENTS_JSON="${1#--events-json=}"; shift ;;
+    --now) NOW="${2:?--now requires an ISO timestamp}"; shift 2 ;;
+    --now=*) NOW="${1#--now=}"; shift ;;
+    --json) OUTPUT_JSON=1; shift ;;
+    -h|--help) usage ;;
+    *) fail "unknown argument: $1" 2 ;;
+  esac
+done
+
+command -v jq >/dev/null 2>&1 || fail "jq required" 2
+case "$COHORT_SIZE" in
+  ''|*[!0-9]*) fail "--cohort-size must be numeric: $COHORT_SIZE" 2 ;;
+esac
+[ "$COHORT_SIZE" -gt 0 ] || fail "--cohort-size must be greater than zero" 2
+[ -n "$EVENTS_JSON" ] || [ -n "$REPO" ] || fail "provide --events-json or --repo" 2
+[ -z "$EVENTS_JSON" ] || [ -r "$EVENTS_JSON" ] || fail "cannot read events JSON: $EVENTS_JSON" 2
+
+TMPROOT=$(mktemp -d -t bug-reopen-iteration.XXXXXX); register_artifact tmpdir "$TMPROOT"
+NORMALIZED="$TMPROOT/events.json"
+
+if [ -n "$EVENTS_JSON" ]; then
+  jq '
+    def issue_number:
+      .issue_number // .issue // .number // .issue.number // .issue_url
+      | if type == "string" then capture("issues/(?<n>[0-9]+)").n? // . else . end
+      | tonumber;
+    [ .[]?
+      | select((.event // .type // "") == "closed" or (.event // .type // "") == "reopened")
+      | {
+          issue_number: issue_number,
+          event: (.event // .type),
+          created_at: (.created_at // .timestamp)
+        }
+      | select(.issue_number != null and .created_at != null)
+    ]
+  ' "$EVENTS_JSON" > "$NORMALIZED"
+else
+  issues="$TMPROOT/issues.json"
+  : > "$NORMALIZED"
+  "$SCRIPT_DIR/studio-gh.sh" api --paginate "/repos/$REPO/issues?state=all&labels=bug&per_page=100" > "$issues"
+  jq -r '.[].number' "$issues" | while IFS= read -r issue_number; do
+    [ -n "$issue_number" ] || continue
+    "$SCRIPT_DIR/studio-gh.sh" api --paginate "/repos/$REPO/issues/$issue_number/events?per_page=100" \
+      | jq --argjson issue_number "$issue_number" '
+          [ .[]?
+            | select(.event == "closed" or .event == "reopened")
+            | {issue_number: $issue_number, event, created_at}
+          ]
+        ' > "$TMPROOT/events-$issue_number.json"
+  done
+  jq -s 'add // []' "$TMPROOT"/events-*.json > "$NORMALIZED" 2>/dev/null || printf '[]\n' > "$NORMALIZED"
+fi
+
+REPORT="$TMPROOT/report.json"
+jq -S \
+  --arg cutover "$CUTOVER" \
+  --arg now "$NOW" \
+  --argjson cohort_size "$COHORT_SIZE" '
+  def rate($reopened; $total):
+    if $total == 0 then null else ($reopened / $total) end;
+  def rounded:
+    if . == null then null else ((. * 10000 | round) / 10000) end;
+  def pct:
+    if . == null then "n/a" else (((. * 10000 | round) / 100) | tostring) + "%" end;
+  def closure_iterations:
+    sort_by(.issue_number, .created_at)
+    | group_by(.issue_number)
+    | map(
+        sort_by(.created_at) as $events
+        | [range(0; $events | length) as $i
+          | select($events[$i].event == "closed")
+          | ($events[$i].created_at) as $closed_at
+          | ([range($i + 1; $events | length) as $j
+              | select($events[$j].event == "closed")
+              | $events[$j].created_at][0] // $now) as $next_close_or_snapshot
+          | {
+              issue_number: $events[$i].issue_number,
+              closed_at: $closed_at,
+              boundary_at: $next_close_or_snapshot,
+              reopened: (any($events[];
+                .event == "reopened"
+                and .created_at > $closed_at
+                and .created_at < $next_close_or_snapshot
+              ))
+            }
+        ]
+      )
+    | add // []
+    | sort_by(.closed_at);
+  def cohort_summary($items):
+    {
+      requested_size: $cohort_size,
+      count: ($items | length),
+      reopened_count: ([$items[] | select(.reopened == true)] | length),
+      rate: (rate(([$items[] | select(.reopened == true)] | length); ($items | length)) | rounded),
+      issue_iterations: $items
+    };
+
+  closure_iterations as $iterations
+  | ([$iterations[] | select(.closed_at < $cutover)] | sort_by(.closed_at) | .[-$cohort_size:]) as $baseline_items
+  | ([$iterations[] | select(.closed_at >= $cutover)] | sort_by(.closed_at) | .[:$cohort_size]) as $post_items
+  | (cohort_summary($baseline_items)) as $baseline
+  | (cohort_summary($post_items)) as $post
+  | {
+      schema_version: 1,
+      kind: "bug-reopen-iteration-report",
+      cutover: $cutover,
+      generated_at: $now,
+      cohort_size: $cohort_size,
+      definition: {
+        unit: "bug-fix closure iteration",
+        numerator: "closure iterations whose issue later receives a reopened event before the next closure for that same issue or the comparison snapshot",
+        baseline: "last N bug-fix closure iterations before cutover",
+        post_cutover: "first N bug-fix closure iterations after cutover"
+      },
+      baseline: $baseline,
+      post_cutover: $post,
+      comparison: {
+        cohorts_complete: (($baseline.count >= $cohort_size) and ($post.count >= $cohort_size)),
+        baseline_rate: $baseline.rate,
+        post_cutover_rate: $post.rate,
+        reduction_fraction: (
+          if ($baseline.rate == null or $baseline.rate == 0 or $post.rate == null)
+          then null
+          else ((($baseline.rate - $post.rate) / $baseline.rate) | rounded)
+          end
+        ),
+        claim_supported: (
+          (($baseline.count >= $cohort_size) and ($post.count >= $cohort_size))
+          and ($baseline.rate != null and $baseline.rate > 0)
+          and ($post.rate != null)
+          and ((($baseline.rate - $post.rate) / $baseline.rate) >= 0.25)
+        ),
+        claim_note: (
+          if (($baseline.count >= $cohort_size) and ($post.count >= $cohort_size)) | not
+          then "Directional only: at least one cohort has fewer than requested closure iterations."
+          elif ($baseline.rate == null or $baseline.rate == 0)
+          then "No 25% reduction claim: baseline rate is zero or undefined."
+          elif ((($baseline.rate - $post.rate) / $baseline.rate) >= 0.25)
+          then "25% reduction claim is supported by complete cohorts."
+          else "No 25% reduction claim: observed reduction is below threshold."
+          end
+        )
+      }
+    }
+  ' "$NORMALIZED" > "$REPORT"
+
+if [ "$OUTPUT_JSON" -eq 1 ]; then
+  cat "$REPORT"
+else
+  jq -r '
+    def pct:
+      if . == null then "n/a" else (((. * 10000 | round) / 100) | tostring) + "%" end;
+    "# Bug Reopen Iteration Report",
+    "",
+    "- Cutover: `" + .cutover + "`",
+    "- Cohort size: `" + (.cohort_size | tostring) + "`",
+    "- Baseline: `" + (.baseline.reopened_count | tostring) + "/" + (.baseline.count | tostring) + "` reopened (`" + (.baseline.rate | pct) + "`)",
+    "- Post-A10: `" + (.post_cutover.reopened_count | tostring) + "/" + (.post_cutover.count | tostring) + "` reopened (`" + (.post_cutover.rate | pct) + "`)",
+    "- Claim supported: `" + (.comparison.claim_supported | tostring) + "`",
+    "- Note: " + .comparison.claim_note
+  ' "$REPORT"
+fi

--- a/scripts/manager-composite-chain.sh
+++ b/scripts/manager-composite-chain.sh
@@ -91,6 +91,53 @@ resolve_issue_repo_slug() {
   printf 'v-i-s-h-a-l/generic-dev-studio\n'
 }
 
+canonicalize_target_repo_root() {
+  local manifest="$1" target="${2:-}" base resolved
+  if [ -z "$target" ] || [ "$target" = "null" ]; then
+    printf '%s\n' "$REPO_ROOT"
+    return 0
+  fi
+  case "$target" in
+    /*) resolved="$target" ;;
+    *)
+      base=$(cd "$(dirname "$manifest")" && pwd -P)
+      resolved="$base/$target"
+      ;;
+  esac
+  [ -d "$resolved" ] || fail "manifest target_repo_root does not exist: $target" 2
+  cd "$resolved" && pwd -P
+}
+
+state_project() {
+  local state_file="$1" project
+  project=$(jq -r '.manifest.project // empty' "$state_file")
+  if [ -n "$project" ]; then
+    printf '%s\n' "$project"
+    return 0
+  fi
+  printf '%s\n' "${STUDIO_COMPOSITE_PLAN_CHAIN_PROJECT:-generic-dev-studio}"
+}
+
+state_issue_repo() {
+  local state_file="$1" repo
+  repo=$(jq -r '.manifest.repo // .manifest.issue_repo // empty' "$state_file")
+  if [ -n "$repo" ]; then
+    github_repo_slug_from_hint "$repo" || fail "state manifest repo is not a GitHub owner/repo slug: $repo" 2
+    return 0
+  fi
+  resolve_issue_repo_slug
+}
+
+state_target_repo_root() {
+  local state_file="$1" root
+  root=$(jq -r '.manifest.target_repo_root // empty' "$state_file")
+  if [ -n "$root" ]; then
+    printf '%s\n' "$root"
+    return 0
+  fi
+  printf '%s\n' "$REPO_ROOT"
+}
+
 validate_run_id() {
   local run_id="${1:?usage: validate_run_id <run-id>}"
   if [[ ! "$run_id" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
@@ -190,16 +237,16 @@ eligible_pending_child_tsv() {
 }
 
 plan_result_path_for() {
-  local plan_run_id="${1:?usage: plan_result_path_for <plan-run-id>}" project_root artifact_home project
-  project="${STUDIO_COMPOSITE_PLAN_CHAIN_PROJECT:-generic-dev-studio}"
+  local state_file="${1:?usage: plan_result_path_for <state> <plan-run-id>}" plan_run_id="${2:?usage: plan_result_path_for <state> <plan-run-id>}" project_root artifact_home project
+  project=$(state_project "$state_file")
   artifact_home=$(resolve_parent_home_for_github)
   project_root=$(HOME="$artifact_home" resolve_project_root_for "$project")
   printf '%s/plan-chains/%s/result.json\n' "$project_root" "$plan_run_id"
 }
 
 child_chain_runs_root() {
-  local artifact_home project_root project
-  project="${STUDIO_COMPOSITE_PLAN_CHAIN_PROJECT:-generic-dev-studio}"
+  local state_file="${1:?usage: child_chain_runs_root <state>}" artifact_home project_root project
+  project=$(state_project "$state_file")
   artifact_home=$(resolve_parent_home_for_github)
   project_root=$(HOME="$artifact_home" resolve_project_root_for "$project")
   printf '%s/chain-runs\n' "$project_root"
@@ -229,8 +276,10 @@ write_halt_record() {
 }
 
 child_plan_command_json() {
-  local state_file="$1" child_index="$2" child_id="$3" issue_repo="$4" source_type issue manifest_path project
-  project="${STUDIO_COMPOSITE_PLAN_CHAIN_PROJECT:-generic-dev-studio}"
+  local state_file="$1" child_index="$2" child_id="$3" source_type issue manifest_path project target_repo_root issue_repo
+  project=$(state_project "$state_file")
+  target_repo_root=$(state_target_repo_root "$state_file")
+  issue_repo=$(state_issue_repo "$state_file")
   source_type=$(jq -r --argjson idx "$child_index" '.children[$idx].source.source_type' "$state_file")
   case "$source_type" in
     issue)
@@ -240,7 +289,7 @@ child_plan_command_json() {
         --arg issue "$issue" \
         --arg issue_repo "$issue_repo" \
         --arg child_id "$child_id" \
-        --arg repo_root "$REPO_ROOT" \
+        --arg repo_root "$target_repo_root" \
         --arg project "$project" \
         '[$script, "--issue", $issue, "--repo", $issue_repo, "--chain", $child_id, "--project", $project, "--target-repo-root", $repo_root, "--no-execute"]'
       ;;
@@ -250,7 +299,7 @@ child_plan_command_json() {
         --arg script "${STUDIO_COMPOSITE_PLAN_CHAIN_SCRIPT:-$SCRIPT_DIR/manager-plan-chain.sh}" \
         --arg manifest_path "$manifest_path" \
         --arg child_id "$child_id" \
-        --arg repo_root "$REPO_ROOT" \
+        --arg repo_root "$target_repo_root" \
         --arg project "$project" \
         '[$script, "--source-file", $manifest_path, "--chain", $child_id, "--project", $project, "--target-repo-root", $repo_root, "--no-execute"]'
       ;;
@@ -329,17 +378,17 @@ child_run_id_from_output() {
 }
 
 child_run_state_for_id() {
-  local child_run_id="$1" root
+  local state_file="$1" child_run_id="$2" root
   [ -n "$child_run_id" ] || return 1
   validate_run_id "$child_run_id"
-  root=$(child_chain_runs_root) || return 1
+  root=$(child_chain_runs_root "$state_file") || return 1
   [ -f "$root/$child_run_id/state.json" ] || return 1
   printf '%s/%s/state.json\n' "$root" "$child_run_id"
 }
 
 latest_child_run_state_for_manifest() {
-  local work_chain_manifest="$1" root row
-  root=$(child_chain_runs_root) || return 1
+  local state_file="$1" work_chain_manifest="$2" root row
+  root=$(child_chain_runs_root "$state_file") || return 1
   [ -d "$root" ] || return 1
   row=$(
     find "$root" -mindepth 2 -maxdepth 2 -name state.json -type f 2>/dev/null | sort | while IFS= read -r candidate; do
@@ -355,13 +404,13 @@ latest_child_run_state_for_manifest() {
 }
 
 resolve_child_run_state() {
-  local work_chain_manifest="$1" stdout_path="$2" stderr_path="$3" child_run_id child_state
+  local state_file="$1" work_chain_manifest="$2" stdout_path="$3" stderr_path="$4" child_run_id child_state
   child_run_id=$(child_run_id_from_output "$stdout_path" "$stderr_path" || true)
-  if [ -n "$child_run_id" ] && child_state=$(child_run_state_for_id "$child_run_id" 2>/dev/null); then
+  if [ -n "$child_run_id" ] && child_state=$(child_run_state_for_id "$state_file" "$child_run_id" 2>/dev/null); then
     printf '%s\n' "$child_state"
     return 0
   fi
-  latest_child_run_state_for_manifest "$work_chain_manifest"
+  latest_child_run_state_for_manifest "$state_file" "$work_chain_manifest"
 }
 
 active_child_halt_json() {
@@ -538,9 +587,19 @@ persist_child_execution_halt_state() {
 
 write_initial_state() {
   local manifest="$1" run_id="$2" state_file="$3" now manifest_abs manifest_data next_command tmp
+  local manifest_repo manifest_project manifest_target_repo_root
   manifest_abs=$(cd "$(dirname "$manifest")" && pwd -P)/$(basename "$manifest")
   now=$(iso_ts_now)
   manifest_data=$(manifest_json "$manifest")
+  manifest_repo=$(printf '%s\n' "$manifest_data" | jq -r '.repo // .issue_repo // empty')
+  if [ -n "$manifest_repo" ]; then
+    manifest_repo=$(github_repo_slug_from_hint "$manifest_repo") || fail "manifest repo must be a GitHub owner/repo slug: $manifest_repo" 2
+  else
+    manifest_repo=$(resolve_issue_repo_slug)
+  fi
+  manifest_target_repo_root=$(canonicalize_target_repo_root "$manifest" "$(printf '%s\n' "$manifest_data" | jq -r '.target_repo_root // .repo_root // empty')")
+  manifest_project=$(printf '%s\n' "$manifest_data" | jq -r '.project // empty')
+  [ -n "$manifest_project" ] || manifest_project="${STUDIO_COMPOSITE_PLAN_CHAIN_PROJECT:-generic-dev-studio}"
   next_command="/dev-studio manager composite-chain status --run-id $run_id"
   tmp="$state_file.tmp.$$"
   mkdir -p "$(dirname "$state_file")"
@@ -548,8 +607,17 @@ write_initial_state() {
   printf '%s\n' "$manifest_data" | jq \
     --arg run_id "$run_id" \
     --arg manifest_path "$manifest_abs" \
+    --arg manifest_repo "$manifest_repo" \
+    --arg manifest_project "$manifest_project" \
+    --arg target_repo_root "$manifest_target_repo_root" \
     --arg now "$now" \
     --arg next_command "$next_command" '
+    (. + {
+      repo: $manifest_repo,
+      project: $manifest_project,
+      target_repo_root: $target_repo_root
+    }) as $manifest
+    |
     {
       schema_version: 1,
       kind: "composite-chain-state",
@@ -558,19 +626,19 @@ write_initial_state() {
         source_type: "manifest",
         parent_issue_url: null,
         manifest_path: $manifest_path,
-        manifest_ref: .name
+        manifest_ref: $manifest.name
       },
-      manifest: .,
+      manifest: $manifest,
       state: "child_ready",
       children: [
-        .children
+        $manifest.children
         | to_entries[]
         | {
             id: .value.id,
             ordinal: .key,
             source: (
               if .value.source_type == "issue" then
-                {source_type:"issue", issue:.value.issue, issue_url:("https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/" + (.value.issue | tostring)), manifest_path:null}
+                {source_type:"issue", issue:.value.issue, issue_url:("https://github.com/" + $manifest_repo + "/issues/" + (.value.issue | tostring)), manifest_path:null}
               else
                 {source_type:"manifest", issue:null, issue_url:null, manifest_path:.value.manifest_path}
               end
@@ -583,7 +651,7 @@ write_initial_state() {
               child_run_id: null,
               issue_url: (
                 if .value.source_type == "issue" then
-                  "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/" + (.value.issue | tostring)
+                  "https://github.com/" + $manifest_repo + "/issues/" + (.value.issue | tostring)
                 else
                   null
                 end
@@ -742,7 +810,7 @@ cmd_status() {
 }
 
 cmd_plan_active_child() {
-  local run_id="" state_file="" output_json=0 eligible child_index child_id now issue_repo command_json plan_run_id
+  local run_id="" state_file="" output_json=0 eligible child_index child_id now command_json plan_run_id
   local attempt_dir stdout_path stderr_path result_json rc result_status reason_id summary details_ref final_rc=0 comment_context_json
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -781,9 +849,8 @@ cmd_plan_active_child() {
   mkdir -p "$attempt_dir"
   stdout_path="$attempt_dir/manager-plan-chain.out"
   stderr_path="$attempt_dir/manager-plan-chain.err"
-  result_json=$(plan_result_path_for "$plan_run_id")
-  issue_repo=$(resolve_issue_repo_slug)
-  command_json=$(child_plan_command_json "$state_file" "$child_index" "$child_id" "$issue_repo")
+  result_json=$(plan_result_path_for "$state_file" "$plan_run_id")
+  command_json=$(child_plan_command_json "$state_file" "$child_index" "$child_id")
   comment_context_json=$(child_comment_context_json "$state_file" "$child_index")
 
   # shellcheck disable=SC2016
@@ -885,7 +952,7 @@ cmd_execute_active_child() {
   rc=$?
   set -e
 
-  child_state=$(resolve_child_run_state "$work_chain_manifest" "$stdout_path" "$stderr_path" 2>/dev/null || true)
+  child_state=$(resolve_child_run_state "$state_file" "$work_chain_manifest" "$stdout_path" "$stderr_path" 2>/dev/null || true)
   if [ -z "$child_state" ] || [ ! -f "$child_state" ]; then
     reason_id="child_run_state_missing"
     summary="Child work-chain command did not leave a durable chain run state."
@@ -951,7 +1018,7 @@ cmd_resume() {
       child_id=$(jq -r --argjson idx "$child_index" '.children[$idx].id' "$state_file")
       plan_run_id=$(jq -r --argjson idx "$child_index" '.children[$idx].refs.plan_run_id // empty' "$state_file")
       [ -n "$plan_run_id" ] || fail "resume cannot reconcile planning child without refs.plan_run_id" 1
-      result_json=$(plan_result_path_for "$plan_run_id")
+      result_json=$(plan_result_path_for "$state_file" "$plan_run_id")
       if [ ! -f "$result_json" ]; then
         persist_planning_halt_state "$state_file" "$child_index" "$child_id" "child_plan_state_missing" "Child planning was in progress but no durable manager-plan-chain result exists." ""
         final_rc=1
@@ -985,10 +1052,10 @@ cmd_resume() {
       child_state=$(jq -r --argjson idx "$child_index" '.children[$idx].refs.child_run_state // empty' "$state_file")
 
       if { [ -z "$child_state" ] || [ ! -f "$child_state" ]; } && [ -n "$child_run_id" ]; then
-        child_state=$(child_run_state_for_id "$child_run_id" 2>/dev/null || true)
+        child_state=$(child_run_state_for_id "$state_file" "$child_run_id" 2>/dev/null || true)
       fi
       if { [ -z "$child_state" ] || [ ! -f "$child_state" ]; } && [ -n "$work_chain_manifest" ] && [ "$work_chain_manifest" != "null" ]; then
-        child_state=$(latest_child_run_state_for_manifest "$work_chain_manifest" 2>/dev/null || true)
+        child_state=$(latest_child_run_state_for_manifest "$state_file" "$work_chain_manifest" 2>/dev/null || true)
       fi
       if [ -n "$child_state" ] && [ -f "$child_state" ]; then
         child_run_id=$(jq -r '.run_id // empty' "$child_state")
@@ -1008,7 +1075,7 @@ cmd_resume() {
           rc=$?
           set -e
 
-          child_state=$(child_run_state_for_id "$child_run_id" 2>/dev/null || printf '%s\n' "$child_state")
+          child_state=$(child_run_state_for_id "$state_file" "$child_run_id" 2>/dev/null || printf '%s\n' "$child_state")
           run_status=$(jq -r '.status // "unknown"' "$child_state")
           if [ "$rc" -eq 0 ] && [ "$run_status" = "completed" ]; then
             persist_child_completion_state "$state_file" "$child_index" "$child_state"

--- a/scripts/prd-task-graph-synthesize.sh
+++ b/scripts/prd-task-graph-synthesize.sh
@@ -228,13 +228,15 @@ function resources_anywhere(text,    rest, value, out) {
   return out
 }
 
-function resources_in_component_body(body,    rest, line, in_reference_section, paragraph, out, found_resources, fr, found_arr, ended) {
+function resources_in_component_body(body,    rest, line, line_l, in_reference_section, in_allowed_paths_section, paragraph, out, found_resources, fr, found_arr, ended) {
   rest = body
   out = ""
   in_reference_section = 0
+  in_allowed_paths_section = 0
   paragraph = ""
   while (match(rest, /\n[^\n]*/)) {
     line = substr(rest, RSTART + 1, RLENGTH - 1)
+    line_l = lower(line)
     rest = substr(rest, RSTART + RLENGTH)
     if (line ~ /^####?[[:space:]]/) {
       if (paragraph != "") {
@@ -250,6 +252,20 @@ function resources_in_component_body(body,    rest, line, in_reference_section, 
       } else {
         in_reference_section = 0
       }
+      in_allowed_paths_section = (line_l ~ /(allowed paths|allowed paths or resources|write resources)/)
+      continue
+    }
+    if (line_l ~ /^[[:space:]]*(allowed paths|allowed paths or resources|write resources):[[:space:]]*$/) {
+      if (paragraph != "") {
+        found_resources = resources_from(paragraph, "write")
+        if (found_resources != "") {
+          split(found_resources, found_arr, ",")
+          for (fr in found_arr) out = add_resource(out, found_arr[fr])
+        }
+        paragraph = ""
+      }
+      in_reference_section = 0
+      in_allowed_paths_section = 1
       continue
     }
     if (in_reference_section) continue
@@ -262,6 +278,7 @@ function resources_in_component_body(body,    rest, line, in_reference_section, 
         }
         paragraph = ""
       }
+      in_allowed_paths_section = 0
       continue
     }
     if (line ~ /^[[:space:]]*[-*][[:space:]]/) {
@@ -272,7 +289,24 @@ function resources_in_component_body(body,    rest, line, in_reference_section, 
           for (fr in found_arr) out = add_resource(out, found_arr[fr])
         }
       }
+      if (in_allowed_paths_section) {
+        found_resources = resources_anywhere(line)
+        if (found_resources != "") {
+          split(found_resources, found_arr, ",")
+          for (fr in found_arr) out = add_resource(out, found_arr[fr])
+        }
+        paragraph = ""
+        continue
+      }
       paragraph = line
+      continue
+    }
+    if (in_allowed_paths_section) {
+      found_resources = resources_anywhere(line)
+      if (found_resources != "") {
+        split(found_resources, found_arr, ",")
+        for (fr in found_arr) out = add_resource(out, found_arr[fr])
+      }
       continue
     }
     paragraph = paragraph " " line

--- a/scripts/test-fixtures/549-bug-reopen-iteration-report/test-bug-reopen-iteration-report.sh
+++ b/scripts/test-fixtures/549-bug-reopen-iteration-report/test-bug-reopen-iteration-report.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUN="$ROOT/scripts/bug-reopen-iteration-report.sh"
+TMPROOT=$(mktemp -d -t bug-reopen-iteration-report.XXXXXX)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "jq required"
+
+EVENTS="$TMPROOT/events.json"
+REPORT="$TMPROOT/report.json"
+cat > "$EVENTS" <<'JSON'
+[
+  {"issue_number": 1, "event": "closed", "created_at": "2026-05-01T00:00:00Z"},
+  {"issue_number": 1, "event": "reopened", "created_at": "2026-05-01T12:00:00Z"},
+  {"issue_number": 1, "event": "closed", "created_at": "2026-05-02T00:00:00Z"},
+  {"issue_number": 2, "event": "closed", "created_at": "2026-05-02T12:00:00Z"},
+  {"issue_number": 3, "event": "closed", "created_at": "2026-05-04T00:00:00Z"},
+  {"issue_number": 4, "event": "closed", "created_at": "2026-05-05T00:00:00Z"},
+  {"issue_number": 4, "event": "reopened", "created_at": "2026-05-05T12:00:00Z"},
+  {"issue_number": 4, "event": "closed", "created_at": "2026-05-06T00:00:00Z"}
+]
+JSON
+
+"$RUN" --events-json "$EVENTS" --cutover "2026-05-03T23:37:02Z" --cohort-size 3 --now "2026-05-18T00:00:00Z" --json > "$REPORT"
+
+jq -e '
+  .kind == "bug-reopen-iteration-report"
+  and .baseline.count == 3
+  and .baseline.reopened_count == 1
+  and .baseline.rate == 0.3333
+  and .post_cutover.count == 3
+  and .post_cutover.reopened_count == 1
+  and .post_cutover.rate == 0.3333
+  and .comparison.cohorts_complete == true
+  and .comparison.claim_supported == false
+' "$REPORT" >/dev/null || {
+  jq . "$REPORT" >&2
+  fail "unexpected bug reopen iteration report JSON"
+}
+
+"$RUN" --events-json "$EVENTS" --cutover "2026-05-03T23:37:02Z" --cohort-size 4 --now "2026-05-18T00:00:00Z" > "$TMPROOT/report.md"
+grep -Fq 'Directional only' "$TMPROOT/report.md" || fail "markdown report did not surface directional smaller-N note"
+
+printf 'PASS: bug reopen iteration report\n'

--- a/scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
+++ b/scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
@@ -205,4 +205,54 @@ esac
 empty_count=$(jq '[.validation.empty_allowed_paths[]?] | length' "$GRAPH")
 [ "$empty_count" = "0" ] || fail "validation reported $empty_count empty allowed_paths nodes"
 
+CONSTRAINT_SOURCE="$TMPROOT/explicit-allowed-paths.md"
+CONSTRAINT_GRAPH="$TMPROOT/explicit-allowed-paths.json"
+cat >"$CONSTRAINT_SOURCE" <<'EOF'
+# Explicit issue-body constraints
+
+Input source: issue brief.
+Output artifact format: JSON worker summaries.
+Verification evidence: focused fixture test.
+
+## Scope
+
+### 1. Navigation shell
+
+Allowed paths:
+- `SampleApp/Sources/Navigation/AppRouter.swift`
+- `SampleApp/Tests/NavigationTests/AppRouterTests.swift`
+
+Required output artifacts:
+- `.studio/chain-worker-summary.json`
+
+Non-goals:
+- Do not edit release scripts.
+
+Verification expectations:
+- `swift test --filter NavigationTests`
+
+### 2. Feature tabs
+
+Allowed Paths Or Resources:
+- `SampleApp/Sources/Navigation/FeatureTabs.swift`
+
+Output format:
+- `.studio/chain-worker-summary.json`
+
+Verification expectations:
+- `swift test --filter FeatureTabsTests`
+EOF
+
+"$RUN" "$CONSTRAINT_SOURCE" >"$CONSTRAINT_GRAPH" 2>"$TMPROOT/explicit-allowed-paths.err" \
+  || { cat "$TMPROOT/explicit-allowed-paths.err" >&2; fail "explicit allowed paths source failed synthesis"; }
+
+jq -e '
+  (.nodes[] | select(.id == "T-R001") | .write_resources | sort)
+    == ["SampleApp/Sources/Navigation/AppRouter.swift", "SampleApp/Tests/NavigationTests/AppRouterTests.swift"]
+  and
+  (.nodes[] | select(.id == "T-R002") | .write_resources | sort)
+    == ["SampleApp/Sources/Navigation/FeatureTabs.swift"]
+  and ([.validation.empty_allowed_paths[]?] | length) == 0
+' "$CONSTRAINT_GRAPH" >/dev/null || fail "explicit Allowed Paths sections were not preserved as write_resources"
+
 printf 'PASS: planner allowed_paths hygiene rejects shell syntax, bare extensions, references, and negation phrasing\n'

--- a/scripts/test-fixtures/953-composite-chain-planning/stub-manager-plan-chain.sh
+++ b/scripts/test-fixtures/953-composite-chain-planning/stub-manager-plan-chain.sh
@@ -7,9 +7,6 @@ set -euo pipefail
   exit 2
 }
 
-artifact_root="$HOME/.dev-studio/generic-dev-studio/plan-chains/$STUDIO_MANAGER_PLAN_CHAIN_RUN_ID"
-mkdir -p "$artifact_root"
-
 if [ -n "${STUB_PLAN_LOG:-}" ]; then
   printf '%s\n' "$*" >> "$STUB_PLAN_LOG"
 fi
@@ -17,6 +14,9 @@ fi
 include_comments=0
 issue_source=0
 body_only=0
+project="generic-dev-studio"
+repo="v-i-s-h-a-l/generic-dev-studio"
+prev=""
 for arg in "$@"; do
   case "$arg" in
     --issue)
@@ -28,8 +28,18 @@ for arg in "$@"; do
     --body-only)
       body_only=1
       ;;
+    *)
+      case "$prev" in
+        --project) project="$arg" ;;
+        --repo) repo="$arg" ;;
+      esac
+      ;;
   esac
+  prev="$arg"
 done
+
+artifact_root="$HOME/.dev-studio/$project/plan-chains/$STUDIO_MANAGER_PLAN_CHAIN_RUN_ID"
+mkdir -p "$artifact_root"
 
 if [ "$issue_source" -eq 1 ] && [ "$body_only" -eq 0 ]; then
   include_comments=1
@@ -49,6 +59,7 @@ jq -n \
   --arg status "$status" \
   --arg artifact_root "$artifact_root" \
   --arg planner "$planner" \
+  --arg repo "$repo" \
   --argjson include_comments "$include_comments" \
   --arg review "$review" \
   --arg work_chain "$work_chain" \
@@ -71,12 +82,12 @@ jq -n \
       {
         node_id: "T001",
         number: 9001,
-        url: "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/9001"
+        url: ("https://github.com/" + $repo + "/issues/9001")
       }
     ],
     parent_issue: {
       number: 123,
-      url: "https://github.com/v-i-s-h-a-l/generic-dev-studio/issues/123"
+      url: ("https://github.com/" + $repo + "/issues/123")
     },
     blocked_decisions: (if $status == "ready" then [] else ["stubbed planner block"] end)
   }' > "$artifact_root/result.json"

--- a/scripts/test-fixtures/953-composite-chain-planning/test-composite-chain-planning.sh
+++ b/scripts/test-fixtures/953-composite-chain-planning/test-composite-chain-planning.sh
@@ -10,6 +10,7 @@ STUB="$FIXTURE_DIR/stub-manager-plan-chain.sh"
 RUN_ID="019e2c8a-9560-7000-8000-000000000001"
 HALT_RUN_ID="019e2c8a-9560-7000-8000-000000000002"
 MANIFEST_CHILD_RUN_ID="019e2c8a-9560-7000-8000-000000000003"
+CROSS_PROJECT_RUN_ID="019e2c8a-9560-7000-8000-000000000004"
 TMPROOT="${TMPDIR:-/tmp}/composite-chain-planning.$$"
 
 trap 'rm -rf "$TMPROOT"' EXIT
@@ -46,6 +47,8 @@ fi
 HOME="$TMPROOT/home" ACHILLES_PROJECT=generic-dev-studio "$MANAGER" validate-state --state "$state_path" >/dev/null
 jq -e '
   .state == "child_planned"
+  and .manifest.repo == "v-i-s-h-a-l/generic-dev-studio"
+  and .manifest.project == "generic-dev-studio"
   and .current_child_id == "first-child"
   and .children[0].status == "planned"
   and (.children[0].refs.planner_artifact | type == "string")
@@ -137,5 +140,53 @@ jq -e '
   .children[0].refs.comment_context.comments_included == false
   and .children[0].refs.comment_context.mode == "body-only"
 ' "$manifest_state_path" >/dev/null || fail "manifest child planning did not preserve body-only context"
+
+cross_project_root="$TMPROOT/turnip-repo"
+cross_project_manifest="$TMPROOT/cross-project-composite.yaml"
+mkdir -p "$cross_project_root"
+cross_project_root=$(cd "$cross_project_root" && pwd -P)
+cat > "$cross_project_manifest" <<YAML
+kind: composite-chain
+schema_version: 1
+name: cross-project-planning-fixture
+mode: sequential
+repo: example-org/sample-app
+project: sample-app
+target_repo_root: $cross_project_root
+children:
+  - id: turnip-child
+    source_type: issue
+    issue: 311
+YAML
+
+cross_log="$TMPROOT/cross-project-plan-calls.log"
+cross_init_json=$(HOME="$TMPROOT/home-cross" ACHILLES_PROJECT=generic-dev-studio \
+  "$MANAGER" init --manifest "$cross_project_manifest" --run-id "$CROSS_PROJECT_RUN_ID" --json)
+cross_state_path=$(printf '%s\n' "$cross_init_json" | jq -r '.state_path')
+
+jq -e \
+  --arg root "$cross_project_root" '
+  .manifest.repo == "example-org/sample-app"
+  and .manifest.project == "sample-app"
+  and .manifest.target_repo_root == $root
+  and .children[0].source.issue_url == "https://github.com/example-org/sample-app/issues/311"
+  and .children[0].refs.issue_url == "https://github.com/example-org/sample-app/issues/311"
+' "$cross_state_path" >/dev/null || fail "cross-project manifest metadata was not normalized into state"
+
+HOME="$TMPROOT/home-cross" ACHILLES_PROJECT=generic-dev-studio \
+  STUDIO_COMPOSITE_PLAN_CHAIN_SCRIPT="$STUB" STUB_PLAN_LOG="$cross_log" \
+  "$MANAGER" plan-active-child --run-id "$CROSS_PROJECT_RUN_ID" --json > "$TMPROOT/cross-plan.json"
+
+grep -Fq -- "--issue 311" "$cross_log" || fail "cross-project child issue was not planned"
+grep -Fq -- "--repo example-org/sample-app" "$cross_log" || fail "cross-project child did not pass manifest repo"
+grep -Fq -- "--project sample-app" "$cross_log" || fail "cross-project child did not pass manifest project"
+grep -Fq -- "--target-repo-root $cross_project_root" "$cross_log" || fail "cross-project child did not pass manifest target repo root"
+HOME="$TMPROOT/home-cross" ACHILLES_PROJECT=generic-dev-studio "$MANAGER" validate-state --state "$cross_state_path" >/dev/null
+jq -e '
+  .state == "child_planned"
+  and (.children[0].refs.plan_result | contains("/.dev-studio/sample-app/plan-chains/"))
+  and .children[0].refs.child_issues[0].url == "https://github.com/example-org/sample-app/issues/9001"
+  and .children[0].refs.parent_issue.url == "https://github.com/example-org/sample-app/issues/123"
+' "$cross_state_path" >/dev/null || fail "cross-project child planning results did not use target project runtime state"
 
 printf 'PASS: composite chain planning\n'


### PR DESCRIPTION
## Summary

- Fix cross-project composite-chain planning by normalizing manifest `repo`, `project`, and `target_repo_root` into durable state and using them for child issue URLs, plan-chain invocation, result lookup, child run lookup, and resume.
- Preserve explicit `Allowed paths` / `Allowed Paths Or Resources` sections in planner synthesis as worker `write_resources`.
- Add `scripts/bug-reopen-iteration-report.sh` for #549's iteration-based bug-reopen metric, with JSON/Markdown output and no unsupported 25% reduction claim.
- Split unrelated #442 feedback into tracked follow-up issues: #1030, #1031, #1032.

## Verification

- `scripts/test-fixtures/953-composite-chain-planning/test-composite-chain-planning.sh`
- `scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh`
- `scripts/test-fixtures/549-bug-reopen-iteration-report/test-bug-reopen-iteration-report.sh`
- `bash -n` for changed scripts/fixtures
- `scripts/lint-runtime-paths.sh --staged`
- `scripts/lint-gh-wrapper.sh --staged`
- `scripts/lint-synthetic-home.sh --staged`
- `scripts/lint-artifact-cleanup.sh --staged`
- `scripts/lint-host-agnostic.sh --staged` (0 errors, existing Argus secret-scope warning)
- `scripts/lint-chain-workflow-docs.sh --staged`
- `scripts/test-fixtures/953-composite-chain-docs/test-composite-chain-docs.sh`

## Phase Review

- Plan review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-18-442-inclusive-plan-review.md` — clean, cross-host satisfied.
- Outcome review: `/Users/vishalsingh/.dev-studio/generic-dev-studio/analysis/2026-05-18-442-inclusive-outcome-review.md` — clean, cross-host satisfied.

## Linked Issues

Fixes #442.
Updates #445.
Updates #549.
