### PR TITLE
studio chain: appstore-watcher-crashlytics-closeout

### DIFF
--- a/_shared/primitives/push-notifications.md
+++ b/_shared/primitives/push-notifications.md
@@ -52,6 +52,7 @@ Agents append to the push queue for these events. The user reads the queue via `
 | `watch_queue_drained` | Chanakya | `--watch` queue empties (all dispatched tasks done) |
 | `build_debt_blocked` | Achilles / Chanakya | Build debt counter crosses 12 |
 | `error` | Any | ERROR-level failure in any agent |
+| `crashlytics_closeout` | Chanakya | App Store watcher observes `READY_FOR_SALE` for a release carrying public-safe crash-fix entries; each entry queues follow-up closeout work. |
 
 Events NOT in the trigger list are written to the event log only (not the push queue).
 

--- a/_shared/primitives/slack-post.md
+++ b/_shared/primitives/slack-post.md
@@ -63,6 +63,21 @@ curl -sS -X POST https://slack.com/api/chat.postMessage \
   -d "{\"channel\":\"CHANNEL_ID\",\"thread_ts\":\"$PARENT_TS\",\"text\":\"DETAIL\"}"
 ```
 
+## Parent Updates (chat.update)
+
+When a later lifecycle event changes the meaning of an existing top-level
+announcement, update that parent message instead of posting a new reply:
+
+```bash
+curl -sS -X POST https://slack.com/api/chat.update \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"channel\":\"CHANNEL_ID\",\"ts\":\"$PARENT_TS\",\"text\":\"UPDATED_MESSAGE_TEXT\"}"
+```
+
+Use the parent message `ts`, not `thread_ts`. This keeps release-channel parent
+messages current when App Store Connect reaches `READY_FOR_SALE`.
+
 ## <!here> Rule
 
 Use `<!here>` only in top-level (non-thread) messages. Slack does not propagate `<!here>` in thread replies — never include it there.

--- a/scripts/appstore-watch.sh
+++ b/scripts/appstore-watch.sh
@@ -12,7 +12,7 @@
 #
 # On terminal state (PENDING_DEVELOPER_RELEASE / READY_FOR_SALE):
 #   1. gh release edit <tag> --draft=false
-#   2. Threaded Slack reply on the original #releases message
+#   2. Slack closeout on the original #releases message
 #   3. Delete marker
 #   4. Emit appstore_released
 # Steps 1 and 2 are tracked in marker.finalize_progress for idempotency —
@@ -287,12 +287,22 @@ PY
       if [ -r "$SLACK_TOKEN_FILE" ] && [ -n "$PARENT_TS" ] && [ -n "$CHANNEL" ]; then
         SLACK_BOT_TOKEN=$(cat "$SLACK_TOKEN_FILE")
         MSG="🎉 Live on App Store — notes: $URL"
-        BODY=$(python3 - "$CHANNEL" "$PARENT_TS" "$MSG" <<'PY'
+        if [ "$STATE" = "READY_FOR_SALE" ]; then
+          SLACK_ENDPOINT=https://slack.com/api/chat.update
+          BODY=$(python3 - "$CHANNEL" "$PARENT_TS" "$MSG" <<'PY'
+import json, sys
+print(json.dumps({'channel': sys.argv[1], 'ts': sys.argv[2], 'text': sys.argv[3]}))
+PY
+)
+        else
+          SLACK_ENDPOINT=https://slack.com/api/chat.postMessage
+          BODY=$(python3 - "$CHANNEL" "$PARENT_TS" "$MSG" <<'PY'
 import json, sys
 print(json.dumps({'channel': sys.argv[1], 'thread_ts': sys.argv[2], 'text': sys.argv[3]}))
 PY
 )
-        if curl -s --max-time 20 -X POST https://slack.com/api/chat.postMessage \
+        fi
+        if curl -s --max-time 20 -X POST "$SLACK_ENDPOINT" \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$BODY" >/dev/null 2>&1; then

--- a/scripts/appstore-watch.sh
+++ b/scripts/appstore-watch.sh
@@ -13,8 +13,9 @@
 # On terminal state (PENDING_DEVELOPER_RELEASE / READY_FOR_SALE):
 #   1. gh release edit <tag> --draft=false
 #   2. Slack closeout on the original #releases message
-#   3. Delete marker
-#   4. Emit appstore_released
+#   3. Queue Crashlytics closeout items once the app is live
+#   4. Delete marker
+#   5. Emit appstore_released
 # Steps 1 and 2 are tracked in marker.finalize_progress for idempotency —
 # a partial failure re-attempts only the unfinished step on the next sweep.
 #
@@ -160,6 +161,82 @@ if [ ! -f "$KEY_PATH" ]; then
 fi
 
 CRASH_FIXES_JSON=$(read_json_field crash_fixes)
+
+queue_crashlytics_closeouts() {
+  [ "${STATE:-}" = "READY_FOR_SALE" ] || return 0
+  [ -n "$CRASH_FIXES_JSON" ] || return 0
+
+  local queue
+  queue=$(resolve_push_queue) || return 1
+  python3 - "$queue" "$TAG" "$VERSION" "$CRASH_FIXES_JSON" <<'PY'
+import datetime
+import hashlib
+import json
+import os
+import sys
+
+queue, tag, version, raw = sys.argv[1:5]
+try:
+    crashes = json.loads(raw)
+except json.JSONDecodeError:
+    crashes = []
+if not isinstance(crashes, list):
+    crashes = []
+
+existing = set()
+try:
+    with open(queue, encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            entry_id = entry.get("id")
+            if entry_id:
+                existing.add(str(entry_id))
+except FileNotFoundError:
+    pass
+
+rows = []
+for crash in crashes:
+    if not isinstance(crash, dict):
+        continue
+    status = str(crash.get("crashlytics_closeout") or crash.get("closeout") or "queued")
+    if status in {"annotated", "skipped"}:
+        continue
+    url = str(crash.get("public_crash_url") or crash.get("crash_url") or crash.get("url") or "")
+    if not url:
+        continue
+    label = str(crash.get("public_label") or crash.get("label") or "")
+    digest = hashlib.sha1(f"{tag}\0{url}".encode("utf-8")).hexdigest()[:16]
+    entry_id = f"crashlytics-closeout-{digest}"
+    if entry_id in existing:
+        continue
+    prefix = f"Close Crashlytics for {tag} ({version}): "
+    detail = f"{label}: {url}" if label else url
+    text = prefix + detail
+    if len(text) > 200:
+        text = f"Close Crashlytics for {tag}: {url}"
+    if len(text) > 200:
+        text = text[:197].rstrip() + "..."
+    rows.append({
+        "id": entry_id,
+        "ts": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source": "chanakya",
+        "kind": "crashlytics_closeout",
+        "task": tag,
+        "text": text,
+        "displayed": False,
+    })
+    existing.add(entry_id)
+
+if rows:
+    os.makedirs(os.path.dirname(queue), exist_ok=True)
+    with open(queue, "a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, separators=(",", ":")) + "\n")
+PY
+}
 
 # Bump failure counter, update cadence, optionally mark stuck. Reused across
 # all error paths. Args: <reason> [<partial-state>]
@@ -339,6 +416,12 @@ PY
       fi
     fi
 
+    if ! queue_crashlytics_closeouts; then
+      fails=$(mark_failure crashlytics_closeout_queue_failed "$STATE")
+      [ "$fails" -ge 3 ] && append_event chanakya appstore_watch_stuck "$TAG" \
+        "{\"reason\":\"crashlytics_closeout_queue_failed\",\"failures\":$fails,\"state\":\"$STATE\"}" 2>/dev/null || true
+      exit 1
+    fi
     [ "$MARKER_SOURCE" = "json" ] && rm -f "$MARKER"
     if [ -n "$release_uuid" ]; then
       release_state=$(yq -r '.state // ""' "$ACTIVE_RELEASE_FILE" 2>/dev/null)

--- a/scripts/test-fixtures/824-appstore-submission/test-appstore-submission.sh
+++ b/scripts/test-fixtures/824-appstore-submission/test-appstore-submission.sh
@@ -49,4 +49,95 @@ printf '%s\n' "$OUT" | grep -q "fastlane discovery/session auth is not an automa
 echo "PASS: Fastlane env does not bypass ASC API credential prerequisites"
 
 echo
+echo "=== Test 3: READY_FOR_SALE updates the Slack parent message ==="
+FIXTURE_BIN="$TMPHOME/bin"
+FIXTURE_PY="$TMPHOME/python"
+mkdir -p "$FIXTURE_BIN" "$FIXTURE_PY" \
+  "$TMPHOME/.dev-studio/824-fixture/.runtime/state" \
+  "$TMPHOME/.dev-studio/824-fixture/secrets/appstoreconnect"
+
+cat >"$FIXTURE_PY/jwt.py" <<'PY'
+def encode(payload, key, algorithm=None, headers=None):
+    return "fixture-jwt"
+PY
+
+cat >"$FIXTURE_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$GH_CALL_FILE"
+exit 0
+SH
+chmod +x "$FIXTURE_BIN/gh"
+
+cat >"$FIXTURE_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+url=""
+body=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    http*) url="$1" ;;
+    -d) shift; body="${1:-}" ;;
+  esac
+  shift || true
+done
+case "$url" in
+  *appStoreVersions*)
+    printf '{"data":[{"attributes":{"appStoreState":"READY_FOR_SALE"}}]}\n'
+    ;;
+  *chat.update*)
+    printf '%s\n' "$url" >"$SLACK_URL_FILE"
+    printf '%s\n' "$body" >"$SLACK_BODY_FILE"
+    printf '{"ok":true,"ts":"1700000000.000100"}\n'
+    ;;
+  *chat.postMessage*)
+    printf '%s\n' "$url" >"$SLACK_URL_FILE"
+    printf '%s\n' "$body" >"$SLACK_BODY_FILE"
+    printf '{"ok":true,"ts":"1700000000.000101"}\n'
+    ;;
+  *)
+    printf 'unexpected curl url: %s\n' "$url" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$FIXTURE_BIN/curl"
+
+printf 'fixture-token\n' >"$TMPHOME/.dev-studio/824-fixture/secrets/slack-bot-token"
+printf 'fixture-key\n' >"$TMPHOME/.dev-studio/824-fixture/secrets/appstoreconnect/AuthKey_FIXTUREKEY.p8"
+
+cat >"$TMPHOME/.dev-studio/824-fixture/.runtime/state/pending-appstore-review.json" <<JSON
+{
+  "project": "824-fixture",
+  "next_check_at": "2000-01-01T00:00:00Z",
+  "tag": "824-zaps",
+  "version": "26.5.0",
+  "asc_app_id": "fixture-app",
+  "repo": "fixture/repo",
+  "slack_channel": "C123",
+  "slack_parent_ts": "1700000000.000100",
+  "github_release_url": "https://github.com/fixture/repo/releases/tag/824-zaps",
+  "asc_key_path": "$TMPHOME/.dev-studio/824-fixture/secrets/appstoreconnect/AuthKey_FIXTUREKEY.p8",
+  "asc_issuer_id": "fixture-issuer",
+  "asc_key_id": "FIXTUREKEY"
+}
+JSON
+
+export PATH="$FIXTURE_BIN:$PATH"
+export PYTHONPATH="$FIXTURE_PY${PYTHONPATH:+:$PYTHONPATH}"
+export GH_CALL_FILE="$TMPHOME/gh-call.txt"
+export SLACK_URL_FILE="$TMPHOME/slack-url.txt"
+export SLACK_BODY_FILE="$TMPHOME/slack-body.json"
+
+"$REPO/scripts/appstore-watch.sh" >"$TMPHOME/appstore-watch.out" 2>&1
+
+grep -q "chat.update" "$SLACK_URL_FILE" \
+  || { echo "FAIL: READY_FOR_SALE did not call chat.update"; cat "$TMPHOME/appstore-watch.out"; exit 1; }
+jq -e '.ts == "1700000000.000100" and (.thread_ts | not)' "$SLACK_BODY_FILE" >/dev/null \
+  || { echo "FAIL: Slack update body did not target the parent ts"; cat "$SLACK_BODY_FILE"; exit 1; }
+[ ! -f "$TMPHOME/.dev-studio/824-fixture/.runtime/state/pending-appstore-review.json" ] \
+  || { echo "FAIL: finalized JSON marker was not removed"; exit 1; }
+grep -q "release edit 824-zaps --repo fixture/repo --draft=false" "$GH_CALL_FILE" \
+  || { echo "FAIL: GitHub draft release was not published"; cat "$GH_CALL_FILE"; exit 1; }
+echo "PASS: READY_FOR_SALE updates the original Slack parent"
+
+echo
 echo "All checks passed."


### PR DESCRIPTION
Automated chain PR for `appstore-watcher-crashlytics-closeout`.

Run by `scripts/studio-chain-runner.sh`.

Chain run: `019e3d3a-d6c5-7131-ac67-64d660a1a75a`
Chain-run UUID: `019e3d3a-febf-764c-a899-5d642c9ab697`
Private report: local only; resolve by run ID on the machine that ran the chain.

Review gate: `scripts/pr-headless-review.sh <pr> --method auto`.