### PR TITLE
V2 idempotency: per-submission items lookup with appStoreVersion

### DIFF
--- a/_shared/schemas/capability-manifest.json
+++ b/_shared/schemas/capability-manifest.json
@@ -5,7 +5,7 @@
     "min_reader": "1.0.0",
     "deprecated_at": null
   },
-  "generated_at": "2026-05-31T10:31:22Z",
+  "generated_at": "2026-05-31T10:57:39Z",
   "agents": [
 
   ]

--- a/docs-surface.json
+++ b/docs-surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-31T10:31:22Z",
+  "generated_at": "2026-05-31T10:57:38Z",
   "schema": 1,
   "commands": [
     {"name": "dev-studio", "source": "commands/dev-studio.md", "description": "Studio v2 umbrella router. Dispatches by canonical role from any project: manager, worker, reviewer, perf, planner, qa-engineer, flow-tester, release-manager.", "agent": null, "scope": "global"},

--- a/scripts/studio-tf-push.sh
+++ b/scripts/studio-tf-push.sh
@@ -1460,29 +1460,36 @@ cmd_appstore() {
   #   2. POST /v1/reviewSubmissionItems      — attach the appStoreVersion
   #   3. PATCH /v1/reviewSubmissions/{id}    — attributes.submitted=true
   #
-  # Idempotency: list non-terminal submissions for the app+platform, include
-  # items, and find the one (if any) whose item already references our
-  # appStoreVersion. Reuse if already submitted; PATCH submitted=true if it
-  # exists in READY_FOR_REVIEW (created but never finalized — e.g. an earlier
-  # partial run or a manual web-UI in-progress submission).
+  # Idempotency: list non-terminal submissions for the app+platform, then per
+  # candidate GET its items with include=appStoreVersion and check if our
+  # appStoreVersion is among them. The list endpoint's include=items returns
+  # reviewSubmissionItems in `included[]` without their `relationships`
+  # populated (only `attributes.state`), and nested includes like
+  # `items.appStoreVersion` are rejected as HTTP 400 — so a second hop per
+  # candidate submission is required to resolve the item→version link.
+  # Reuse if already submitted; PATCH submitted=true if it exists in
+  # READY_FOR_REVIEW (created but never finalized — e.g. an earlier partial
+  # run or a manual web-UI in-progress submission).
   local sub_id="" sub_state=""
   local sub_listing_resp sub_listing_status
-  sub_listing_resp=$(asc_api GET "/v1/apps/${APP_ID}/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW,WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES&include=items&limit=50")
+  sub_listing_resp=$(asc_api GET "/v1/apps/${APP_ID}/reviewSubmissions?filter%5Bplatform%5D=IOS&filter%5Bstate%5D=READY_FOR_REVIEW,WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES&limit=50")
   sub_listing_status=$(asc_status "$sub_listing_resp")
   case "$sub_listing_status" in
     200)
-      local sub_listing_body
+      local sub_listing_body candidate_id items_resp items_status
       sub_listing_body=$(asc_body "$sub_listing_resp")
-      sub_id=$(printf '%s' "$sub_listing_body" | jq -r --arg vid "$version_id" '
-        (.included // [])
-        | map(select(.type == "reviewSubmissionItems"
-            and (.relationships.appStoreVersion.data.id // "") == $vid))
-        | .[0].relationships.reviewSubmission.data.id // empty
-      ')
-      if [ -n "$sub_id" ]; then
-        sub_state=$(printf '%s' "$sub_listing_body" | jq -r --arg sid "$sub_id" '
-          .data[] | select(.id == $sid) | .attributes.state // empty')
-      fi
+      for candidate_id in $(printf '%s' "$sub_listing_body" | jq -r '.data[].id'); do
+        items_resp=$(asc_api GET "/v1/reviewSubmissions/${candidate_id}/items?include=appStoreVersion&limit=200")
+        items_status=$(asc_status "$items_resp")
+        [ "$items_status" = "200" ] || continue
+        if asc_body "$items_resp" | jq -e --arg vid "$version_id" \
+          '.data[] | select((.relationships.appStoreVersion.data.id // "") == $vid)' >/dev/null 2>&1; then
+          sub_id="$candidate_id"
+          sub_state=$(printf '%s' "$sub_listing_body" | jq -r --arg sid "$sub_id" \
+            '.data[] | select(.id == $sid) | .attributes.state // empty')
+          break
+        fi
+      done
       ;;
     404)
       : # No submissions for app — fresh state.


### PR DESCRIPTION
## Summary

**bugfix-shipped:** Fix V2 reviewSubmissions idempotency to actually find existing in-flight submissions.

## Why

The V2 migration in #1060 listed non-terminal reviewSubmissions with `?include=items` and walked `included[]` looking for items whose `appStoreVersion` matched ours. Apple's list endpoint returns the included `reviewSubmissionItems` **without `relationships` populated** — only `attributes.state`. The jq filter always returned empty, the script fell through to "create new", and the resulting POST `/v1/reviewSubmissionItems` halted with HTTP 409 "This resource cannot be reviewed" because the appStoreVersion was already an item in the existing user-submitted submission. Every retry also added an empty debris reviewSubmission in `READY_FOR_REVIEW`.

Also empirically confirmed against ASC: nested includes (e.g. `include=items.appStoreVersion`) are rejected as HTTP 400 — that shortcut isn't available.

## Fix

Two-step lookup:

1. List candidate non-terminal submissions for app+platform.
2. For each candidate, GET `/v1/reviewSubmissions/{id}/items?include=appStoreVersion` — this *does* populate `item.relationships.appStoreVersion`. Match our `version_id` against the items' `appStoreVersion.data.id`. First match wins.

`sub_state` is read from the original listing once the matching `sub_id` is found.

## Debris note

The empty `READY_FOR_REVIEW` submissions left by previous failed runs can't be cleaned up: `DELETE /v1/reviewSubmissions` returns HTTP 403 (not allowed), and `PATCH attributes.canceled=true` on an item-less READY_FOR_REVIEW submission returns HTTP 409 "Resource is not in cancellable state." With idempotency correct, no new debris accumulates.

## Test plan

- [ ] Re-run `studio-tf-push.sh appstore --build 3266 --version 26.5.3` against turnip-ios; expect idempotency to find the operator's existing WAITING_FOR_REVIEW submission and log `reusing`, then proceed to tag/GH/PR/Slack/marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)