### PR TITLE
Find appStoreVersion in any state, skip locked mutations

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-31T10:27:29Z",
+  "generated_at": "2026-05-31T10:31:22Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-31T10:27:29Z",
+  "generated_at": "2026-05-31T10:31:22Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -1368,33 +1368,56 @@ cmd_appstore() {
   build_id=$(asc_body "$build_resp" | jq -r '.data[0].id // empty')
   [ -n "$build_id" ] || halt_failed prereq "ASC: build $BUILD not found"
 
-  local versions_resp version_id
+  # Find the appStoreVersion by versionString across *any* state. The version
+  # may already exist in a post-PREPARE state if a prior partial run mutated
+  # it, or if the operator submitted via the App Store Connect web UI before
+  # the script could finalize. Filtering only on PREPARE_FOR_SUBMISSION here
+  # would miss those cases and the create POST below would 409 with
+  # ENTITY_ERROR.RELATIONSHIP.INVALID — "You cannot create a new version of
+  # the App in the current state."
+  local versions_resp version_id version_state
   versions_resp=$(asc_api GET "/v1/apps/${APP_ID}/appStoreVersions?fields[appStoreVersions]=versionString,appStoreState,releaseType")
   version_id=$(asc_body "$versions_resp" \
-    | jq -r --arg v "$VERSION" '.data[] | select(.attributes.appStoreState=="PREPARE_FOR_SUBMISSION" and .attributes.versionString==$v) | .id' \
+    | jq -r --arg v "$VERSION" '.data[] | select(.attributes.versionString==$v) | .id' \
     | head -1)
-  if [ -z "$version_id" ]; then
+  if [ -n "$version_id" ]; then
+    version_state=$(asc_body "$versions_resp" \
+      | jq -r --arg v "$VERSION" '.data[] | select(.attributes.versionString==$v) | .attributes.appStoreState' \
+      | head -1)
+  else
     local create_resp
     create_resp=$(asc_api POST "/v1/appStoreVersions" \
       "$(jq -nc --arg v "$VERSION" --arg app "$APP_ID" '{data:{type:"appStoreVersions",attributes:{platform:"IOS",versionString:$v,releaseType:"MANUAL"},relationships:{app:{data:{type:"apps",id:$app}}}}}')")
     version_id=$(asc_body "$create_resp" | jq -r '.data.id // empty')
     [ -n "$version_id" ] || halt_failed prereq "ASC: appStoreVersion create failed: $(asc_body "$create_resp")"
+    version_state="PREPARE_FOR_SUBMISSION"
   fi
 
-  asc_api PATCH "/v1/appStoreVersions/${version_id}" \
-    "$(jq -nc --arg id "$version_id" --arg bid "$build_id" '{data:{type:"appStoreVersions",id:$id,attributes:{releaseType:"MANUAL"},relationships:{build:{data:{type:"builds",id:$bid}}}}}')" \
-    >/dev/null
-
-  local locs_resp whatsnew_text
-  whatsnew_text=$(cat "$WHATSNEW_FILE")
-  locs_resp=$(asc_api GET "/v1/appStoreVersions/${version_id}/appStoreVersionLocalizations")
+  # Only mutate the version's build relationship + localization whatsNew when
+  # it's still in the mutable PREPARE_FOR_SUBMISSION state. Once it moves on
+  # (WAITING_FOR_REVIEW, IN_REVIEW, etc.) Apple locks those attributes and a
+  # PATCH would fail; the build-mismatch guard below still verifies the
+  # already-bound build matches what we expected to submit. READY_FOR_SALE
+  # means the version is live — the build-mismatch guard handles the refusal.
   local loc_count=0
-  for loc_id in $(asc_body "$locs_resp" | jq -r '.data[].id'); do
-    asc_api PATCH "/v1/appStoreVersionLocalizations/${loc_id}" \
-      "$(jq -nc --arg id "$loc_id" --arg w "$whatsnew_text" '{data:{type:"appStoreVersionLocalizations",id:$id,attributes:{whatsNew:$w}}}')" \
+  if [ "$version_state" = "PREPARE_FOR_SUBMISSION" ]; then
+    asc_api PATCH "/v1/appStoreVersions/${version_id}" \
+      "$(jq -nc --arg id "$version_id" --arg bid "$build_id" '{data:{type:"appStoreVersions",id:$id,attributes:{releaseType:"MANUAL"},relationships:{build:{data:{type:"builds",id:$bid}}}}}')" \
       >/dev/null
-    loc_count=$((loc_count + 1))
-  done
+
+    local locs_resp whatsnew_text
+    whatsnew_text=$(cat "$WHATSNEW_FILE")
+    locs_resp=$(asc_api GET "/v1/appStoreVersions/${version_id}/appStoreVersionLocalizations")
+    for loc_id in $(asc_body "$locs_resp" | jq -r '.data[].id'); do
+      asc_api PATCH "/v1/appStoreVersionLocalizations/${loc_id}" \
+        "$(jq -nc --arg id "$loc_id" --arg w "$whatsnew_text" '{data:{type:"appStoreVersionLocalizations",id:$id,attributes:{whatsNew:$w}}}')" \
+        >/dev/null
+      loc_count=$((loc_count + 1))
+    done
+  else
+    printf 'studio-tf-push: appStoreVersion %s is in state %s (past PREPARE_FOR_SUBMISSION) — skipping build/whatsNew PATCH; will defer to reviewSubmission idempotency below\n' \
+      "$version_id" "$version_state" >&2
+  fi
 
   # ─── real App Store submission ──────────────────────────────────────────
   # Without this block, the flow would stop after PATCHing the version and


### PR DESCRIPTION
## Summary

**bugfix-shipped:** Broaden the appStoreVersion lookup in `cmd_appstore()` to match `versionString` in any state, and skip the build/whatsNew PATCHes when the version is past `PREPARE_FOR_SUBMISSION`.

## Why

If the version already exists but has moved past `PREPARE_FOR_SUBMISSION` — e.g. an operator submitted via the App Store Connect web UI between script runs, or a prior partial run left the version mid-flight — the previous state-filtered lookup missed it and the script tried to POST a fresh version with the same versionString. Apple refuses with:

```
HTTP 409 ENTITY_ERROR.RELATIONSHIP.INVALID
"You cannot create a new version of the App in the current state."
```

Hit during the 26.5.4 build 3266 retry on `turnip-ios` after the operator manually submitted via web UI between the V1-deprecation halt and the script re-run.

## How

- Match `versionString` only; capture `appStoreState` into `version_state`.
- PATCH build relationship + whatsNew only when `version_state == PREPARE_FOR_SUBMISSION`. Once past that state Apple locks those attributes; the build-mismatch guard below still verifies the already-bound build matches what we intend to submit.
- The V2 `reviewSubmissions` idempotency block (introduced in #1060) then detects the in-flight submission and reuses it, so the script proceeds to tag/GH/PR/Slack/marker even when the operator submitted manually.

## Test plan

- [ ] Re-run `studio-tf-push.sh appstore` against 26.5.4 build 3266 (operator already manually submitted); expect `appStoreVersion ... is in state WAITING_FOR_REVIEW ... skipping build/whatsNew PATCH` log line, then `reviewSubmission already submitted ... reusing`, then tag/GH/PR/Slack/marker artifacts.
- [ ] Next clean App Store push (PREPARE_FOR_SUBMISSION) still runs the normal mutate-then-submit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)