### PR TITLE
Commit current script reliability fixes

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-28T03:27:31Z",
+  "generated_at": "2026-05-28T03:28:19Z",
   "agents": [
 
   ]

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-20T00:19:18Z",
+  "generated_at": "2026-05-28T03:27:31Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-20T00:19:18Z",
+  "generated_at": "2026-05-28T03:27:31Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-28T03:27:31Z",
+  "generated_at": "2026-05-28T03:28:19Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/codex-worker-exec.sh
+++ b/scripts/codex-worker-exec.sh
@@ -32,10 +32,11 @@ codex_home=$(resolve_codex_worker_home)
 }
 
 dev_studio_root="${STUDIO_CODEX_WRITABLE_ROOT:-${HOME:?HOME required}/.dev-studio}"
+worker_sandbox="${STUDIO_CODEX_WORKER_SANDBOX:-workspace-write}"
 
 exec env CODEX_HOME="$codex_home" codex exec \
   --ephemeral \
-  --sandbox workspace-write \
+  --sandbox "$worker_sandbox" \
   --add-dir "$dev_studio_root" \
   -c approval_policy=never \
   "$@"

--- a/scripts/manager-composite-chain.sh
+++ b/scripts/manager-composite-chain.sh
@@ -277,10 +277,11 @@ write_halt_record() {
 }
 
 child_plan_command_json() {
-  local state_file="$1" child_index="$2" child_id="$3" source_type issue manifest_path project target_repo_root issue_repo
+  local state_file="$1" child_index="$2" child_id="$3" source_type issue manifest_path project target_repo_root issue_repo source_branch
   project=$(state_project "$state_file")
   target_repo_root=$(state_target_repo_root "$state_file")
   issue_repo=$(state_issue_repo "$state_file")
+  source_branch=$(jq -r '.manifest.source.base_branch // .manifest.base_branch // empty' "$state_file")
   source_type=$(jq -r --argjson idx "$child_index" '.children[$idx].source.source_type' "$state_file")
   case "$source_type" in
     issue)
@@ -292,7 +293,10 @@ child_plan_command_json() {
         --arg child_id "$child_id" \
         --arg repo_root "$target_repo_root" \
         --arg project "$project" \
-        '[$script, "--issue", $issue, "--repo", $issue_repo, "--chain", $child_id, "--project", $project, "--target-repo-root", $repo_root, "--no-execute"]'
+        --arg source_branch "$source_branch" \
+        '[$script, "--issue", $issue, "--repo", $issue_repo, "--chain", $child_id, "--project", $project, "--target-repo-root", $repo_root]
+          + (if $source_branch == "" then [] else ["--source-branch", $source_branch] end)
+          + ["--no-execute"]'
       ;;
     manifest)
       manifest_path=$(jq -r --argjson idx "$child_index" '.children[$idx].source.manifest_path' "$state_file")
@@ -302,7 +306,10 @@ child_plan_command_json() {
         --arg child_id "$child_id" \
         --arg repo_root "$target_repo_root" \
         --arg project "$project" \
-        '[$script, "--source-file", $manifest_path, "--chain", $child_id, "--project", $project, "--target-repo-root", $repo_root, "--no-execute"]'
+        --arg source_branch "$source_branch" \
+        '[$script, "--source-file", $manifest_path, "--chain", $child_id, "--project", $project, "--target-repo-root", $repo_root]
+          + (if $source_branch == "" then [] else ["--source-branch", $source_branch] end)
+          + ["--no-execute"]'
       ;;
     *)
       fail "unsupported child source_type for planning: $source_type" 1

--- a/scripts/manager-plan-chain.sh
+++ b/scripts/manager-plan-chain.sh
@@ -740,6 +740,7 @@ write_generated_planner_artifact() {
     --arg requirement_packet "$REQUIREMENT_PACKET" \
     --arg task_graph "$TASK_GRAPH" \
     --arg review_input "$REVIEW_INPUT" \
+    --arg source_branch "$SOURCE_BRANCH" \
     --argjson include_comments "$INCLUDE_COMMENTS" \
     --argjson body_only_explicit "$BODY_ONLY_EXPLICIT" \
     --arg comment_packet "$COMMENT_PACKET_MD" \
@@ -765,7 +766,9 @@ write_generated_planner_artifact() {
             mode: (if $include_comments == 1 then "issue-context-packet" else "body-only" end),
             packet_path: (if $comment_packet == "" then null else $comment_packet end),
             comment_sidecar_path: (if $comment_sidecar == "" then null else $comment_sidecar end),
-            body_only_explicit: ($body_only_explicit == 1)
+            body_only_explicit: ($body_only_explicit == 1),
+            base_branch: $source_branch,
+            forbidden_base_branches: []
           },
           scope: ($tasks | map(.label)),
           non_goals: ["Do not execute implementation work inside the planning session."],
@@ -793,14 +796,15 @@ write_generated_planner_artifact() {
                 summary: .label,
                 owner_role: "worker",
                 allowed_paths: (.write_resources // []),
-                required_checks: [
+                required_checks: (.required_checks // [
+                  "Run `git diff --check`.",
                   "Run the narrowest relevant test/lint/build checks for the files changed by this worker contract."
-                ],
-                stop_conditions: [
+                ]),
+                stop_conditions: (.stop_conditions // [
                   "The contract requires files or behavior outside the reviewed issue body.",
                   "Required checks cannot be run or interpreted.",
                   "Implementation would need a different role owner."
-                ],
+                ]),
                 summary_artifact: ".studio/chain-worker-summary.json"
               })
           ),

--- a/scripts/phase-review.sh
+++ b/scripts/phase-review.sh
@@ -285,6 +285,23 @@ case "$review_host" in
 esac
 
 input_content=$(cat "$input")
+extra_add_dirs=""
+while IFS= read -r candidate; do
+  [ -n "$candidate" ] || continue
+  [ -d "$candidate" ] || continue
+  case "$extra_add_dirs" in
+    *"$candidate"$'\n'*|*"$candidate") ;;
+    *) extra_add_dirs="${extra_add_dirs}${candidate}"$'\n' ;;
+  esac
+done < <(awk '
+  {
+    while (match($0, /`\/[^`]+`/)) {
+      value = substr($0, RSTART + 1, RLENGTH - 2)
+      print value
+      $0 = substr($0, RSTART + RLENGTH)
+    }
+  }
+' "$input")
 input_bytes=$(wc -c < "$input" 2>/dev/null | tr -d ' ' || printf '0')
 input_lines=$(wc -l < "$input" 2>/dev/null | tr -d ' ' || printf '0')
 case "$input_bytes" in ""|*[!0-9]*) input_bytes=0 ;; esac
@@ -317,6 +334,10 @@ $input_content
 Assess whether the execution may proceed. Be direct: list fatal blockers first,
 then warnings, then recommendations or plan adjustments.
 
+If the artifact names an issue worktree or commit-after hash, validate changed
+artifacts against that worktree/commit. Do not validate against the reviewer
+process current directory or an unrelated checkout.
+
 End with exactly one stable verdict line:
 
 PHASE_REVIEW_VERDICT=clean
@@ -331,7 +352,13 @@ EOF
 
 review_argv=("${spawn_argv[@]}")
 case "$review_host" in
-  claude*|*claude*) review_argv+=("--add-dir=$input_dir") ;;
+  claude*|*claude*)
+    review_argv+=("--add-dir=$input_dir")
+    while IFS= read -r add_dir; do
+      [ -n "$add_dir" ] || continue
+      review_argv+=("--add-dir=$add_dir")
+    done <<< "$extra_add_dirs"
+    ;;
 esac
 review_cmd=(review_host_run_command "$review_host" "$reviewer_home" \
   --env REVIEW_PAYLOAD "$input" \

--- a/scripts/pr-headless-review.sh
+++ b/scripts/pr-headless-review.sh
@@ -466,8 +466,8 @@ run_review_candidate() {
     return 1
   fi
 
-  verdict_count=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary" | wc -l | tr -d ' ')
-  verdict=$(sed -n 's/^STUDIO_REVIEW_VERDICT=//p' "$summary")
+  verdict=$(sed -n -E 's/^[[:space:]]*`?STUDIO_REVIEW_VERDICT=(approved|approved_with_fixes|blocked)`?[[:space:]]*$/\1/p' "$summary")
+  verdict_count=$(printf '%s\n' "$verdict" | sed '/^$/d' | wc -l | tr -d ' ')
   if [ "$verdict_count" = "0" ] \
       && grep -Eq '^REVIEW_CONTEXT_FALLBACK=expanded|INSUFFICIENT_CONTEXT' "$summary" \
       && [ "$(printf '%s\n' "$PR_REVIEW_CONTEXT_JSON" | jq -r '.mode')" != "expanded" ]; then

--- a/scripts/prd-intake-normalize.sh
+++ b/scripts/prd-intake-normalize.sh
@@ -136,6 +136,13 @@ function print_bucket(prefix, count, line_arr, section_arr, text_arr, reason_arr
   }
 }
 
+function add_component_line(text) {
+  if (component_count == 0) {
+    return
+  }
+  component_body[component_count] = component_body[component_count] "\n" text
+}
+
 BEGIN {
   section = ""
   explicit_count = 0
@@ -148,6 +155,7 @@ BEGIN {
   saw_acceptance = 0
   saw_non_goal = 0
   saw_verification = 0
+  component_count = 0
 }
 
 {
@@ -176,6 +184,17 @@ BEGIN {
   key = slug(visible)
   polarity = (lower ~ /(^|[^[:alnum:]_])(must not|should not|will not|do not|does not|out of scope|non-goals?|non goals?)([^[:alnum:]_]|$)/) ? "negative" : "positive"
 
+  if (section_l ~ /(worker decomposition|component decomposition|task decomposition)/) {
+    component_line = line
+    if (component_line ~ /^[0-9]+[.)][[:space:]]+/) {
+      component_count++
+      component_title[component_count] = strip_marker(component_line)
+      component_body[component_count] = ""
+    } else if (component_count > 0) {
+      add_component_line(original)
+    }
+  }
+
   if (lower ~ /(^|[^[:alnum:]_])(prd|transcript|issue brief|input|source)([^[:alnum:]_]|$)/) saw_input = 1
   if (lower ~ /(^|[^[:alnum:]_])(output|artifact|packet|brief)([^[:alnum:]_]|$)/) saw_output = 1
   if (lower ~ /(^|[^[:alnum:]_])(markdown|yaml|json|schema|format|template)([^[:alnum:]_]|$)/) saw_format = 1
@@ -203,6 +222,17 @@ END {
   printf "## Intake Metadata\n\n"
   printf "- Source: `%s`\n", source
   printf "- Method: deterministic lexical normalization; exact source language is quoted below.\n\n"
+
+  if (component_count >= 2) {
+    printf "## Worker Decomposition Components\n\n"
+    for (i = 1; i <= component_count; i++) {
+      printf "### %d. %s\n", i, escape_md(component_title[i])
+      if (component_body[i] != "") {
+        printf "%s\n", component_body[i]
+      }
+      printf "\n"
+    }
+  }
 
   printf "## Explicit Requirements\n\n"
   print_bucket("R", explicit_count, explicit_line, explicit_section, explicit_text, explicit_reason)

--- a/scripts/prd-task-graph-synthesize.sh
+++ b/scripts/prd-task-graph-synthesize.sh
@@ -289,7 +289,7 @@ function resources_in_component_body(body,    rest, line, line_l, in_reference_s
           for (fr in found_arr) out = add_resource(out, found_arr[fr])
         }
       }
-      if (in_allowed_paths_section) {
+      if (in_allowed_paths_section || line_l ~ /allowed paths/) {
         found_resources = resources_anywhere(line)
         if (found_resources != "") {
           split(found_resources, found_arr, ",")
@@ -357,6 +357,20 @@ function fallback_component_resources(title,    l, out) {
     out = add_resource(out, "scripts/studio-chain-runner.sh")
   }
   return out
+}
+
+function ownership_line(body,    rest, line) {
+  rest = body
+  while (match(rest, /\n[^\n]*/)) {
+    line = substr(rest, RSTART + 1, RLENGTH - 1)
+    rest = substr(rest, RSTART + RLENGTH)
+    sub(/^[[:space:]]*[-*][[:space:]]+/, "", line)
+    line = trim(line)
+    if (lower(line) ~ /^owns /) {
+      return line
+    }
+  }
+  return ""
 }
 
 function add_packet_conflict(source_id, text) {
@@ -572,6 +586,12 @@ END {
     if (node_kind[source_id] != "task") {
       continue
     }
+    if (component_mode == 1 && node_kind[source_id] == "task") {
+      owner_text = ownership_line(component_body[source_id])
+      if (owner_text != "") {
+        node_label[source_id] = component_title[source_id] " " owner_text
+      }
+    }
     for (j = 1; j <= node_count; j++) {
       dep_source_id = node_order[j]
       if (node_kind[dep_source_id] == "shared_prerequisite") {
@@ -595,6 +615,19 @@ END {
         match(candidate, /R[0-9][0-9][0-9]/)
         dep_source_id = substr(candidate, RSTART, RLENGTH)
         add_dependency(source_id, dep_source_id, "explicit source reference")
+        rest = substr(rest, outer_end)
+      }
+      rest = lower(component_body[source_id])
+      while (match(rest, /[^\n]*(depends on|after|requires?|follows)[^\n]*/)) {
+        outer_end = RSTART + RLENGTH
+        candidate = substr(rest, RSTART, RLENGTH)
+        if (candidate ~ /(worker|workers)/) {
+          while (match(candidate, /[0-9]+/)) {
+            dep_source_id = sprintf("R%03d", substr(candidate, RSTART, RLENGTH) + 0)
+            add_dependency(source_id, dep_source_id, "explicit worker reference")
+            candidate = substr(candidate, RSTART + RLENGTH)
+          }
+        }
         rest = substr(rest, outer_end)
       }
       if (source_id != "R001" && lower(component_title["R001"]) ~ /(policy|config|foundation|schema|setup)/) {

--- a/scripts/studio-chain-runner.sh
+++ b/scripts/studio-chain-runner.sh
@@ -353,9 +353,22 @@ chain_status_hidden_from_default_discovery() {
   esac
 }
 
+iter_chain_selector_manifest_files() {
+  local parent_home studio_home
+  if [ -d "$REPO_ROOT/chains" ]; then
+    find "$REPO_ROOT/chains" -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null
+  fi
+
+  parent_home=$(resolve_parent_home_for_github 2>/dev/null || true)
+  [ -n "$parent_home" ] || return 0
+  studio_home="$parent_home/.dev-studio"
+  [ -d "$studio_home" ] || return 0
+  find "$studio_home" -path "$studio_home/*/plan-chains/*/work-chain.yaml" -type f 2>/dev/null
+  find "$studio_home" -path "$studio_home/*/plan-chains/*/work-chain.yml" -type f 2>/dev/null
+}
+
 resolve_manifest_by_chain_selector() {
   local input="$1" matches_tmp manifest chain_count idx name chain_id count row
-  [ -d "$REPO_ROOT/chains" ] || return 1
   matches_tmp=$(mktemp -t studio-chain-selector.XXXXXX) || return 1
   while IFS= read -r manifest; do
     [ -n "$manifest" ] || continue
@@ -370,7 +383,7 @@ resolve_manifest_by_chain_selector() {
       fi
     done
   done <<EOF
-$(find "$REPO_ROOT/chains" -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | sort)
+$(iter_chain_selector_manifest_files | sort -u)
 EOF
   count=$(wc -l < "$matches_tmp" | tr -d ' ')
   case "$count" in
@@ -440,7 +453,7 @@ resolve_manifest() {
 
   printf 'studio-chain-runner: manifest not found: %s\n' "$input" >&2
   printf 'studio-chain-runner: tried %s and %s\n' "$REPO_ROOT/chains/$input.yaml" "$REPO_ROOT/chains/$input.yml" >&2
-  printf 'studio-chain-runner: also searched chain names and chain ids under %s\n' "$REPO_ROOT/chains" >&2
+  printf 'studio-chain-runner: also searched chain names and chain ids under %s and generated project plan-chains\n' "$REPO_ROOT/chains" >&2
   exit 2
 }
 
@@ -4959,13 +4972,17 @@ resolve_issue_repo_slug() {
 
 issue_view_json_or_fail() {
   local issue="${1:?usage: issue_view_json_or_fail <issue> <json-fields> <context>}" fields="${2:?usage: issue_view_json_or_fail <issue> <json-fields> <context>}" context="${3:-preflight}"
-  local out
-  if ! out=$(with_login_home_for_github gh issue view "$issue" --repo "$REPO_SLUG" --json "$fields" 2>&1); then
+  local out err_file err
+  err_file=$(mktemp -t studio-chain-issue-view.XXXXXX)
+  if ! out=$(with_login_home_for_github gh issue view "$issue" --repo "$REPO_SLUG" --json "$fields" 2>"$err_file"); then
+    err=$(cat "$err_file" 2>/dev/null || true)
+    rm -f "$err_file"
     printf 'studio-chain-runner: GitHub issue lookup failed for repo %s (target repo root: %s) while resolving issue #%s during %s\n' \
       "$REPO_SLUG" "$TARGET_REPO_ROOT" "$issue" "$context" >&2
-    printf 'studio-chain-runner: issue lookup output: %s\n' "$out" >&2
+    printf 'studio-chain-runner: issue lookup output: %s%s%s\n' "$out" "${err:+ }" "$err" >&2
     return 1
   fi
+  rm -f "$err_file"
   printf '%s\n' "$out"
 }
 
@@ -6916,7 +6933,11 @@ verify_expected_source_sha_or_abort() {
     SOURCE_SHA_ACTUAL="$expected_sha"
     return 0
   fi
-  actual_sha=$(studio_git_transport_ls_remote --heads origin "$source_branch" 2>/dev/null | awk 'NR == 1 { print $1 }') || actual_sha=""
+  actual_sha=$(
+    cd "$TARGET_REPO_ROOT" &&
+      studio_git_transport_ls_remote --heads origin "$source_branch" 2>/dev/null |
+      awk 'NR == 1 { print $1 }'
+  ) || actual_sha=""
   SOURCE_SHA_ACTUAL="$actual_sha"
   if [ -z "$actual_sha" ]; then
     summary="cannot verify origin/$source_branch before $phase for chain $chain_name"
@@ -6941,6 +6962,10 @@ verify_expected_source_sha_or_abort() {
   fi
 }
 
+target_repo_git_transport_ls_remote() {
+  ( cd "$TARGET_REPO_ROOT" && studio_git_transport_ls_remote "$@" )
+}
+
 live_preflight() {
   local plan="$1" reviewer_host chain_name branch issue_branch base expected_source_sha approved_release_id strict_source_sha
   run_retryable_or_abort github_auth_unavailable "GitHub auth is not available" \
@@ -6956,7 +6981,7 @@ live_preflight() {
     [ "$expected_source_sha" = "__none__" ] && expected_source_sha=""
     [ "$approved_release_id" = "__none__" ] && approved_release_id=""
     run_retryable_or_abort network_partition "cannot verify origin/$base" \
-      studio_git_transport_ls_remote --exit-code --heads origin "$base"
+      target_repo_git_transport_ls_remote --exit-code --heads origin "$base"
     strict_source_sha="allow-drift"
     if [ -n "$approved_release_id" ] && [ "$approved_release_id" != "null" ]; then
       strict_source_sha="strict"
@@ -6966,7 +6991,7 @@ live_preflight() {
       printf 'studio-chain-runner: local chain branch already exists: %s\n' "$branch" >&2
       exit 2
     fi
-    if [ -z "$RESUME_ID" ] && studio_git_transport_ls_remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    if [ -z "$RESUME_ID" ] && ( cd "$TARGET_REPO_ROOT" && studio_git_transport_ls_remote --exit-code --heads origin "$branch" >/dev/null 2>&1 ); then
       printf 'studio-chain-runner: remote chain branch already exists: %s\n' "$branch" >&2
       exit 2
     fi
@@ -6979,7 +7004,7 @@ EOF
       printf 'studio-chain-runner: local issue branch already exists: %s\n' "$issue_branch" >&2
       exit 2
     fi
-    if [ -z "$RESUME_ID" ] && studio_git_transport_ls_remote --exit-code --heads origin "$issue_branch" >/dev/null 2>&1; then
+    if [ -z "$RESUME_ID" ] && ( cd "$TARGET_REPO_ROOT" && studio_git_transport_ls_remote --exit-code --heads origin "$issue_branch" >/dev/null 2>&1 ); then
       printf 'studio-chain-runner: remote issue branch already exists: %s\n' "$issue_branch" >&2
       exit 2
     fi
@@ -7631,6 +7656,9 @@ finalize_chain_pr() {
     return 0
   fi
 
+  local pr_create_err
+  pr_create_err=$(mktemp "${TMPDIR:-/tmp}/studio-pr-create.XXXXXX")
+  set +e
   pr_url=$(with_login_home_for_github gh pr create \
     --repo "$REPO_SLUG" \
     --base "$base" \
@@ -7644,7 +7672,19 @@ Chain run: \`$RUN_ID\`
 Chain-run UUID: \`$chain_run_id\`
 Private report: local only; resolve by run ID on the machine that ran the chain.
 
-Review gate: \`scripts/pr-headless-review.sh <pr> --method auto\`.")
+Review gate: \`scripts/pr-headless-review.sh <pr> --method auto\`." 2>"$pr_create_err")
+  pr_create_rc=$?
+  set -e
+  if [ "$pr_create_rc" -ne 0 ]; then
+    pr_url=$(with_login_home_for_github gh pr view "$chain_branch" --repo "$REPO_SLUG" --json url --jq '.url' 2>/dev/null || true)
+    if [ -n "$pr_url" ]; then
+      log "reusing existing PR $pr_url"
+    else
+      cat "$pr_create_err" >&2
+      abort_run "PR create failed for $chain_branch"
+    fi
+  fi
+  rm -f "$pr_create_err"
   pr_number=$(printf '%s' "$pr_url" | sed -E 's#.*/pull/([0-9]+).*#\1#')
   FINAL_PR_URL="$pr_url"
   log "opened PR $pr_url"
@@ -7662,7 +7702,7 @@ Public-safe telemetry: run/chain UUIDs and abstract gap names only."; then
   review_started_at=$(now_epoch)
   review_out="$CHAIN_RUN_ROOT/review-$pr_number.out"
   set +e
-  STUDIO_PARENT_HOST="${STUDIO_PARENT_HOST:-$implementation_host}" "$SCRIPT_DIR/pr-headless-review.sh" "$pr_number" --method auto >"$review_out" 2>&1
+  GH_REPO="$REPO_SLUG" STUDIO_PARENT_HOST="${STUDIO_PARENT_HOST:-$implementation_host}" "$SCRIPT_DIR/pr-headless-review.sh" "$pr_number" --method auto >"$review_out" 2>&1
   review_rc=$?
   set -e
   cat "$review_out"
@@ -7908,7 +7948,7 @@ write_issue_phase_plan_artifact() {
 }
 
 write_issue_phase_outcome_artifact() {
-  local artifact="$1" chain_name="$2" issue="$3" issue_run_id="$4" before="$5" after="$6" summary_file="$7"
+  local artifact="$1" chain_name="$2" issue="$3" issue_run_id="$4" before="$5" after="$6" summary_file="$7" issue_worktree="${8:-}"
   mkdir -p "$(dirname "$artifact")"
   {
     printf '# Chain Issue Phase Outcome\n\n'
@@ -7916,9 +7956,14 @@ write_issue_phase_outcome_artifact() {
     printf -- '- Chain: `%s`\n' "$chain_name"
     printf -- '- Issue: `#%s`\n' "$issue"
     printf -- '- Issue-run UUID: `%s`\n' "$issue_run_id"
+    [ -z "$issue_worktree" ] || printf -- '- Issue worktree: `%s`\n' "$issue_worktree"
     printf -- '- Commit before: `%s`\n' "$before"
     printf -- '- Commit after: `%s`\n' "$after"
     printf -- '- Worker summary: `%s`\n\n' "$summary_file"
+    if [ -n "$issue_worktree" ]; then
+      printf '## Review Filesystem Context\n\n'
+      printf 'Validate changed artifacts against the issue worktree above and commit-after above. Do not validate against the reviewer process current directory or any unrelated checkout.\n\n'
+    fi
     printf '## What Changed\n\n'
     jq -r '
       def lines($v):
@@ -8207,7 +8252,7 @@ run_issue_job() {
   if phase_review_required_for_issue "$phase_review_mode" "$issue_count_for_review"; then
     boundary_id="$chain_run_id-$issue_run_id"
     phase_outcome_artifact="$PHASE_REVIEW_ROOT/$boundary_id-outcome.md"
-    write_issue_phase_outcome_artifact "$phase_outcome_artifact" "$name" "$issue" "$issue_run_id" "$before" "$after" "$summary_file"
+    write_issue_phase_outcome_artifact "$phase_outcome_artifact" "$name" "$issue" "$issue_run_id" "$before" "$after" "$summary_file" "$issue_worktree"
     set +e
     run_phase_review_gate outcome "$boundary_id" "$phase_outcome_artifact" "$chain_run_id" "$issue_run_id" "$name" "$issue"
     phase_review_rc=$?
@@ -8508,7 +8553,7 @@ reconcile_resume_issue_summary() {
   if phase_review_required_for_issue "$phase_review_mode" "$issue_count_for_review"; then
     boundary_id="$chain_run_id-$issue_run_id"
     phase_outcome_artifact="$PHASE_REVIEW_ROOT/$boundary_id-outcome.md"
-    write_issue_phase_outcome_artifact "$phase_outcome_artifact" "$chain_name" "$issue" "$issue_run_id" "$before" "$after" "$summary_file"
+    write_issue_phase_outcome_artifact "$phase_outcome_artifact" "$chain_name" "$issue" "$issue_run_id" "$before" "$after" "$summary_file" "$issue_worktree"
     set +e
     run_phase_review_gate outcome "$boundary_id" "$phase_outcome_artifact" "$chain_run_id" "$issue_run_id" "$chain_name" "$issue"
     phase_review_rc=$?

--- a/scripts/studio-comment.sh
+++ b/scripts/studio-comment.sh
@@ -14,7 +14,7 @@ Usage:
 Supported kinds:
   chain-progress, chain-issue-started, chain-issue-completed,
   chain-issue-blocked, chain-review, chain-final-summary,
-  feedback-ingest, staleness-triage
+  chain-parent-closeout, feedback-ingest, staleness-triage
 
 The first body line is the studio-comment:v1 marker. Dry-run prints the
 structured JSON payload and never calls GitHub. Posting routes through
@@ -114,7 +114,7 @@ done
 [ -n "$summary" ] || { printf 'studio-comment: --summary is required\n' >&2; exit 2; }
 
 case "$kind" in
-  chain-progress|chain-issue-started|chain-issue-completed|chain-issue-blocked|chain-review|chain-final-summary|feedback-ingest|staleness-triage) ;;
+  chain-progress|chain-issue-started|chain-issue-completed|chain-issue-blocked|chain-review|chain-final-summary|chain-parent-closeout|feedback-ingest|staleness-triage) ;;
   *)
     printf 'studio-comment: unsupported kind: %s\n' "$kind" >&2
     exit 2


### PR DESCRIPTION
## Summary
- preserve planner source-branch and worker decomposition context in generated chain artifacts
- harden chain runner and review paths around generated manifests, target repo checks, existing PR reuse, worktree-aware phase review, and fenced verdict parsing
- keep Codex worker sandbox behavior defaulted to workspace-write while allowing an explicit env override

## Verification
- git diff --check
- bash -n touched scripts
- bash scripts/test-fixtures/793-planner-allowed-paths-hygiene/test-planner-allowed-paths-hygiene.sh
- bash scripts/test-fixtures/980-manager-plan-chain-comments/test-manager-plan-chain-comments.sh
- bash scripts/test-fixtures/454-phase-review/test-phase-review.sh
- bash scripts/test-fixtures/318-pr-headless-review/test-pr-headless-review-verdict-count.sh
- bash scripts/test-fixtures/980-comment-pipeline-writer/test-comment-pipeline-writer.sh
- bash scripts/test-fixtures/990-parent-closeout/test-parent-closeout.sh
- bash scripts/test-fixtures/975-runner-auth-home/test-runner-auth-home.sh
- bash scripts/test-fixtures/748-chain-manifest-preflight/test-chain-manifest-preflight.sh