### PR TITLE
Switch Claude review default to Opus 4.6

### DIFF
--- a/_shared/rules/model-policy.yaml
+++ b/_shared/rules/model-policy.yaml
@@ -38,12 +38,12 @@ roles:
     reasoning_effort: medium
     independent_provider_family_required: true
     model_preferences:
-      - sonnet
+      - opus
       - openai_gpt_5_5
       - openai_gpt_5_3_codex
       - openai_gpt_5_2
       - openai_gpt_5
-      - opus
+      - sonnet
     downgrade_requires_telemetry: true
   reviewer.fallback:
     purpose: user-approved same-family fallback when no independent eligible reviewer can run
@@ -51,12 +51,12 @@ roles:
     reasoning_effort: medium
     user_approved_bypass_required: true
     model_preferences:
-      - sonnet
+      - opus
       - openai_gpt_5_5
       - openai_gpt_5_3_codex
       - openai_gpt_5_2
       - openai_gpt_5
-      - opus
+      - sonnet
   planner.heavyweight:
     purpose: Claude planner/architect planning, decomposition, and plan review preparation
     role_suitability: planner
@@ -70,9 +70,9 @@ roles:
       - opus
     opus_requires_explicit_extreme_need: true
   reviewer.reasoning_effort:
-    default: medium
+    default: high
     routine_after_telemetry: medium
-    rule: "Use Sonnet 4.6 with high effort for Claude review/planner defaults. Opus is a last-resort tier only when explicitly justified as extreme need; do not use unverified Opus snapshots such as Opus 4.7 by default."
+    rule: "Use Opus 4.6 with high effort for Claude review defaults. Keep planner defaults on Sonnet unless planning policy changes separately; do not use unverified Opus snapshots such as Opus 4.7 by default."
 reviewer_selection:
   default_role: reviewer.heavyweight
   fallback_role: reviewer.fallback

--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-28T03:28:19Z",
+  "generated_at": "2026-05-28T04:44:54Z",
   "agents": [
 
   ]

--- a/_shared/schemas/model-catalog.yaml
+++ b/_shared/schemas/model-catalog.yaml
@@ -3,7 +3,7 @@ schema_version:
   version: 1.1.0
   min_reader: 1.0.0
   deprecated_at: null
-updated_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-28T00:00:00Z
 refresh_policy:
   cadence: before-changing-defaults
   command: scripts/check-model-catalog.sh --print-refresh-checklist
@@ -24,6 +24,9 @@ official_sources:
   anthropic_models:
     url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
     last_verified_at: 2026-05-02T00:00:00Z
+  anthropic_opus_4_6_release:
+    url: https://www.anthropic.com/news/claude-opus-4-6
+    last_verified_at: 2026-05-28T00:00:00Z
   aws_bedrock_claude_sonnet_4_6:
     url: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html
     last_verified_at: 2026-05-17T00:00:00Z
@@ -64,8 +67,8 @@ adapter_profiles:
     profile: reviewer
 models:
   opus:
-    id: claude-opus-4-1-20250805
-    display_name: Claude Opus 4.1
+    id: claude-opus-4-6
+    display_name: Claude Opus 4.6
     provider_family: anthropic
     adapter_profiles:
       - claude-code
@@ -75,24 +78,29 @@ models:
     capability_tier: heavyweight
     role_suitability:
       - implementer
+      - reviewer
+      - planner
       - architect
-    stable_aliases: []
+    stable_aliases:
+      - claude-opus-4-6
     snapshot_ids:
-      - claude-opus-4-1-20250805
+      - claude-opus-4-6
     reasoning_effort:
       supported: true
       levels:
+        - low
         - medium
         - high
+        - max
       default: high
-      provider_name: extended_thinking
-    released_at: 2025-08-05
-    variant_1m: false
+      provider_name: effort
+    released_at: 2026-02-05
+    variant_1m: true
     supports_fast: false
     knowledge_cutoff: null
     source:
-      url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
-      last_verified_at: 2026-05-02T00:00:00Z
+      url: https://www.anthropic.com/news/claude-opus-4-6
+      last_verified_at: 2026-05-28T00:00:00Z
   sonnet:
     id: claude-sonnet-4-6
     display_name: Claude Sonnet 4.6

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-28T03:28:19Z",
+  "generated_at": "2026-05-28T04:44:54Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/test-fixtures/322-model-policy/test-model-policy.sh
+++ b/scripts/test-fixtures/322-model-policy/test-model-policy.sh
@@ -40,7 +40,7 @@ bash "$ROOT/scripts/resolve-reviewer-model.sh" \
 claude_rc=$?
 assert "claude reviewer resolves for openai implementation" "[ '$claude_rc' -eq 0 ]"
 assert "claude reviewer uses anthropic family" "grep -q '^REVIEWER_MODEL_PROVIDER_FAMILY=anthropic$' '$claude_out'"
-assert "claude reviewer uses sonnet 4.6" "grep -q '^REVIEWER_MODEL_ID=claude-sonnet-4-6$' '$claude_out'"
+assert "claude reviewer uses opus 4.6" "grep -q '^REVIEWER_MODEL_ID=claude-opus-4-6$' '$claude_out'"
 assert "claude reviewer uses high reasoning" "grep -q '^REVIEWER_MODEL_REASONING_EFFORT=high$' '$claude_out'"
 
 planner_out="$TMPROOT/planner.out"

--- a/scripts/test-fixtures/454-phase-review/test-phase-review.sh
+++ b/scripts/test-fixtures/454-phase-review/test-phase-review.sh
@@ -143,7 +143,7 @@ fi
 grep -q 'PHASE_REVIEW_HOST=claude-reviewer' "$out"
 grep -q 'PHASE_REVIEW_OUTPUT=' "$out"
 grep -q 'PHASE_REVIEW_VERDICT=clean' "$out"
-grep -q 'PHASE_REVIEW_MODEL_ID=claude-sonnet-4-6' "$out"
+grep -q 'PHASE_REVIEW_MODEL_ID=claude-opus-4-6' "$out"
 grep -q 'PHASE_REVIEW_REASONING_EFFORT=high' "$out"
 grep -q 'nothing fatal' "$output"
 [ ! -s "$output.err" ]


### PR DESCRIPTION
## Summary
- update the Anthropic opus catalog entry to Claude Opus 4.6 (claude-opus-4-6)
- prefer opus before sonnet for Claude reviewer-heavyweight and fallback review roles
- update resolver and phase-review fixtures to assert Opus 4.6 high effort for Claude review gates

## Verification
- scripts/resolve-reviewer-model.sh --review-host claude-reviewer --implementation-host codex
- scripts/check-model-catalog.sh
- git diff --check
- bash -n scripts/resolve-reviewer-model.sh scripts/check-model-catalog.sh
- bash scripts/test-fixtures/322-model-policy/test-model-policy.sh
- bash scripts/test-fixtures/454-phase-review/test-phase-review.sh

## Source
- Anthropic Opus 4.6 announcement documents API model id claude-opus-4-6 and default high effort.