### PR TITLE
docs: document crash report access boundaries

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-18T22:20:39Z",
+  "generated_at": "2026-05-19T17:56:50Z",
   "agents": [
     {
       "name": "studio",

--- a/_shared/schemas/crash.md
+++ b/_shared/schemas/crash.md
@@ -127,6 +127,20 @@ crash:
   versions_affected: ["1.11.0", "1.12.0"]
 ```
 
+### Repository access boundary
+
+Crash-fix issues, PRs, and release artifacts may live in the target repository
+when that repository's access boundary is appropriate for the crash context. A
+private target repo may carry private crash-fix issue/PR discussion visible to
+that repo's members. A public target repo, public release note, or public Slack
+surface must use only the public-safe projection below.
+
+Crashlytics issue links are allowed when the destination repo or channel is
+inside the intended access boundary. The Firebase project still controls who can
+open the link; the link by itself does not authorize access. Do not paste raw
+stack traces, user/session/device details, or private Crashlytics dumps into a
+public repo just because the Crashlytics URL is access-controlled.
+
 Allowed in public GitHub commits, PR descriptions, chain worker prompts, build summaries, release notes, and post-release annotations:
 
 - Crashlytics issue URLs.

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T22:20:38Z",
+  "generated_at": "2026-05-19T17:56:49Z",
   "schema": 1,
   "commands": [
     {"name": "chanakya-help", "source": "commands/chanakya-help.md", "description": "", "agent": null, "scope": "global"},


### PR DESCRIPTION
## Summary

- Documented the crash-report repository access boundary in `_shared/schemas/crash.md`.
- Clarified that private crash context may live only inside the target repo/channel access boundary.
- Kept public repos, public release notes, and public Slack surfaces limited to the public-safe crash projection; Crashlytics URLs are acceptable when Firebase access still controls the destination.

## Verification

- `git diff --check`
- `scripts/pre-commit-review.sh --review-host codex-reviewer` => approved

## Notes

The pre-commit hook refreshed generated timestamps in `docs-surface.json` and `_shared/schemas/capability-manifest.json`.
